### PR TITLE
[854302] Platform name is no longer required for run-script command

### DIFF
--- a/src/BuildScriptGenerator/BuildScriptGeneratorContext.cs
+++ b/src/BuildScriptGenerator/BuildScriptGeneratorContext.cs
@@ -3,21 +3,17 @@
 // Licensed under the MIT license.
 // --------------------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-
 namespace Microsoft.Oryx.BuildScriptGenerator
 {
     /// <summary>
     /// Options for the build script generation process.
     /// </summary>
-    public partial class BuildScriptGeneratorContext
+    public partial class BuildScriptGeneratorContext : ScriptGeneratorContext
     {
         /// <summary>
         /// Gets or sets the information which is used to correlate log messages.
         /// </summary>
         public string OperationId { get; set; }
-
-        public ISourceRepo SourceRepo { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the main programming language used in the repo.
@@ -27,7 +23,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
         /// <summary>
         /// Gets or sets the version of the programming language used in the repo.
-        /// If provided, the <see cref="BuildScriptGeneratorContext.Language"/> property should also be provided.
+        /// If provided, the <see cref="Language"/> property should also be provided.
         /// </summary>
         public string LanguageVersion { get; set; }
 
@@ -47,11 +43,6 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         /// are disabled even if they are enabled by their specific flags.
         /// </summary>
         public bool DisableMultiPlatformBuild { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets specific properties for the build script.
-        /// </summary>
-        public IDictionary<string, string> Properties { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether build-time checkers should run.

--- a/src/BuildScriptGenerator/Contracts/ILanguageDetector.cs
+++ b/src/BuildScriptGenerator/Contracts/ILanguageDetector.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         /// <summary>
         /// Detects language name and version of the application in source directory.
         /// </summary>
-        /// <param name="context">The <see cref="BuildScriptGeneratorContext"/>.</param>
+        /// <param name="context">The <see cref="ScriptGeneratorContext"/>.</param>
         /// <returns>An instance of <see cref="LanguageDetectorResult"/> if detection was
         /// successful, <c>null</c> otherwise</returns>
-        LanguageDetectorResult Detect(BuildScriptGeneratorContext context);
+        LanguageDetectorResult Detect(ScriptGeneratorContext context);
     }
 }

--- a/src/BuildScriptGenerator/Contracts/IProgrammingPlatform.cs
+++ b/src/BuildScriptGenerator/Contracts/IProgrammingPlatform.cs
@@ -26,10 +26,10 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         /// <summary>
         /// Detects the programming platform name and version required by the application in source directory.
         /// </summary>
-        /// <param name="context">The <see cref="BuildScriptGeneratorContext"/>.</param>
+        /// <param name="context">The <see cref="ScriptGeneratorContext"/>.</param>
         /// <returns>An instance of <see cref="LanguageDetectorResult"/> if detection was
         /// successful, <c>null</c> otherwise</returns>
-        LanguageDetectorResult Detect(BuildScriptGeneratorContext context);
+        LanguageDetectorResult Detect(ScriptGeneratorContext context);
 
         /// <summary>
         /// Sets the version of the platform in the <see cref="BuildScriptGeneratorContext"/>.

--- a/src/BuildScriptGenerator/DefaultRunScriptGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultRunScriptGenerator.cs
@@ -44,15 +44,15 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             }
 
             IProgrammingPlatform targetPlatform = null;
-            if (!string.IsNullOrEmpty(ctx.Language))
+            if (!string.IsNullOrEmpty(ctx.Platform))
             {
                 targetPlatform = _programmingPlatforms
-                    .Where(p => p.Name.EqualsIgnoreCase(ctx.Language))
+                    .Where(p => p.Name.EqualsIgnoreCase(ctx.Platform))
                     .FirstOrDefault();
 
                 if (targetPlatform == null)
                 {
-                    throw new UnsupportedLanguageException($"Platform '{ctx.Language}' is not supported.");
+                    throw new UnsupportedLanguageException($"Platform '{ctx.Platform}' is not supported.");
                 }
             }
             else

--- a/src/BuildScriptGenerator/DefaultRunScriptGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultRunScriptGenerator.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Oryx.BuildScriptGenerator.Exceptions;
 using Microsoft.Oryx.Common;
 using Microsoft.Oryx.Common.Extensions;
+using NLog.Targets;
 
 namespace Microsoft.Oryx.BuildScriptGenerator
 {
@@ -35,31 +36,63 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             _logger = logger;
         }
 
-        public string GenerateBashScript(string targetPlatformName, RunScriptGeneratorOptions opts)
+        public string GenerateBashScript(RunScriptGeneratorContext ctx)
         {
-            if (opts.SourceRepo == null)
+            if (ctx.SourceRepo == null)
             {
-                throw new ArgumentNullException(nameof(opts.SourceRepo), "Source repository must be supplied.");
+                throw new ArgumentNullException(nameof(ctx.SourceRepo), "Source repository must be supplied.");
             }
 
-            var targetPlatform = _programmingPlatforms
-                .Where(p => p.Name.EqualsIgnoreCase(targetPlatformName))
-                .FirstOrDefault();
-
-            if (targetPlatform == null)
+            IProgrammingPlatform targetPlatform = null;
+            if (!string.IsNullOrEmpty(ctx.Language))
             {
-                throw new UnsupportedLanguageException($"Platform '{targetPlatformName}' is not supported.");
+                targetPlatform = _programmingPlatforms
+                    .Where(p => p.Name.EqualsIgnoreCase(ctx.Language))
+                    .FirstOrDefault();
+
+                if (targetPlatform == null)
+                {
+                    throw new UnsupportedLanguageException($"Platform '{ctx.Language}' is not supported.");
+                }
+            }
+            else
+            {
+                _logger.LogDebug("No platform provided for run-script command; attempting to determine platform...");
+                foreach (var platform in _programmingPlatforms)
+                {
+                    _logger.LogDebug($"Checking if platform '{platform.Name}' is compatible...");
+                    var detectionResult = platform.Detect(ctx);
+                    if (detectionResult != null)
+                    {
+                        _logger.LogDebug($"Detected platform '{detectionResult.Language}' with version '{detectionResult.LanguageVersion}'.");
+                        if (string.IsNullOrEmpty(detectionResult.LanguageVersion))
+                        {
+                            throw new UnsupportedVersionException($"Couldn't detect a version for platform '{detectionResult.Language}' in the repo.");
+                        }
+
+                        targetPlatform = platform;
+                        break;
+                    }
+                }
+
+                if (targetPlatform == null)
+                {
+                    throw new UnsupportedLanguageException("Unable to determine the platform for the given repo.");
+                }
             }
 
-            return RunStartupScriptGeneratorForPlatform(targetPlatform, opts);
+            return RunStartupScriptGeneratorForPlatform(targetPlatform, ctx);
         }
 
-        private string RunStartupScriptGeneratorForPlatform(IProgrammingPlatform plat, RunScriptGeneratorOptions opts)
+        private string RunStartupScriptGeneratorForPlatform(IProgrammingPlatform plat, RunScriptGeneratorContext ctx)
         {
             var scriptGenPath = FilePaths.RunScriptGeneratorDir + "/" + plat.Name;
 
-            var scriptGenArgs = new List<string> { "-appPath", opts.SourceRepo.RootPath, "-output", _tempScriptPath };
-            scriptGenArgs.AddRange(opts.PassThruArguments);
+            var scriptGenArgs = new List<string> { "-appPath", ctx.SourceRepo.RootPath, "-output", _tempScriptPath };
+            if (ctx.PassThruArguments != null)
+            {
+                scriptGenArgs.AddRange(ctx.PassThruArguments);
+            }
 
             (int exitCode, string stdout, string stderr) = ProcessHelper.RunProcess(
                 scriptGenPath, scriptGenArgs, Environment.CurrentDirectory, RunScriptGeneratorTimeout);

--- a/src/BuildScriptGenerator/DotNetCore/DotnetCoreLanguageDetector.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCoreLanguageDetector.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             _writer = writer;
         }
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             var projectFile = _projectFileProvider.GetRelativePathToProjectFile(context);
             if (string.IsNullOrEmpty(projectFile))

--- a/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 
         public IEnumerable<string> SupportedVersions => _versionProvider.SupportedDotNetCoreVersions;
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             return _detector.Detect(context);
         }

--- a/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/DefaultProjectFileProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/DefaultProjectFileProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             _projectFileProviders = projectFileProviders;
         }
 
