### PR TITLE
Fix flaky runtime images unit test related to apinsight injection

### DIFF
--- a/tests/Oryx.Integration.Tests/NodeEndToEndTests.cs
+++ b/tests/Oryx.Integration.Tests/NodeEndToEndTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
+    [Trait("category", "node")]
     public class NodeEndToEndTests : PlatformEndToEndTestsBase
     {
         private const int HostPort = Constants.NodeEndToEndTestsPort;
@@ -372,7 +373,7 @@ namespace Microsoft.Oryx.Integration.Tests
         public async Task CanBuildAndRun_NodeApp_WithAppInsights_Configured(string nodeVersion)
         {
             // Arrange
-            var appName = "webfrontend";
+            var appName = "linxnodeexpress";
             var hostDir = Path.Combine(_hostSamplesDir, "nodejs", appName);
             var volume = DockerVolume.Create(hostDir);
             var appDir = volume.ContainerDir;
@@ -419,7 +420,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 async () =>
                 {
                     var data = await _httpClient.GetStringAsync($"http://localhost:{HostPort}/");
-                    Assert.Contains("Say It Again", data);
+                    Assert.Contains("Hello World from express!", data);
                 });
         }
 

--- a/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
             // Arrange
             var imageName = string.Concat("oryxdevms/node-", nodeVersion);
             var hostSamplesDir = Path.Combine(Directory.GetCurrentDirectory(), "SampleApps");
-            var volume = DockerVolume.Create(Path.Combine(hostSamplesDir, "nodejs", "webfrontend"));
+            var volume = DockerVolume.Create(Path.Combine(hostSamplesDir, "nodejs", "linxnodeexpress"));
             var appDir = volume.ContainerDir;
             var manifestFileContent = "injectedAppInsight=\"True\"";
             var aiNodesdkLoaderContent = @"try {
@@ -380,8 +380,8 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
                 .AddDirectoryExistsCheck($"{appDir}/node_modules/applicationinsights")
                 .AddCommand("./run.sh")
                 .ToString();
-           
-            await EndToEndTestHelper.RunAndAssertAppAsync(
+
+           await EndToEndTestHelper.RunAndAssertAppAsync(
                 imageName: $"oryxdevms/node-{nodeVersion}",
                 output: _output,
                 volumes: new List<DockerVolume> { volume },
@@ -393,9 +393,10 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
                 assertAction: async () =>
                 {
                     var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
-                    Assert.Contains("Say It Again", data);
+                    Assert.Contains("Hello World from express!", data);
                 },
                 dockerCli: _dockerCli);
+            
         }
 
         [Theory]
@@ -405,7 +406,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
             // Arrange
             var imageName = string.Concat("oryxdevms/node-", nodeVersion);
             var hostSamplesDir = Path.Combine(Directory.GetCurrentDirectory(), "SampleApps");
-            var volume = DockerVolume.Create(Path.Combine(hostSamplesDir, "nodejs", "webfrontend"));
+            var volume = DockerVolume.Create(Path.Combine(hostSamplesDir, "nodejs", "linxnodeexpress"));
             var appDir = volume.ContainerDir;
             var manifestFileContent = "injectedAppInsight=\"True\"";
             var aiNodesdkLoaderContent = @"try {
@@ -432,7 +433,6 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
                 .AddCommand("./run.sh")
                 .ToString();
 
-
             await EndToEndTestHelper.RunAndAssertAppAsync(
                 imageName: $"oryxdevms/node-{nodeVersion}",
                 output: _output,
@@ -445,7 +445,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
                 assertAction: async () =>
                 {
                     var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
-                    Assert.Contains("Say It Again", data);
+                    Assert.Contains("Hello World from express!", data);
                 },
                 dockerCli: _dockerCli);
         }

--- a/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/NodeImagesTest.cs
@@ -403,6 +403,12 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
         [MemberData(nameof(TestValueGenerator.GetNodeVersions_SupportDebugging), MemberType = typeof(TestValueGenerator))]
         public async Task GeneratesScript_CanRun_AppInsightsModule_NotFound(string nodeVersion)
         {
+            // This test is for the following scenario: 
+            // When we find injectedAppInsight=True in the manifest file, we assume that appinsights
+            // has been injected and it's installed during build (npm install). But for some reason if we 
+            // don't see the appinsights node_module we shouldn't break the app. We should run the app 
+            // and additionally print the exception message
+            
             // Arrange
             var imageName = string.Concat("oryxdevms/node-", nodeVersion);
             var hostSamplesDir = Path.Combine(Directory.GetCurrentDirectory(), "SampleApps");

--- a/vsts/pipelines/nightly.yml
+++ b/vsts/pipelines/nightly.yml
@@ -55,6 +55,7 @@ jobs:
     - Job_RuntimeImages
   pool:
     name: OryxLinux
+  timeoutInMinutes: 150
   steps:
   - script: |
       echo "##vso[task.setvariable variable=BuildBuildImages;]false"

--- a/vsts/scripts/pullandretag.sh
+++ b/vsts/scripts/pullandretag.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 # --------------------------------------------------------------------------------------------
 
-set -euxo pipefail
+set -euo pipefail
 
 while read sourceImage; do
   # Always use specific build number based tag and then use the same tag to create a 'latest' tag and push it

--- a/vsts/scripts/pullandretag.sh
+++ b/vsts/scripts/pullandretag.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 # --------------------------------------------------------------------------------------------
 
-set -o pipefail
+set -euxo pipefail
 
 while read sourceImage; do
   # Always use specific build number based tag and then use the same tag to create a 'latest' tag and push it


### PR DESCRIPTION
 increasing timeout for integration tests and changing sampleapp in runtime images unit test  and integration tests for appinsights to avoid concurrency issue.
Total time saved ~ 6.5 minutes
~ 4 minutes by getting rid of extra runtime images test
~ 2.5 minutes by changing sampleapp (lighter sampleApp compared to webfrontend)