### PR TITLE
Use 'create-script' command for all runtime script generators

### DIFF
--- a/src/startupscriptgenerator/src/common/commandLineFlags.go
+++ b/src/startupscriptgenerator/src/common/commandLineFlags.go
@@ -10,18 +10,26 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 )
 
-func ValidateCommands(versionCommand *flag.FlagSet, scriptCommand *flag.FlagSet, setupEnvCommand *flag.FlagSet) {
+func getCommandNameList(commands []*flag.FlagSet) []string {
+	cmdsList := make([]string, len(commands))
+	for i := 0; i < len(cmdsList); i++ {
+		cmdsList[i] = commands[i].Name()
+	}
+	return cmdsList
+}
+
+func ValidateCommands(commands []*flag.FlagSet) {
 	// Verify that a subcommand has been provided
-	// os.Arg[0] is the main command
-	// os.Arg[1] will be the subcommand
+	// os.Arg[0] is the main command (ex: 'oryx')
+	// os.Arg[1] will be the subcommand (ex: 'create-script')
 	if len(os.Args) < 2 {
+		cmdsList := getCommandNameList(commands)
 		fmt.Println(fmt.Sprintf(
-			"Error: '%s' or '%s' or '%s' subcommand is required",
-			consts.VersionCommandName,
-			consts.SetupEnvCommandName,
-			consts.CreateScriptCommandName))
+			"Error: Invalid execution. Available subcommands: %s",
+			strings.Join(cmdsList, ", ")))
 		os.Exit(1)
 	}
 
