### PR TITLE
Add --no-cache for building base images

### DIFF
--- a/build/build-runtimeimages-bases.sh
+++ b/build/build-runtimeimages-bases.sh
@@ -85,7 +85,7 @@ for dockerFile in $dockerFiles; do
     cd $REPO_DIR
 
     echo
-    docker build --no-cache -f $dockerFile -t $localImageTagName $labels .
+    docker build -f $dockerFile -t $localImageTagName --build-arg CACHEBUST=$(date +%s) $labels . 
 
     # Retag build image with DockerHub & ACR tags
     if [ -n "$BUILD_NUMBER" ]

--- a/build/build-runtimeimages-bases.sh
+++ b/build/build-runtimeimages-bases.sh
@@ -85,7 +85,7 @@ for dockerFile in $dockerFiles; do
     cd $REPO_DIR
 
     echo
-    docker build -f $dockerFile -t $localImageTagName $labels .
+    docker build --no-cache -f $dockerFile -t $localImageTagName $labels .
 
     # Retag build image with DockerHub & ACR tags
     if [ -n "$BUILD_NUMBER" ]

--- a/images/runtime/node/4.4/Dockerfile.base
+++ b/images/runtime/node/4.4/Dockerfile.base
@@ -33,6 +33,10 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/4.5/Dockerfile.base
+++ b/images/runtime/node/4.5/Dockerfile.base
@@ -34,6 +34,10 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/4.8/Dockerfile.base
+++ b/images/runtime/node/4.8/Dockerfile.base
@@ -68,6 +68,10 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/6.10/Dockerfile.base
+++ b/images/runtime/node/6.10/Dockerfile.base
@@ -59,6 +59,10 @@ RUN set -ex \
   && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/6.11/Dockerfile.base
+++ b/images/runtime/node/6.11/Dockerfile.base
@@ -68,6 +68,10 @@ RUN set -ex \
   && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/6.2/Dockerfile.base
+++ b/images/runtime/node/6.2/Dockerfile.base
@@ -33,6 +33,10 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/6.6/Dockerfile.base
+++ b/images/runtime/node/6.6/Dockerfile.base
@@ -34,6 +34,10 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/6.9/Dockerfile.base
+++ b/images/runtime/node/6.9/Dockerfile.base
@@ -37,6 +37,10 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/8.0/Dockerfile.base
+++ b/images/runtime/node/8.0/Dockerfile.base
@@ -59,6 +59,10 @@ RUN set -ex \
   && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/8.1/Dockerfile.base
+++ b/images/runtime/node/8.1/Dockerfile.base
@@ -59,6 +59,10 @@ RUN set -ex \
   && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 RUN apt-get update \
   && apt-get install -y unzip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/runtime/node/8.2/Dockerfile.base
+++ b/images/runtime/node/8.2/Dockerfile.base
@@ -71,6 +71,10 @@ RUN set -ex \
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 # PM2 is supported as an option when running the app,
 # so we need to make sure it is available in our images.
 RUN npm install -g pm2

--- a/images/runtime/node/8.8/Dockerfile.base
+++ b/images/runtime/node/8.8/Dockerfile.base
@@ -72,6 +72,10 @@ RUN set -ex \
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 # PM2 is supported as an option when running the app,
 # so we need to make sure it is available in our images.
 RUN npm install -g pm2

--- a/images/runtime/node/8.9/Dockerfile.base
+++ b/images/runtime/node/8.9/Dockerfile.base
@@ -73,6 +73,10 @@ RUN set -ex \
 RUN mkdir -p /node_modules \
  && chmod 777 /node_modules
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 # PM2 is supported as an option when running the app,
 # so we need to make sure it is available in our images.
 RUN npm install -g pm2

--- a/images/runtime/node/Dockerfile.base.template
+++ b/images/runtime/node/Dockerfile.base.template
@@ -14,6 +14,10 @@ RUN set -e \
         npm install -g npm@6.9.0; \
     fi
 
+# This is a way to avoid using caches for the next stages, since we want the remaining steps
+# to always run
+ARG CACHEBUST=0
+
 # PM2 is supported as an option when running the app,
 # so we need to make sure it is available in our images.
 RUN npm install -g pm2


### PR DESCRIPTION
This is causing issues since we were not reinstalling the latest version of tools that go in the image.