### PR TITLE
Adding PM2 to the node images

### DIFF
--- a/images/runtime/node/4.4/Dockerfile
+++ b/images/runtime/node/4.4/Dockerfile
@@ -59,5 +59,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/4.5/Dockerfile
+++ b/images/runtime/node/4.5/Dockerfile
@@ -60,5 +60,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/4.8/Dockerfile
+++ b/images/runtime/node/4.8/Dockerfile
@@ -91,5 +91,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/6.10/Dockerfile
+++ b/images/runtime/node/6.10/Dockerfile
@@ -85,5 +85,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/6.11/Dockerfile
+++ b/images/runtime/node/6.11/Dockerfile
@@ -91,5 +91,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/6.2/Dockerfile
+++ b/images/runtime/node/6.2/Dockerfile
@@ -59,5 +59,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/6.6/Dockerfile
+++ b/images/runtime/node/6.6/Dockerfile
@@ -60,5 +60,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/6.9/Dockerfile
+++ b/images/runtime/node/6.9/Dockerfile
@@ -63,5 +63,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/8.0/Dockerfile
+++ b/images/runtime/node/8.0/Dockerfile
@@ -85,5 +85,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/8.1/Dockerfile
+++ b/images/runtime/node/8.1/Dockerfile
@@ -85,5 +85,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/8.2/Dockerfile
+++ b/images/runtime/node/8.2/Dockerfile
@@ -93,5 +93,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/8.8/Dockerfile
+++ b/images/runtime/node/8.8/Dockerfile
@@ -94,5 +94,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/8.9/Dockerfile
+++ b/images/runtime/node/8.9/Dockerfile
@@ -95,5 +95,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/images/runtime/node/Dockerfile.template
+++ b/images/runtime/node/Dockerfile.template
@@ -20,5 +20,9 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# PM2 is supported as an option when running the app,
+# so we need to make sure it is available in our images.
+RUN npm install -g pm2
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx

--- a/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
             // Arrange & Act
             var result = _dockerCli.Run(
                 $"oryxdevms/node-{nodeTag}:latest",
-                "sh", new[] { "-c", "which tar && which unzip" });
+                "sh", new[] { "-c", "which tar && which unzip && which pm2" });
 
             // Assert
             RunAsserts(() => Assert.True(result.IsSuccess), result.GetDebugInfo());


### PR DESCRIPTION
We will need PM2, with its use being option through a flag to the entrypoint script generator, for backward compatibility with app service.