-        public virtual string GetRelativePathToProjectFile(BuildScriptGeneratorContext context)
+        public virtual string GetRelativePathToProjectFile(ScriptGeneratorContext context)
         {
             foreach (var projectFileProvider in _projectFileProviders)
             {

--- a/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/ExplicitProjectFileProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/ExplicitProjectFileProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             _logger = logger;
         }
 
-        public string GetRelativePathToProjectFile(BuildScriptGeneratorContext context)
+        public string GetRelativePathToProjectFile(ScriptGeneratorContext context)
         {
             var projectPath = GetProjectInfoFromSettings(context);
             if (string.IsNullOrEmpty(projectPath))
@@ -55,7 +55,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             return projectFileWithRelativePath;
         }
 
-        private string GetProjectInfoFromSettings(BuildScriptGeneratorContext context)
+        private string GetProjectInfoFromSettings(ScriptGeneratorContext context)
         {
             // Value from command line has higher precedence than from environment variables
             if (context.Properties != null && context.Properties.TryGetValue(

--- a/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/IProjectFileProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/IProjectFileProvider.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 {
     public interface IProjectFileProvider
     {
-        string GetRelativePathToProjectFile(BuildScriptGeneratorContext context);
+        string GetRelativePathToProjectFile(ScriptGeneratorContext context);
     }
 }

--- a/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/ProbeAndFindProjectFileProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/ProbeAndFindProjectFileProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             _writer = writer;
         }
 
-        public string GetRelativePathToProjectFile(BuildScriptGeneratorContext context)
+        public string GetRelativePathToProjectFile(ScriptGeneratorContext context)
         {
             if (_probedForProjectFile)
             {

--- a/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/RootDirectoryProjectFileProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/ProjectFileProviders/RootDirectoryProjectFileProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             _logger = logger;
         }
 
-        public string GetRelativePathToProjectFile(BuildScriptGeneratorContext context)
+        public string GetRelativePathToProjectFile(ScriptGeneratorContext context)
         {
             var sourceRepo = context.SourceRepo;
 

--- a/src/BuildScriptGenerator/Node/NodeLanguageDetector.cs
+++ b/src/BuildScriptGenerator/Node/NodeLanguageDetector.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
             _writer = writer;
         }
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             bool isNodeApp = false;
 

--- a/src/BuildScriptGenerator/Node/NodePlatform.cs
+++ b/src/BuildScriptGenerator/Node/NodePlatform.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
 
         public IEnumerable<string> SupportedVersions => _nodeVersionProvider.SupportedNodeVersions;
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             return _detector.Detect(context);
         }

--- a/src/BuildScriptGenerator/Php/PhpLanguageDetector.cs
+++ b/src/BuildScriptGenerator/Php/PhpLanguageDetector.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
             _writer = writer;
         }
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             var sourceRepo = context.SourceRepo;
             if (!sourceRepo.FileExists(PhpConstants.ComposerFileName))

--- a/src/BuildScriptGenerator/Php/PhpPlatform.cs
+++ b/src/BuildScriptGenerator/Php/PhpPlatform.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
 
         public IEnumerable<string> SupportedVersions => _phpVersionProvider.SupportedPhpVersions;
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             return _detector.Detect(context);
         }

--- a/src/BuildScriptGenerator/Python/PythonLanguageDetector.cs
+++ b/src/BuildScriptGenerator/Python/PythonLanguageDetector.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
             _writer = writer;
         }
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             var sourceRepo = context.SourceRepo;
             if (!sourceRepo.FileExists(PythonConstants.RequirementsFileName))

