### PR TITLE
Improving support for Node startup files

### DIFF
--- a/src/startupscriptgenerator/node/scriptgenerator.go
+++ b/src/startupscriptgenerator/node/scriptgenerator.go
@@ -120,6 +120,21 @@ func (gen *NodeStartupScriptGenerator) GenerateEntrypointScript() string {
 		}
 
 		if startupCommand == "" {
+			startupCommand = gen.getProcessJsonCommand(userStartupCommandFullPath)
+			commandSource = "ProcessJson"
+		}
+
+		if startupCommand == "" {
+			startupCommand = gen.getConfigJsCommand(userStartupCommandFullPath)
+			commandSource = "ConfigJs"
+		}
+
+		if startupCommand == "" {
+			startupCommand = gen.getConfigYamlCommand(userStartupCommandFullPath)
+			commandSource = "ConfigYaml"
+		}
+
+		if startupCommand == "" {
 			startupCommand = gen.getUserProvidedJsFileCommand(userStartupCommandFullPath)
 			commandSource = "UserJsFilePath"
 		}
@@ -162,12 +177,11 @@ func (gen *NodeStartupScriptGenerator) GenerateEntrypointScript() string {
 func (gen *NodeStartupScriptGenerator) getPackageJsonStartCommand(packageJsonObj *packageJson, packageJsonPath string) string {
 	if packageJsonObj != nil && packageJsonObj.Scripts != nil && packageJsonObj.Scripts.Start != "" {
 		var commandBuilder strings.Builder
-		if gen.RemoteDebugging || gen.RemoteDebuggingBreakBeforeStart {
+		if gen.isDebugging() {
 			// At this point we know debugging is enabled, and node will be called indirectly through npm
 			// or yarn. We inject the wrapper in the path so it executes instead of the node binary.
-			commandBuilder.WriteString("export PATH=" + NodeWrapperPath + ":$PATH\n")
-			debugFlag := gen.getDebugFlag()
-			commandBuilder.WriteString("export " + inspectParamVariableName + "=\"" + debugFlag + "\"\n")
+			debugCommand := gen.getNodeWrapperDebugCommand()
+			commandBuilder.WriteString(debugCommand)
 		}
 		packageJsonDir := filepath.Dir(packageJsonPath)
 		isPackageJsonAtRoot := filepath.Clean(packageJsonDir) == filepath.Clean(gen.SourcePath)
@@ -184,7 +198,7 @@ func (gen *NodeStartupScriptGenerator) getPackageJsonStartCommand(packageJsonObj
 			} else {
 				commandBuilder.WriteString("npm start")
 			}
-			if gen.RemoteDebugging || gen.RemoteDebuggingBreakBeforeStart {
+			if gen.isDebugging() {
 				commandBuilder.WriteString(" --scripts-prepend-node-path false")
 			}
 			commandBuilder.WriteString("\n")
@@ -192,6 +206,18 @@ func (gen *NodeStartupScriptGenerator) getPackageJsonStartCommand(packageJsonObj
 		return commandBuilder.String()
 	}
 	return ""
+}
+
+// Creates the commands that inject the node wrapper, which will intercept calls to 'node' and
+// add the debug option.
+func (gen *NodeStartupScriptGenerator) getNodeWrapperDebugCommand() string {
+	var commandBuilder strings.Builder
+	// At this point we know debugging is enabled, and node will be called indirectly through npm
+	// or yarn. We inject the wrapper in the path so it executes instead of the node binary.
+	commandBuilder.WriteString("export PATH=" + NodeWrapperPath + ":$PATH\n")
+	debugFlag := gen.getDebugFlag()
+	commandBuilder.WriteString("export " + inspectParamVariableName + "=\"" + debugFlag + "\"\n")
+	return commandBuilder.String()
 }
 
 // Gets the startup script from package.json if defined. Returns empty string if not found.
@@ -213,6 +239,56 @@ func (gen *NodeStartupScriptGenerator) getPackageJsonMainCommand(packageJsonObj 
 		return startupCommand
 	}
 	return ""
+}
+
+func (gen *NodeStartupScriptGenerator) getProcessJsonCommand(userInputPath string) string {
+	processJsonPath := ""
+	if userInputPath != "" {
+		if strings.HasSuffix(userInputPath, ".json") {
+			processJsonPath = userInputPath
+		}
+	} else {
+		processJsonPath = "process.json"
+	}
+
+	if processJsonPath != "" {
+		processJsonFullPath := filepath.Join(gen.SourcePath, processJsonPath)
+		if common.FileExists(processJsonFullPath) {
+			debugCommand := ""
+			if gen.isDebugging() {
+				debugCommand = gen.getNodeWrapperDebugCommand()
+			}
+			return debugCommand + getPm2StartCommand(processJsonPath)
+		}
+	}
+	return ""
+}
+
+func (gen *NodeStartupScriptGenerator) getConfigYamlCommand(userInputFullPath string) string {
+	if strings.HasSuffix(userInputFullPath, ".yml") || strings.HasSuffix(userInputFullPath, ".yaml") {
+		return getPm2StartCommand(userInputFullPath)
+	}
+	return ""
+}
+
+func (gen *NodeStartupScriptGenerator) getConfigJsCommand(userInputFullPath string) string {
+	configJsFullPath := ""
+	if userInputFullPath != "" {
+		if strings.HasSuffix(userInputFullPath, ".config.js") {
+			configJsFullPath = userInputFullPath
+		}
+	} else {
+		configJsFullPath = filepath.Join(gen.SourcePath, "ecosystem.config.js")
+	}
+
+	if configJsFullPath != "" && common.FileExists(configJsFullPath) {
+		return getPm2StartCommand(configJsFullPath)
+	}
+	return ""
+}
+
+func (gen *NodeStartupScriptGenerator) isDebugging() bool {
+	return gen.RemoteDebugging || gen.RemoteDebuggingBreakBeforeStart
 }
 
 func (gen *NodeStartupScriptGenerator) getUserProvidedJsFileCommand(fileFullPath string) string {
@@ -262,13 +338,21 @@ func (gen *NodeStartupScriptGenerator) getStartupCommandFromJsFile(mainJsFilePat
 		debugFlag := gen.getDebugFlag()
 		commandBuilder.WriteString("node " + debugFlag)
 	} else if gen.UsePm2 {
-		commandBuilder.WriteString("pm2 start --no-daemon")
+		commandBuilder.WriteString(getPm2StartCommand(""))
 	} else {
 		commandBuilder.WriteString("node")
 	}
 
 	commandBuilder.WriteString(" " + mainJsFilePath)
 	return commandBuilder.String()
+}
+
+func getPm2StartCommand(filePath string) string {
+	if filePath != "" {
+		filePath = " " + filePath
+	}
+	command := "pm2 start" + filePath + " --no-daemon"
+	return command
 }
 
 // Builds the flag that should be passed to `node` to enable debugging.
@@ -297,27 +381,31 @@ func getPackageJsonObject(appPath string, userProvidedPath string) (obj *package
 	defer logger.Shutdown()
 
 	const packageFileName = "package.json"
-	var packageJsonPath string
+	packageJsonPath := ""
 
 	// We prioritize the file the user provided
-	if strings.HasSuffix(userProvidedPath, packageFileName) {
-		logger.LogInformation("Using user-provided path for packageJson: " + userProvidedPath)
-		packageJsonPath = userProvidedPath
+	if userProvidedPath != "" {
+		if strings.HasSuffix(userProvidedPath, packageFileName) {
+			logger.LogInformation("Using user-provided path for packageJson: " + userProvidedPath)
+			packageJsonPath = userProvidedPath
+		}
 	} else {
 		logger.LogInformation("Use package.json at the root.")
-		packageJsonPath = filepath.Join(appPath, packageFileName)
+		packageJsonPath = packageFileName
 	}
+	if packageJsonPath != "" {
+		packageJsonPath = filepath.Join(appPath, packageJsonPath)
+		if _, err := os.Stat(packageJsonPath); !os.IsNotExist(err) {
+			packageJsonBytes, err := ioutil.ReadFile(packageJsonPath)
+			if err != nil {
+				return nil, ""
+			}
 
-	if _, err := os.Stat(packageJsonPath); !os.IsNotExist(err) {
-		packageJsonBytes, err := ioutil.ReadFile(packageJsonPath)
-		if err != nil {
-			return nil, ""
-		}
-
-		packageJsonObj := new(packageJson)
-		err = json.Unmarshal(packageJsonBytes, &packageJsonObj)
-		if err == nil {
-			return packageJsonObj, packageJsonPath
+			packageJsonObj := new(packageJson)
+			err = json.Unmarshal(packageJsonBytes, &packageJsonObj)
+			if err == nil {
+				return packageJsonObj, packageJsonPath
+			}
 		}
 	}
 	return nil, ""

--- a/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
         }
 
         [Theory]
-        [MemberData(nameof(TestValueGenerator.GetNodeVersions), MemberType = typeof(TestValueGenerator))]
+        [MemberData(nameof(TestValueGenerator.GetNodeVersions_SupportPm2), MemberType = typeof(TestValueGenerator))]
         public async Task RunNodeAppUsingProcessJson(string nodeVersion)
         {
 

--- a/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
@@ -249,7 +249,6 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
         [MemberData(nameof(TestValueGenerator.GetNodeVersions_SupportDebugging), MemberType = typeof(TestValueGenerator))]
         public async Task RunNodeAppUsingProcessJson_withDebugging(string nodeVersion)
         {
-
             var appName = "express-process-json";
             var hostDir = Path.Combine(_hostSamplesDir, "nodejs", appName);
             var volume = DockerVolume.Create(hostDir);

--- a/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
@@ -4,16 +4,26 @@
 // --------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.Oryx.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.RuntimeImage.Tests
 {
-    public class NodeImagesTest : TestBase
+    public class NodeImagesTest : TestBase, IClassFixture<TestTempDirTestFixture>
     {
-        public NodeImagesTest(ITestOutputHelper output) : base(output)
+        private readonly string _hostSamplesDir;
+        private readonly string _tempRootDir;
+        protected readonly HttpClient _httpClient = new HttpClient();
+
+        public NodeImagesTest(ITestOutputHelper output, TestTempDirTestFixture testTempDirTestFixture) : base(output)
         {
+            _hostSamplesDir = Path.Combine(Directory.GetCurrentDirectory(), "SampleApps");
+            _tempRootDir = testTempDirTestFixture.RootDirPath;
         }
 
         [SkippableTheory]
@@ -119,6 +129,82 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
             
             // Assert
             RunAsserts(() => Assert.Equal(res.ExitCode, exitCodeSentinel), res.GetDebugInfo());
+        }
+
+        [Theory]
+        [MemberData(nameof(TestValueGenerator.GetNodeVersions), MemberType = typeof(TestValueGenerator))]
+        public async Task RunNodeAppUsingProcessJson(string nodeVersion)
+        {
+
+            var appName = "express-process-json";
+            var hostDir = Path.Combine(_hostSamplesDir, "nodejs", appName);
+            var volume = DockerVolume.Create(hostDir);
+            var dir = volume.ContainerDir;
+            int hostPort = 8585;
+            int containerPort = 80;
+
+            var runAppScript = new ShellScriptBuilder()
+                .AddCommand($"cd {dir}/app")
+                .AddCommand("npm install")
+                .AddCommand("cd ..")
+                .AddCommand($"oryx -bindPort {containerPort}")
+                .AddCommand("./run.sh")
+                .ToString();
+
+            await EndToEndTestHelper.RunAndAssertAppAsync(
+                imageName: $"oryxdevms/node-{nodeVersion}",
+                output: _output,
+                volumes:  new List<DockerVolume> { volume },
+                environmentVariables: null,
+                portMapping: $"{hostPort}:{containerPort}",
+                link: null,
+                runCmd: "/bin/sh",
+                runArgs: new[] { "-c", runAppScript },
+                assertAction: async () =>
+                {
+                    var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
+                    Assert.Equal("Hello World from express!", data);
+                },
+                dockerCli: _dockerCli);
+            
+        }
+
+        [Theory(Skip="Investigating debugging using pm2")]
+        [MemberData(nameof(TestValueGenerator.GetNodeVersions_SupportDebugging), MemberType = typeof(TestValueGenerator))]
+        public async Task RunNodeAppUsingProcessJson_withDebugging(string nodeVersion)
+        {
+
+            var appName = "express-process-json";
+            var hostDir = Path.Combine(_hostSamplesDir, "nodejs", appName);
+            var volume = DockerVolume.Create(hostDir);
+            var dir = volume.ContainerDir;
+            int hostPort = 8585;
+            int containerDebugPort = 9593;
+
+            var runAppScript = new ShellScriptBuilder()
+                .AddCommand($"cd {dir}/app")
+                .AddCommand("npm install")
+                .AddCommand("cd ..")
+                .AddCommand($"oryx -remoteDebug -debugPort={containerDebugPort}")
+                .AddCommand("./run.sh")
+                .ToString();
+
+            await EndToEndTestHelper.RunAndAssertAppAsync(
+                imageName: $"oryxdevms/node-{nodeVersion}",
+                output: _output,
+                volumes: new List<DockerVolume> { volume },
+                environmentVariables: null,
+                portMapping: $"{hostPort}:{containerDebugPort}",
+                link: null,
+                runCmd: "/bin/sh",
+                runArgs: new[] { "-c", runAppScript },
+                assertAction: async () =>
+                {
+                    var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/json/list");
+                    Assert.Contains("devtoolsFrontendUrl", data);
+                },
+                dockerCli: _dockerCli);
+
         }
     }
 }

--- a/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
+++ b/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
@@ -23,4 +23,11 @@
     <ProjectReference Include="..\Oryx.Tests.Common\Oryx.Tests.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\SampleApps\**\*">
+      <Link>SampleApps\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/tests/Oryx.Tests.Common/DockerVolume.cs
+++ b/tests/Oryx.Tests.Common/DockerVolume.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Oryx.Tests.Common
             }
             else
             {
-                // Put the folders in a well known location which the CI build defnition looks for to clean up.
+                // Put the folders in a well known location which the CI build definition looks for to clean up.
                 tempDirRoot = Path.Combine(Path.GetTempPath(), MountedHostDirRootName);
             }
 

--- a/tests/Oryx.Tests.Common/EndToEndTestHelper.cs
+++ b/tests/Oryx.Tests.Common/EndToEndTestHelper.cs
@@ -117,13 +117,18 @@ namespace Microsoft.Oryx.Tests.Common
                output);
 
             // Run
+            await RunAndAssertAppAsync(runtimeImageName, output, volumes, environmentVariables, portMapping, link, runCmd, runArgs, assertAction, dockerCli);
+        }
+
+        public static async Task RunAndAssertAppAsync(string imageName, ITestOutputHelper output, List<DockerVolume> volumes, List<EnvironmentVariable> environmentVariables, string portMapping, string link, string runCmd, string[] runArgs, Func<Task> assertAction, DockerCli dockerCli)
+        {
             DockerRunCommandProcessResult runResult = null;
             try
             {
                 // Docker run the runtime container as a foreground process. This way we can catch any errors
                 // that might occur when the application is being started.
                 runResult = dockerCli.RunAndDoNotWaitForProcessExit(
-                    runtimeImageName,
+                    imageName,
                     environmentVariables,
                     volumes: volumes,
                     portMapping,

--- a/tests/Oryx.Tests.Common/EndToEndTestHelper.cs
+++ b/tests/Oryx.Tests.Common/EndToEndTestHelper.cs
@@ -120,7 +120,17 @@ namespace Microsoft.Oryx.Tests.Common
             await RunAndAssertAppAsync(runtimeImageName, output, volumes, environmentVariables, portMapping, link, runCmd, runArgs, assertAction, dockerCli);
         }
 
-        public static async Task RunAndAssertAppAsync(string imageName, ITestOutputHelper output, List<DockerVolume> volumes, List<EnvironmentVariable> environmentVariables, string portMapping, string link, string runCmd, string[] runArgs, Func<Task> assertAction, DockerCli dockerCli)
+        public static async Task RunAndAssertAppAsync(
+            string imageName,
+            ITestOutputHelper output,
+            List<DockerVolume> volumes, 
+            List<EnvironmentVariable> environmentVariables, 
+            string portMapping, 
+            string link, 
+            string runCmd, 
+            string[] runArgs, 
+            Func<Task> assertAction, 
+            DockerCli dockerCli)
         {
             DockerRunCommandProcessResult runResult = null;
             try

--- a/tests/Oryx.Tests.Common/TestValueGenerator.cs
+++ b/tests/Oryx.Tests.Common/TestValueGenerator.cs
@@ -56,5 +56,12 @@ namespace Microsoft.Oryx.Tests.Common
                 yield return new object[] { version };
             }
         }
+
+        public static IEnumerable<object[]> GetNodeVersions_SupportPm2()
+        {
+            return NodeVersions
+                .Where(v => !v.StartsWith("4."))
+                .Select(v => new object[] { v });
+        }
     }
 }

--- a/tests/SampleApps/nodejs/express-config-js/app/package.json
+++ b/tests/SampleApps/nodejs/express-config-js/app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "node-js-sample",
+  "version": "0.2.0",
+  "description": "A sample Node.js app using Express 4",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.13.3"
+  },
+  "engines": {
+    "node": ">=4.4.7"
+  },
+  "keywords": [
+    "node",
+    "express"
+  ],
+  "author": "Jenny Lawrance",
+  "contributors": [
+    "Jenny Lawrance"
+  ],
+  "license": "MIT"
+}

--- a/tests/SampleApps/nodejs/express-config-js/app/server.js
+++ b/tests/SampleApps/nodejs/express-config-js/app/server.js
@@ -1,0 +1,11 @@
+var express = require('express');
+var app = express();
+
+app.get('/', function (req, res) {
+  res.send('Hello World from express!');
+});
+
+var port = process.env.PORT || 80;
+app.listen(port, function () {
+  console.log('Example app listening on port ' + port);
+});

--- a/tests/SampleApps/nodejs/express-config-js/ecosystem.config.js
+++ b/tests/SampleApps/nodejs/express-config-js/ecosystem.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  apps : [{
+    name: 'API',
+    script: 'app/server.js',
+
+    // Options reference: https://pm2.io/doc/en/runtime/reference/ecosystem-file/
+    args: 'one two',
+    instances: 1,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '1G',
+    env: {
+      NODE_ENV: 'development'
+    },
+    env_production: {
+      NODE_ENV: 'production'
+    }
+  }],
+};

