### PR TITLE
stop test containers when tests fail

### DIFF
--- a/tests/Oryx.Tests.Common/EndToEndTestHelper.cs
+++ b/tests/Oryx.Tests.Common/EndToEndTestHelper.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Oryx.Tests.Common
             }
             finally
             {
-                if (runResult != null && runResult.Exception == null)
+                if (runResult != null)
                 {
                     // Stop the container so that shared resources (like ports) are disposed.
                     dockerCli.StopContainer(runResult.ContainerName);


### PR DESCRIPTION
it creates problem in build agents when we have an immortal container .. weird but true docker kill and docker stop sometimes doesn't work .. so it's better to stop the container for exceptions