@@ -29,15 +37,25 @@ func ValidateCommands(versionCommand *flag.FlagSet, scriptCommand *flag.FlagSet,
 	// Parse the flags for appropriate FlagSet
 	// FlagSet.Parse() requires a set of arguments to parse as input
 	// os.Args[2:] will be all arguments starting after the subcommand at os.Args[1]
-	switch os.Args[1] {
-	case consts.VersionCommandName:
+	suppliedCommandName := os.Args[1]
+	if suppliedCommandName == consts.VersionCommandName {
 		PrintVersionInfo()
-	case consts.CreateScriptCommandName:
-		scriptCommand.Parse(os.Args[2:])
-	case consts.SetupEnvCommandName:
-		setupEnvCommand.Parse(os.Args[2:])
-	default:
-		flag.PrintDefaults()
-		os.Exit(1)
+	} else {
+		isValidCommand := false
+		for i := 0; i < len(commands); i++ {
+			if suppliedCommandName == commands[i].Name() {
+				isValidCommand = true
+				commands[i].Parse(os.Args[2:])
+				break
+			}
+		}
+		if !isValidCommand {
+			cmdsList := getCommandNameList(commands)
+			fmt.Println(fmt.Sprintf(
+				"Error: Invalid subcommand '%s'. Available subcommands: %s",
+				suppliedCommandName,
+				strings.Join(cmdsList, ", ")))
+			os.Exit(1)
+		}
 	}
 }

--- a/src/startupscriptgenerator/src/node/main.go
+++ b/src/startupscriptgenerator/src/node/main.go
@@ -70,7 +70,8 @@ func main() {
 	defer logger.Shutdown()
 	logger.StartupScriptRequested()
 
-	common.ValidateCommands(versionCommand, scriptCommand, setupEnvCommand)
+	commands := []*flag.FlagSet{versionCommand, scriptCommand, setupEnvCommand}
+	common.ValidateCommands(commands)
 
 	if scriptCommand.Parsed() {
 		fullAppPath := common.GetValidatedFullPath(*appPathPtr)

--- a/src/startupscriptgenerator/src/php/main.go
+++ b/src/startupscriptgenerator/src/php/main.go
@@ -35,7 +35,6 @@ func main() {
 	startupCmdPtr := scriptCommand.String("startupCommand", startupCommand, "Command that will be executed to start the application server up.")
 	bindPortPtr := scriptCommand.String("bindPort", "", "[Optional] Port where the application will bind to. Default is 8080")
 	outputPathPtr := scriptCommand.String("output", "run.sh", "Path to the script to be generated.")
-	scriptCommand.Parse()
 
 	logger := common.GetLogger("php.main")
 	defer logger.Shutdown()

--- a/src/startupscriptgenerator/src/php/main.go
+++ b/src/startupscriptgenerator/src/php/main.go
@@ -13,9 +13,11 @@ import (
 )
 
 func main() {
-	common.PrintVersionInfo()
-	appPathPtr := flag.String("appPath", ".", "The path to the application folder, e.g. '/home/site/wwwroot/'.")
-	manifestDirPtr := flag.String(
+	versionCommand := flag.NewFlagSet(consts.VersionCommandName, flag.ExitOnError)
+
+	scriptCommand := flag.NewFlagSet(consts.CreateScriptCommandName, flag.ExitOnError)
+	appPathPtr := scriptCommand.String("appPath", ".", "The path to the application folder, e.g. '/home/site/wwwroot/'.")
+	manifestDirPtr := scriptCommand.String(
 		"manifestDir",
 		"",
 		"[Optional] Path to the directory where build manifest file can be found. If no value is provided, then "+
@@ -30,27 +32,32 @@ func main() {
 		startupCommand = "apache2-foreground"
 	}
 
-	startupCmdPtr := flag.String("startupCommand", startupCommand, "Command that will be executed to start the application server up.")
-	bindPortPtr := flag.String("bindPort", "", "[Optional] Port where the application will bind to. Default is 8080")
-	outputPathPtr := flag.String("output", "run.sh", "Path to the script to be generated.")
-	flag.Parse()
+	startupCmdPtr := scriptCommand.String("startupCommand", startupCommand, "Command that will be executed to start the application server up.")
+	bindPortPtr := scriptCommand.String("bindPort", "", "[Optional] Port where the application will bind to. Default is 8080")
+	outputPathPtr := scriptCommand.String("output", "run.sh", "Path to the script to be generated.")
+	scriptCommand.Parse()
 
 	logger := common.GetLogger("php.main")
 	defer logger.Shutdown()
 	logger.StartupScriptRequested()
 
-	fullAppPath := common.GetValidatedFullPath(*appPathPtr)
+	commands := []*flag.FlagSet{versionCommand, scriptCommand}
+	common.ValidateCommands(commands)
 
-	buildManifest := common.GetBuildManifest(manifestDirPtr, fullAppPath)
-	common.SetGlobalOperationID(buildManifest)
+	if scriptCommand.Parsed() {
+		fullAppPath := common.GetValidatedFullPath(*appPathPtr)
 
-	entrypointGenerator := PhpStartupScriptGenerator{
-		SourcePath: fullAppPath,
-		StartupCmd: *startupCmdPtr,
-		BindPort:   *bindPortPtr,
-		Manifest:   buildManifest,
+		buildManifest := common.GetBuildManifest(manifestDirPtr, fullAppPath)
+		common.SetGlobalOperationID(buildManifest)
+
+		entrypointGenerator := PhpStartupScriptGenerator{
+			SourcePath: fullAppPath,
+			StartupCmd: *startupCmdPtr,
+			BindPort:   *bindPortPtr,
+			Manifest:   buildManifest,
+		}
+
+		command := entrypointGenerator.GenerateEntrypointScript()
+		common.WriteScript(*outputPathPtr, command)
 	}
-
-	command := entrypointGenerator.GenerateEntrypointScript()
-	common.WriteScript(*outputPathPtr, command)
 }

--- a/src/startupscriptgenerator/src/python/main.go
+++ b/src/startupscriptgenerator/src/python/main.go
@@ -58,7 +58,8 @@ func main() {
 	defer logger.Shutdown()
 	logger.StartupScriptRequested()
 
-	common.ValidateCommands(versionCommand, scriptCommand, setupEnvCommand)
+	commands := []*flag.FlagSet{versionCommand, scriptCommand, setupEnvCommand}
+	common.ValidateCommands(commands)
 
 	if scriptCommand.Parsed() {
 		fullAppPath := common.GetValidatedFullPath(*appPathPtr)

--- a/tests/Oryx.Integration.Tests/Database/DatabaseTestsBase.cs
+++ b/tests/Oryx.Integration.Tests/Database/DatabaseTestsBase.cs
@@ -48,16 +48,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var scriptBuilder = new ShellScriptBuilder()
                 .AddCommand($"cd {appDir}");
 
-            if (string.Equals("python", language, StringComparison.OrdinalIgnoreCase) 
-                || string.Equals("nodejs", language, StringComparison.OrdinalIgnoreCase))
-            {
-                scriptBuilder = scriptBuilder.AddCommand($"oryx create-script -appPath {appDir} {bindPortFlag}");
-            }
-            else
-            {
-                scriptBuilder = scriptBuilder.AddCommand($"oryx -appPath {appDir} {bindPortFlag}");
-            }
-
+            scriptBuilder = scriptBuilder.AddCommand($"oryx create-script -appPath {appDir} {bindPortFlag}");
             var script = scriptBuilder.AddCommand(entrypointScript)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/Database/SqlServerIntegrationTests.cs
+++ b/tests/Oryx.Integration.Tests/Database/SqlServerIntegrationTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var volume = DockerVolume.CreateMirror(hostDir);
             var appDir = volume.ContainerDir;
             var script = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx create-script -appPath {appDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion10Tests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion10Tests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion11Tests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion11Tests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -78,7 +78,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion20Tests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion20Tests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion21Tests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion21Tests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -88,7 +88,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort} -manifestDir {manifestDir}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort} -manifestDir {manifestDir}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -135,7 +135,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -180,7 +180,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var runtimeImageScript = new ShellScriptBuilder()
                 // NOTE: Make sure the current directory is the output directory
                 .AddCommand($"cd {appOutputDir}")
-                .AddCommand($"oryx -bindPort {ContainerPort}")
+                .AddCommand($"oryx create-script -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -224,7 +224,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -288,7 +288,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"mkdir -p {tempAppDir}")
                 .AddCommand($"cp -rf {appOutputDir}/* {tempAppDir}")
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -output {startupFilePath} " +
+                $"oryx create-script -appPath {appOutputDir} -output {startupFilePath} " +
                 $"-userStartupCommand {startupCommand} -bindPort {ContainerPort}")
                 .AddCommand(startupFilePath)
                 .ToString();
@@ -340,7 +340,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"echo 'dotnet {tempAppDir}/{NetCoreApp21WebApp}.dll' >> {userStartupFile}")
                 .AddCommand($"chmod +x {userStartupFile}")
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -userStartupCommand {userStartupFile} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -userStartupCommand {userStartupFile} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -387,7 +387,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(setProjectEnvVariable)
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -430,7 +430,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .AddCommand($"oryx build {repoDir} -o {appOutputDir}")
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -475,7 +475,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -520,7 +520,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -runFromPath /tmp/output -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -runFromPath /tmp/output -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -579,7 +579,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var startupCommand = $"\"dotnet WebApp2.dll\"";
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -userStartupCommand {startupCommand} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -userStartupCommand {startupCommand} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -633,7 +633,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand($"rm -f {appOutputDir}/{FilePaths.BuildManifestFileName}")
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -defaultAppFilePath {defaultAppDir}/output/{DefaultWebApp}.dll " +
+                $"oryx create-script -appPath {appOutputDir} -defaultAppFilePath {defaultAppDir}/output/{DefaultWebApp}.dll " +
                 $"-bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
@@ -682,7 +682,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -userStartupCommand \"{command}\" " +
+                $"oryx create-script -appPath {appOutputDir} -userStartupCommand \"{command}\" " +
                 $"-defaultAppFilePath {defaultAppDir}/output/{DefaultWebApp}.dll " +
                 $"-bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
@@ -733,7 +733,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .AddFileExistsCheck($"{appOutputDir}/{renamedAppName}.runtimeconfig.json")
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion22Tests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion22Tests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Oryx.Integration.Tests
 
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort} -output {startupFile}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort} -output {startupFile}")
                 .AddCommand(startupFile)
                 .ToString();
 
@@ -84,7 +84,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -128,7 +128,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand($"export PORT={ContainerPort}")
                 .AddCommand(
-                $"oryx -appPath {appOutputDir}")
+                $"oryx create-script -appPath {appOutputDir}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -172,7 +172,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand($"export PORT=9095")
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -217,7 +217,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -260,7 +260,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand($"mkdir -p {doesNotContainApp}")
                 .AddCommand(
-                $"oryx -appPath {doesNotContainApp} " +
+                $"oryx create-script -appPath {doesNotContainApp} " +
                 $"-defaultAppFilePath {defaultAppDir}/output/{DefaultWebApp}.dll " +
                 $"-bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)

--- a/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion30Tests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion30Tests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -77,7 +77,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -121,7 +121,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -177,7 +177,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -217,7 +217,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var volume = DockerVolume.CreateMirror(hostDir);
             var appDir = volume.ContainerDir;
             var runtimeImageScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appDir} -bindPort {ContainerPort}")
+                .AddCommand($"oryx create-script -appPath {appDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -257,7 +257,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -userStartupCommand {startupCommand} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -userStartupCommand {startupCommand} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 
@@ -301,7 +301,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion31Tests.cs
+++ b/tests/Oryx.Integration.Tests/DotNetCore/DotNetCoreRuntimeVersion31Tests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .ToString();
             var runtimeImageScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx -appPath {appOutputDir} -bindPort {ContainerPort}")
+                $"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/Php/PhpExifTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpExifTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .AddCommand($"oryx build {appDir} --platform php --language-version {phpVersion}")
                .ToString();
             var runScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appDir} -output {RunScriptPath}")
+                .AddCommand($"oryx create-script -appPath {appDir} -output {RunScriptPath}")
                 .AddCommand(RunScriptPath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/Php/PhpGdTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpGdTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .AddCommand($"oryx build {appDir} --platform php --language-version {phpVersion}")
                .ToString();
             var runScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appDir} -output {RunScriptPath}")
+                .AddCommand($"oryx create-script -appPath {appDir} -output {RunScriptPath}")
                 .AddCommand(RunScriptPath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/Php/PhpImagickExampleTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpImagickExampleTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .AddCommand($"oryx build {appDir} --platform php --language-version {phpVersion}")
                .ToString();
             var runScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appDir} -output {RunScriptPath}")
+                .AddCommand($"oryx create-script -appPath {appDir} -output {RunScriptPath}")
                 .AddCommand(RunScriptPath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/Php/PhpTwigExampleTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpTwigExampleTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .AddCommand($"oryx build {appDir} --platform php --language-version {phpVersion}")
                .ToString();
             var runScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appDir} -output {RunScriptPath}")
+                .AddCommand($"oryx create-script -appPath {appDir} -output {RunScriptPath}")
                 .AddCommand(RunScriptPath)
                 .ToString();
 

--- a/tests/Oryx.Integration.Tests/Php/PhpWordPressTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpWordPressTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Oryx.Integration.Tests
                .AddCommand($"oryx build {appDir} --platform php --language-version {phpVersion}")
                .ToString();
             var runScript = new ShellScriptBuilder()
-                .AddCommand($"oryx -appPath {appDir} -output {RunScriptPath}")
+                .AddCommand($"oryx create-script -appPath {appDir} -output {RunScriptPath}")
                 .AddCommand(RunScriptPath)
                 .ToString();
 

--- a/tests/Oryx.RuntimeImage.Tests/DotNetCore/DotnetCoreImageVersionsTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/DotNetCore/DotnetCoreImageVersionsTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
             {
                 ImageId = _imageHelper.GetTestRuntimeImage("dotnetcore", version),
                 CommandToExecuteOnRun = "oryx",
-                CommandArguments = new[] { " " }
+                CommandArguments = new[] { "version" }
             });
 
             // Assert

--- a/tests/Oryx.RuntimeImage.Tests/Php-fpm/PhpFpmImageTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/Php-fpm/PhpFpmImageTest.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
             {
                 ImageId = _imageHelper.GetTestRuntimeImage("php", version),
                 CommandToExecuteOnRun = "oryx",
-                CommandArguments = new[] { " " }
+                CommandArguments = new[] { "version" }
             });
 
             // Assert

--- a/tests/Oryx.RuntimeImage.Tests/Php/PhpImageTest.cs
+++ b/tests/Oryx.RuntimeImage.Tests/Php/PhpImageTest.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Oryx.RuntimeImage.Tests
             {
                 ImageId = _imageHelper.GetTestRuntimeImage("php", version),
                 CommandToExecuteOnRun = "oryx",
-                CommandArguments = new[] { " " }
+                CommandArguments = new[] { "version" }
             });
 
             // Assert


### PR DESCRIPTION
Currently only Python and Node runtime script generators have the `create-script` and `version` subcommands, With this PR I made change to even make DotNetCore and PHP runtime script generators to have this subcommand. This is so that AppService does not need to do special logic per platform and can have a consistent experience all across.