### PR TITLE
add cleanup for mounted directories

### DIFF
--- a/vsts/pipelines/_buildParallel.yml
+++ b/vsts/pipelines/_buildParallel.yml
@@ -212,7 +212,7 @@ steps:
   condition: or(eq(variables['TestBuildImages'], 'true'), eq(variables['TestRuntimeImages'], 'true'), eq(variables['TestIntegration'], 'true'))
 
 - task: ShellScript@2
-  displayName: 'Clean up Docker artifacts from mounted directory'
+  displayName: 'Clean up Docker mounted directories'
   inputs:
     scriptPath: ./vsts/scripts/dockerArtifactsRemoval.sh
   condition: or(eq(variables['TestBuildImages'], 'true'), eq(variables['TestRuntimeImages'], 'true'), eq(variables['TestIntegration'], 'true'))

--- a/vsts/pipelines/_buildTemplate.yml
+++ b/vsts/pipelines/_buildTemplate.yml
@@ -179,6 +179,12 @@ steps:
   condition: or(eq(variables['TestBuildImages'], 'true'), eq(variables['TestRuntimeImages'], 'true'), eq(variables['TestIntegration'], 'true'))
 
 - task: ShellScript@2
+  displayName: 'Clean up Docker artifacts from mounted directory'
+  inputs:
+    scriptPath: ./vsts/scripts/dockerArtifactsRemoval.sh
+  condition: or(eq(variables['TestBuildImages'], 'true'), eq(variables['TestRuntimeImages'], 'true'), eq(variables['TestIntegration'], 'true'))
+  
+- task: ShellScript@2
   displayName: 'Generate release notes'
   inputs:
     scriptPath: ./vsts/scripts/generate-release-notes.sh

--- a/vsts/pipelines/_buildTemplate.yml
+++ b/vsts/pipelines/_buildTemplate.yml
@@ -179,7 +179,7 @@ steps:
   condition: or(eq(variables['TestBuildImages'], 'true'), eq(variables['TestRuntimeImages'], 'true'), eq(variables['TestIntegration'], 'true'))
 
 - task: ShellScript@2
-  displayName: 'Clean up Docker artifacts from mounted directory'
+  displayName: 'Clean up Docker mounted directories'
   inputs:
     scriptPath: ./vsts/scripts/dockerArtifactsRemoval.sh
   condition: or(eq(variables['TestBuildImages'], 'true'), eq(variables['TestRuntimeImages'], 'true'), eq(variables['TestIntegration'], 'true'))


### PR DESCRIPTION
we have decomposed docker cleanup task in two different script now, one for untag and deleting images etc and another one for removing mounted directories from /tmp which gets generated every time integration tests ran. So ci builds should adopt that.