### PR TITLE
Do not add common runtime image to the list of images built

### DIFF
--- a/build/buildRunTimeImages.sh
+++ b/build/buildRunTimeImages.sh
@@ -67,7 +67,8 @@ for generateDockerFile in $generateDockerFiles; do
     "$generateDockerFile"
 done
 
-dockerFiles=$(find $runtimeImagesSourceDir -type f -name "Dockerfile")
+# The common base image is built separately, so we ignore it
+dockerFiles=$(find $runtimeImagesSourceDir -type f \( -name "Dockerfile" ! -path "$RUNTIME_IMAGES_SRC_DIR/commonbase/*" \) )
 if [ -z "$dockerFiles" ]
 then
     echo "Couldn't find any Dockerfiles under '$runtimeImagesSourceDir' and its sub-directories."


### PR DESCRIPTION
This prevents the image from being added to the list of images built, which is used to push the images to the repos.