### PR TITLE
change .NET core framework 2.1 to 3.1

### DIFF
--- a/build/tools/SharedCodeGenerator/SharedCodeGenerator.csproj
+++ b/build/tools/SharedCodeGenerator/SharedCodeGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
   <PropertyGroup>

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -212,6 +212,6 @@ The *Run* images are published to MCR (mcr.microsoft.com/oryx/&lt;platform&gt;).
 The following are required to run and test this project locally.
 
 - Bash v4.4
-- [.NET Core 2.1](https://dotnet.microsoft.com/download/dotnet-core)
+- [.NET Core 3.1](https://dotnet.microsoft.com/download/dotnet-core)
 - [Go 1.11+](https://golang.org/dl/) (for startup script generator)
 - [Docker v18.06.1-ce](https://docs.docker.com/install/)

--- a/src/BuildScriptGenerator/BuildScriptGenerator.csproj
+++ b/src/BuildScriptGenerator/BuildScriptGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Oryx.BuildScriptGenerator</AssemblyName>
     <RootNamespace>Microsoft.Oryx.BuildScriptGenerator</RootNamespace>
     <ApplicationIcon />

--- a/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
+++ b/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeFrameworkVersion>2.1</RuntimeFrameworkVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeFrameworkVersion>3.1</RuntimeFrameworkVersion>
     <AssemblyName>GenerateBuildScript</AssemblyName>
     <RootNamespace>Microsoft.Oryx.BuildScriptGeneratorCli</RootNamespace>
     <OutputType>Exe</OutputType>

--- a/src/BuildScriptGeneratorCli/Oryx_sign.signproj
+++ b/src/BuildScriptGeneratorCli/Oryx_sign.signproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(RuntimeIdentifier)\publish</OutDir>
-    <IntermediateOutputPath>obj\$(Configuration)\netcoreapp2.1\$(RuntimeIdentifier)</IntermediateOutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\netcoreapp3.1\$(RuntimeIdentifier)</IntermediateOutputPath>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\build\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Oryx.Common</AssemblyName>
     <LangVersion>7.3</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
+++ b/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/tests/BuildScriptGeneratorCli.Tests/BuildScriptGeneratorCli.Tests.csproj
+++ b/tests/BuildScriptGeneratorCli.Tests/BuildScriptGeneratorCli.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/tests/Oryx.BuildImage.Tests/Oryx.BuildImage.Tests.csproj
+++ b/tests/Oryx.BuildImage.Tests/Oryx.BuildImage.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AssemblyOriginatorKeyFile>..\..\build\TestAssembliesKey.snk</AssemblyOriginatorKeyFile>

--- a/tests/Oryx.Common.Tests/Oryx.Common.Tests.csproj
+++ b/tests/Oryx.Common.Tests/Oryx.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Oryx.Integration.Tests/Oryx.Integration.Tests.csproj
+++ b/tests/Oryx.Integration.Tests/Oryx.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
+++ b/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/tests/Oryx.Tests.Common/Oryx.Tests.Common.csproj
+++ b/tests/Oryx.Tests.Common/Oryx.Tests.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.Oryx.Tests.Common</RootNamespace>
     <AssemblyName>Microsoft.Oryx.Tests.Common</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\build\TestAssembliesKey.snk</AssemblyOriginatorKeyFile>

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -27,10 +27,10 @@ steps:
     or(in(variables['SIGNTYPE'], 'real', 'Real'), in(variables['SignType'], 'real', 'Real')),
     or(startsWith(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/heads/patch/' )))
 
-- task: ShellScript@2
-  displayName: 'Build Oryx.sln'
-  inputs:
-    scriptPath: ./build/buildSln.sh
+# - task: ShellScript@2
+#   displayName: 'Build Oryx.sln'
+#   inputs:
+#     scriptPath: ./build/buildSln.sh
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection - OSS Compliance'


### PR DESCRIPTION
Move oryx repo from .NET core 2.1 to 3.1.
In order to reduce command line length and size to pull images