### PR TITLE
Moved script content log to be as early as possible

### DIFF
--- a/src/BuildScriptGeneratorCli/Commands/BuildCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/BuildCommand.cs
@@ -210,6 +210,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             // Write build script to selected path
             File.WriteAllText(buildScriptPath, scriptContent);
             logger.LogTrace("Build script written to file");
+            logger.LogDebug("Build script content:\n" + scriptContent);
 
             var buildEventProps = new Dictionary<string, string>()
             {
@@ -286,7 +287,6 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 timedEvent.AddProperty("exitCode", exitCode.ToString());
             }
 
-            logger.LogDebug("Build script content:\n" + scriptContent);
             logger.LogLongMessage(LogLevel.Debug, "Build script output", buildScriptOutput.ToString());
 
             if (exitCode != ProcessConstants.ExitSuccess)


### PR DESCRIPTION
This way, if a build times out, its script will still be logged.