--- a/src/BuildScriptGenerator/Python/PythonPlatform.cs
+++ b/src/BuildScriptGenerator/Python/PythonPlatform.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
 
         public IEnumerable<string> SupportedVersions => _pythonVersionProvider.SupportedPythonVersions;
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             return _detector.Detect(context);
         }

--- a/src/BuildScriptGenerator/RunScriptGeneratorContext.cs
+++ b/src/BuildScriptGenerator/RunScriptGeneratorContext.cs
@@ -11,16 +11,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator
     public class RunScriptGeneratorContext : ScriptGeneratorContext
     {
         /// <summary>
-        /// Gets or sets the name of the main programming language used in the repo.
-        /// If none is given, a language detection algorithm will attemp to detect it.
+        /// Gets or sets the name of the main programming platform used in the repo.
+        /// If none is given, a platform detection algorithm will attemp to detect it.
         /// </summary>
-        public string Language { get; set; }
+        public string Platform { get; set; }
 
         /// <summary>
-        /// Gets or sets the version of the programming language used in the repo.
-        /// If provided, the <see cref="Language"/> property should also be provided.
+        /// Gets or sets the version of the programming platform used in the repo.
+        /// If provided, the <see cref="Platform"/> property should also be provided.
         /// </summary>
-        public string LanguageVersion { get; set; }
+        public string PlatformVersion { get; set; }
 
         /// <summary>
         /// Gets or sets the arguments to be passed into the run script generator.

--- a/src/BuildScriptGenerator/RunScriptGeneratorContext.cs
+++ b/src/BuildScriptGenerator/RunScriptGeneratorContext.cs
@@ -1,0 +1,30 @@
+﻿// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+
+namespace Microsoft.Oryx.BuildScriptGenerator
+{
+    /// <summary>
+    /// Options for the run script generation process.
+    /// </summary>
+    public class RunScriptGeneratorContext : ScriptGeneratorContext
+    {
+        /// <summary>
+        /// Gets or sets the name of the main programming language used in the repo.
+        /// If none is given, a language detection algorithm will attemp to detect it.
+        /// </summary>
+        public string Language { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the programming language used in the repo.
+        /// If provided, the <see cref="Language"/> property should also be provided.
+        /// </summary>
+        public string LanguageVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets the arguments to be passed into the run script generator.
+        /// </summary>
+        public string[] PassThruArguments { get; set; }
+    }
+}

--- a/src/BuildScriptGenerator/ScriptGeneratorContext.cs
+++ b/src/BuildScriptGenerator/ScriptGeneratorContext.cs
@@ -3,15 +3,20 @@
 // Licensed under the MIT license.
 // --------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Oryx.BuildScriptGenerator
 {
-    public interface IRunScriptGenerator
+    /// <summary>
+    /// Abstraction over the context used for the script generation process.
+    /// </summary>
+    public abstract class ScriptGeneratorContext
     {
+        public ISourceRepo SourceRepo { get; set; }
+
         /// <summary>
-        /// Generates a bash script to run the application.
+        /// Gets or sets specific properties for the generated script.
         /// </summary>
-        /// <param name="ctx">The <see cref="RunScriptGeneratorContext"/> with parameters for the script.</param>
-        /// <returns>Bash script to run the application.</returns>
-        string GenerateBashScript(RunScriptGeneratorContext ctx);
+        public IDictionary<string, string> Properties { get; set; }
     }
 }

--- a/src/BuildScriptGeneratorCli/Commands/RunScriptCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/RunScriptCommand.cs
@@ -45,19 +45,19 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
 
         internal override int Execute(IServiceProvider serviceProvider, IConsole console)
         {
-            string appPath = Path.GetFullPath(AppDir);
             ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-            var sourceRepo = new LocalSourceRepo(appPath, loggerFactory);
+            var sourceRepo = new LocalSourceRepo(AppDir, loggerFactory);
 
-            var options = new RunScriptGeneratorOptions
+            var ctx = new RunScriptGeneratorContext
             {
                 SourceRepo = sourceRepo,
-                PlatformVersion = PlatformVersion,
+                Language = PlatformName,
+                LanguageVersion = PlatformVersion,
                 PassThruArguments = RemainingArgs,
             };
 
             var runScriptGenerator = serviceProvider.GetRequiredService<IRunScriptGenerator>();
-            var script = runScriptGenerator.GenerateBashScript(PlatformName, options);
+            var script = runScriptGenerator.GenerateBashScript(ctx);
             if (string.IsNullOrEmpty(script))
             {
                 console.WriteErrorLine("Couldn't generate startup script.");
@@ -82,9 +82,10 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
 
         internal override bool IsValidInput(IServiceProvider serviceProvider, IConsole console)
         {
-            if (string.IsNullOrWhiteSpace(PlatformName))
+            AppDir = string.IsNullOrEmpty(AppDir) ? Directory.GetCurrentDirectory() : Path.GetFullPath(AppDir);
+            if (!Directory.Exists(AppDir))
             {
-                console.WriteErrorLine("Platform name is required.");
+                console.WriteErrorLine($"Could not find the source directory '{AppDir}'.");
                 return false;
             }
 

--- a/src/BuildScriptGeneratorCli/Commands/RunScriptCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/RunScriptCommand.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             var ctx = new RunScriptGeneratorContext
             {
                 SourceRepo = sourceRepo,
-                Language = PlatformName,
-                LanguageVersion = PlatformVersion,
+                Platform = PlatformName,
+                PlatformVersion = PlatformVersion,
                 PassThruArguments = RemainingArgs,
             };
 

--- a/tests/BuildScriptGenerator.Tests/DefaultBuildScriptGeneratorTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DefaultBuildScriptGeneratorTest.cs
@@ -688,7 +688,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests
 
             public bool DetectInvoked { get; private set; }
 
-            public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+            public LanguageDetectorResult Detect(ScriptGeneratorContext context)
             {
                 DetectInvoked = true;
 
@@ -722,7 +722,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests
 
             public bool DetectInvoked { get; private set; }
 
-            public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+            public LanguageDetectorResult Detect(ScriptGeneratorContext context)
             {
                 DetectInvoked = true;
 

--- a/tests/BuildScriptGenerator.Tests/DotnetCore/DotnetCoreLanguageDetectorTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DotnetCore/DotnetCoreLanguageDetectorTest.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
                 _projectFilePath = projectFilePath;
             }
 
-            public override string GetRelativePathToProjectFile(BuildScriptGeneratorContext context)
+            public override string GetRelativePathToProjectFile(ScriptGeneratorContext context)
             {
                 return _projectFilePath;
             }

--- a/tests/BuildScriptGeneratorCli.Tests/BuildCommandTest.cs
+++ b/tests/BuildScriptGeneratorCli.Tests/BuildCommandTest.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
 
         private class TestLanguageDetector : ILanguageDetector
         {
-            public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+            public LanguageDetectorResult Detect(ScriptGeneratorContext context)
             {
                 return new LanguageDetectorResult
                 {

--- a/tests/BuildScriptGeneratorCli.Tests/ScriptCommandTest.cs
+++ b/tests/BuildScriptGeneratorCli.Tests/ScriptCommandTest.cs
@@ -6,22 +6,15 @@
 using System;
 using System.IO;
 using McMaster.Extensions.CommandLineUtils;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Oryx.BuildScriptGenerator;
 using Microsoft.Oryx.Tests.Common;
 using Xunit;
 
 namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
 {
-    public class ScriptCommandTest : IClassFixture<TestTempDirTestFixture>
+    public class ScriptCommandTest : ScriptCommandTestBase
     {
-        private static string _testDirPath;
-
-        public ScriptCommandTest(TestTempDirTestFixture testFixture)
-        {
-            _testDirPath = testFixture.RootDirPath;
-        }
+        public ScriptCommandTest(TestTempDirTestFixture testFixture) : base(testFixture) { }
 
         [Fact]
         public void OnExecute_ShowsHelp_AndExits_WhenSourceDirectoryDoesNotExist()
@@ -96,67 +89,6 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
             Assert.Equal(0, exitCode);
             Assert.Contains(scriptContentWithCRLF.Replace("\r\n", "\n"), testConsole.StdOutput);
             Assert.Equal(string.Empty, testConsole.StdError);
-        }
-
-        private IServiceProvider CreateServiceProvider(TestProgrammingPlatform generator, bool scriptOnly)
-        {
-            var sourceCodeFolder = Path.Combine(_testDirPath, "src");
-            Directory.CreateDirectory(sourceCodeFolder);
-            var outputFolder = Path.Combine(_testDirPath, "output");
-            Directory.CreateDirectory(outputFolder);
-            var servicesBuilder = new ServiceProviderBuilder()
-                .ConfigureServices(services =>
-                {
-                    // Add 'test' script generator here as we can control what the script output is rather
-                    // than depending on in-built script generators whose script could change overtime causing
-                    // this test to be difficult to manage.
-
-                    services.RemoveAll<ILanguageDetector>();
-                    services.TryAddEnumerable(
-                        ServiceDescriptor.Singleton<ILanguageDetector, TestLanguageDetector>());
-
-                    services.RemoveAll<IProgrammingPlatform>();
-                    services.TryAddEnumerable(
-                        ServiceDescriptor.Singleton<IProgrammingPlatform>(generator));
-
-                    services.AddSingleton<ITempDirectoryProvider>(
-                        new TestTempDirectoryProvider(Path.Combine(_testDirPath, "temp")));
-                })
-                .ConfigureScriptGenerationOptions(o =>
-                {
-                    o.SourceDir = sourceCodeFolder;
-                    o.DestinationDir = outputFolder;
-                    o.ScriptOnly = scriptOnly;
-                });
-            return servicesBuilder.Build();
-        }
-
-        private class TestTempDirectoryProvider : ITempDirectoryProvider
-        {
-            private readonly string _tempDir;
-
-            public TestTempDirectoryProvider(string tempDir)
-            {
-                _tempDir = tempDir;
-            }
-
-            public string GetTempDirectory()
-            {
-                Directory.CreateDirectory(_tempDir);
-                return _tempDir;
-            }
-        }
-
-        private class TestLanguageDetector : ILanguageDetector
-        {
-            public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
-            {
-                return new LanguageDetectorResult
-                {
-                    Language = "test",
-                    LanguageVersion = "1.0.0"
-                };
-            }
         }
     }
 }

--- a/tests/BuildScriptGeneratorCli.Tests/ScriptCommandTestBase.cs
+++ b/tests/BuildScriptGeneratorCli.Tests/ScriptCommandTestBase.cs
@@ -1,0 +1,90 @@
+﻿// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Oryx.BuildScriptGenerator;
+using Microsoft.Oryx.Tests.Common;
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
+{
+    public class ScriptCommandTestBase : IClassFixture<TestTempDirTestFixture>
+    {
+        internal static TestTempDirTestFixture _testDir;
+        internal static string _testDirPath;
+
+        public ScriptCommandTestBase(TestTempDirTestFixture testFixture)
+        {
+            _testDir = testFixture;
+            _testDirPath = testFixture.RootDirPath;
+        }
+
+        internal IServiceProvider CreateServiceProvider(TestProgrammingPlatform generator, bool scriptOnly)
+        {
+            var sourceCodeFolder = Path.Combine(_testDirPath, "src");
+            Directory.CreateDirectory(sourceCodeFolder);
+            var outputFolder = Path.Combine(_testDirPath, "output");
+            Directory.CreateDirectory(outputFolder);
+            var servicesBuilder = new ServiceProviderBuilder()
+                .ConfigureServices(services =>
+                {
+                    // Add 'test' script generator here as we can control what the script output is rather
+                    // than depending on in-built script generators whose script could change overtime causing
+                    // this test to be difficult to manage.
+
+                    services.RemoveAll<ILanguageDetector>();
+                    services.TryAddEnumerable(
+                        ServiceDescriptor.Singleton<ILanguageDetector, TestLanguageDetector>());
+
+                    services.RemoveAll<IProgrammingPlatform>();
+                    services.TryAddEnumerable(
+                        ServiceDescriptor.Singleton<IProgrammingPlatform>(generator));
+
+                    services.AddSingleton<ITempDirectoryProvider>(
+                        new TestTempDirectoryProvider(Path.Combine(_testDirPath, "temp")));
+                })
+                .ConfigureScriptGenerationOptions(o =>
+                {
+                    o.SourceDir = sourceCodeFolder;
+                    o.DestinationDir = outputFolder;
+                    o.ScriptOnly = scriptOnly;
+                });
+            return servicesBuilder.Build();
+        }
+
+        internal class TestTempDirectoryProvider : ITempDirectoryProvider
+        {
+            private readonly string _tempDir;
+
+            public TestTempDirectoryProvider(string tempDir)
+            {
+                _tempDir = tempDir;
+            }
+
+            public string GetTempDirectory()
+            {
+                Directory.CreateDirectory(_tempDir);
+                return _tempDir;
+            }
+        }
+
+        internal class TestLanguageDetector : ILanguageDetector
+        {
+            public LanguageDetectorResult Detect(ScriptGeneratorContext context)
+            {
+                return new LanguageDetectorResult
+                {
+                    Language = "test",
+                    LanguageVersion = "1.0.0"
+                };
+            }
+        }
+    }
+}

--- a/tests/Oryx.Tests.Common/TestProgrammingPlatform.cs
+++ b/tests/Oryx.Tests.Common/TestProgrammingPlatform.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Oryx.Tests.Common
 
         public IEnumerable<string> SupportedVersions { get; }
 
-        public LanguageDetectorResult Detect(BuildScriptGeneratorContext context)
+        public LanguageDetectorResult Detect(ScriptGeneratorContext context)
         {
             return _detector?.Detect(context);
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

Resolves issue 854302 (or GitHub issue https://github.com/microsoft/Oryx/issues/90) -- the `run-script` command currently fails if the user does not provide a value for the `--platform` parameter. These changes will use the same detection algorithm as the `build*` commands to determine the platform of the given repository (or the current directory if a source is not given).

A `ScriptGeneratorContext` abstraction was introduced to allow `build*` and `run*` commands to have their own information about the generator context, but not disrupt what the platform and detector classes need to determine if their platform is compatible.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
