### PR TITLE
Enable .NET Core startup script to take either source path or published output path as input.

### DIFF
--- a/src/startupscriptgenerator/common/fsvalidation.go
+++ b/src/startupscriptgenerator/common/fsvalidation.go
@@ -54,7 +54,7 @@ func GetValidatedFullPath(filePath string) string {
 
 // Writes the entrypoint command to an executable file
 func WriteScript(filePath string, command string) {
-	fmt.Println("Writing output script to '" + filePath + "'")
+	fmt.Println("Writing output script to '" + filePath + "'\n")
 
 	// Ensure directory
 	dir := filepath.Dir(filePath)

--- a/src/startupscriptgenerator/dotnetcore/main.go
+++ b/src/startupscriptgenerator/dotnetcore/main.go
@@ -20,8 +20,8 @@ func main() {
 	appPathPtr := flag.String(
 		"appPath",
 		".",
-		"The path to the published output of the application or the root of the source that is going to be run, e.g. '/home/site/wwwroot/'. or '/home/site/repository' "+
-			"Default is current directory.")
+		"The path to the published output of the application or the root of the source that is going to be run," +
+		" e.g. '/home/site/wwwroot/' or '/home/site/repository'. Default is current directory.")
 	runFromPathPtr := flag.String(
 		"runFromPath",
 		"",
@@ -72,7 +72,6 @@ func main() {
 		return
 	}
 
-	fmt.Println("Building the startup script...")
 	scriptBuilder := strings.Builder{}
 	scriptBuilder.WriteString("#!/bin/bash\n")
 	scriptBuilder.WriteString("set -e\n\n")

--- a/src/startupscriptgenerator/dotnetcore/scriptgenerator.go
+++ b/src/startupscriptgenerator/dotnetcore/scriptgenerator.go
@@ -122,6 +122,7 @@ if [ -z "$startUpCommand" ]; then
 fi
 
 echo "Running the command '$startUpCommand'..."
+echo
 eval "$startUpCommand"
 `
 	scriptBuilder.WriteString(script)

--- a/tests/Oryx.Integration.Tests/DotNetCoreEndToEndTests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCoreEndToEndTests.cs
@@ -347,7 +347,6 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {repoDir}")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(setProjectEnvVariable)
                 .AddCommand(
                 $"oryx -appPath {repoDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
@@ -434,7 +433,6 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {repoDir} -p {ScriptGenerator.Constants.ZipAllOutputBuildPropertyKey}=true")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(setProjectEnvVariable)
                 .AddCommand(
                 $"oryx -appPath {repoDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)

--- a/tests/Oryx.Integration.Tests/DotNetCoreEndToEndTests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCoreEndToEndTests.cs
@@ -261,8 +261,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {appDir}")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(
-                $"oryx -appPath {appDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx -appPath {appDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -302,8 +301,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {appDir}")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(
-                $"oryx -appPath {appDir} -runFromPath /tmp/output -bindPort {ContainerPort}")
+                .AddCommand($"oryx -appPath {appDir} -runFromPath /tmp/output -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -347,8 +345,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {repoDir}")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(
-                $"oryx -appPath {repoDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx -appPath {repoDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -388,8 +385,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {appDir} -p {ScriptGenerator.Constants.ZipAllOutputBuildPropertyKey}=true")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(
-                $"oryx -appPath {appDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx -appPath {appDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -433,8 +429,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {repoDir} -p {ScriptGenerator.Constants.ZipAllOutputBuildPropertyKey}=true")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(
-                $"oryx -appPath {repoDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx -appPath {repoDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -724,7 +719,6 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {repoDir} -o {appOutputDir}") // Do not specify language and version
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand(setProjectEnvVariable)
                 .AddCommand(
                 $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)


### PR DESCRIPTION
In case source path is supplied, then we by default look for the reserved folder name 'oryx_publish_output'.
If found, this folder will become the app path otherwise the source path would be acting as a published output path