### PR TITLE
fix retagging in nightly builds with oryxtests images

### DIFF
--- a/Oryx.sln
+++ b/Oryx.sln
@@ -30,6 +30,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{0FEBE7DD
 		build\build-constants.yaml = build\build-constants.yaml
 		build\build-runtimeimages.sh = build\build-runtimeimages.sh
 		build\build-solution.sh = build\build-solution.sh
+		build\build-testimage.sh = build\build-testimage.sh
 		build\test-buildimages.sh = build\test-buildimages.sh
 		build\test-buildscriptgenerator.sh = build\test-buildscriptgenerator.sh
 		build\test-integration.sh = build\test-integration.sh

--- a/build/build-testimage.sh
+++ b/build/build-testimage.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -e
+
+declare -r REPO_DIR=$( cd $( dirname "$0" ) && cd .. && pwd )
+
+# Load all variables
+source $REPO_DIR/build/__variables.sh
+
+echo
+echo Building a base image for tests...
+docker build -t $ORYXTESTS_BUILDIMAGE_REPO -f "$ORYXTESTS_BUILDIMAGE_DOCKERFILE" .
+
+echo
+echo "Cleanup: Run 'docker system prune': $DOCKER_SYSTEM_PRUNE"
+if [ "$DOCKER_SYSTEM_PRUNE" == "true" ]
+then
+	docker system prune -f
+fi

--- a/vsts/pipelines/_buildParallel.yml
+++ b/vsts/pipelines/_buildParallel.yml
@@ -100,6 +100,13 @@ steps:
     args: $(System.ArtifactsDirectory)/drop/images/runtime-images-acr.txt
   condition: and(succeeded(), eq(variables['TestIntegration'], 'true'))
 
+- task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
+  displayName: 'Create images having restricted permissions for testing build and runtime images'
+  inputs:
+    type: FilePath
+    scriptPath: ./vsts/scripts/build-testimage.sh
+  condition: and(succeeded(), eq(variables['TestIntegration'], 'true'))
+
 - task: AzureKeyVault@1
   displayName: 'Fetch storage account key from vault'
   inputs:


### PR DESCRIPTION
We use both oryxdevms/build and oryxtests/build  in our tests, so we need to retag iamges  with oryxtests as well