--- a/tests/SampleApps/nodejs/express-config-yaml/app/package.json
+++ b/tests/SampleApps/nodejs/express-config-yaml/app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "node-js-sample",
+  "version": "0.2.0",
+  "description": "A sample Node.js app using Express 4",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.13.3"
+  },
+  "engines": {
+    "node": ">=4.4.7"
+  },
+  "keywords": [
+    "node",
+    "express"
+  ],
+  "author": "Jenny Lawrance",
+  "contributors": [
+    "Jenny Lawrance"
+  ],
+  "license": "MIT"
+}

--- a/tests/SampleApps/nodejs/express-config-yaml/app/server.js
+++ b/tests/SampleApps/nodejs/express-config-yaml/app/server.js
@@ -1,0 +1,11 @@
+var express = require('express');
+var app = express();
+
+app.get('/', function (req, res) {
+  res.send('Hello World from express!');
+});
+
+var port = process.env.PORT || 80;
+app.listen(port, function () {
+  console.log('Example app listening on port ' + port);
+});

--- a/tests/SampleApps/nodejs/express-config-yaml/config.yml
+++ b/tests/SampleApps/nodejs/express-config-yaml/config.yml
@@ -1,0 +1,10 @@
+apps:
+  - script   : app/server.js
+    name     : 'app'
+    instances: 2
+    exec_mode: cluster
+    env    :
+      NODE_ENV: development
+    env_production:
+      NODE_ENV: production
+  

