### PR TITLE
Increasing timeout for some jobs

### DIFF
--- a/vsts/pipelines/ci.yml
+++ b/vsts/pipelines/ci.yml
@@ -26,7 +26,7 @@ jobs:
   displayName: Build and Publish Oryx Images
   dependsOn: Job_2
   condition: succeeded()
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   pool:
     name: OryxLinux
   steps:

--- a/vsts/pipelines/nightly.yml
+++ b/vsts/pipelines/nightly.yml
@@ -33,7 +33,8 @@ jobs:
   condition: succeeded()
   pool:
     name: OryxLinux
-  timeoutInMinutes: 100
+  # Building runtime images can take a long time due our PHP images
+  timeoutInMinutes: 150
   steps:
   - script: |
       echo "##vso[task.setvariable variable=BuildBuildImages;]false"


### PR DESCRIPTION
PHP runtime images take a long time to build, so increasing the timeouts.