--- a/tests/SampleApps/nodejs/express-process-json/app/package.json
+++ b/tests/SampleApps/nodejs/express-process-json/app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "node-js-sample",
+  "version": "0.2.0",
+  "description": "A sample Node.js app using Express 4",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.13.3"
+  },
+  "engines": {
+    "node": ">=4.4.7"
+  },
+  "keywords": [
+    "node",
+    "express"
+  ],
+  "author": "Jenny Lawrance",
+  "contributors": [
+    "Jenny Lawrance"
+  ],
+  "license": "MIT"
+}

--- a/tests/SampleApps/nodejs/express-process-json/app/server.js
+++ b/tests/SampleApps/nodejs/express-process-json/app/server.js
@@ -1,0 +1,11 @@
+var express = require('express');
+var app = express();
+
+app.get('/', function (req, res) {
+  res.send('Hello World from express!');
+});
+
+var port = process.env.PORT || 80;
+app.listen(port, function () {
+  console.log('Example app listening on port ' + port);
+});

--- a/tests/SampleApps/nodejs/express-process-json/process.json
+++ b/tests/SampleApps/nodejs/express-process-json/process.json
@@ -1,0 +1,16 @@
+{
+  "apps" : [{
+    "name": "API",
+    "script": "app/server.js",
+    "instances": 1,
+    "autorestart": true,
+    "watch": false,
+    "max_memory_restart": "1G",
+    "env": {
+      "NODE_ENV": "development"
+    },
+    "env_production": {
+      "NODE_ENV": "production"
+    }
+  }]
+}


### PR DESCRIPTION
This change will make us backwards compatible with the app service startup [script generator](https://github.com/Azure-App-Service/node/blob/master/10.14/startup/generateStartupCommand.js)
It adds support for .json files (other than package.json of course), and [config files](https://pm2.io/doc/en/runtime/guide/ecosystem-file/).