### PR TITLE
run build from setup.py for python apps

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -1,5 +1,5 @@
 declare -r TS_FMT='[%T%z] '
-declare -r REQS_NOT_FOUND_MSG='Could not find requirements.txt; Not running pip install'
+declare -r REQS_NOT_FOUND_MSG='Could not find setup.py or requirements.txt; Not running pip install'
 echo "Python Version: $python"
 PIP_CACHE_DIR=/usr/local/share/pip-cache
 
@@ -45,6 +45,18 @@ then
 	then
 		exit $pipInstallExitCode
 	fi
+elif [ -e "setup.py" ]
+then
+	echo
+	START_TIME=$SECONDS
+
+	echo "Running python setup.py install..."
+	python setup.py install | ts $TS_FMT
+	pythonBuildExitCode=${PIPESTATUS[0]}
+	if [[ $pythonBuildExitCode != 0 ]]
+	then
+		exit $pythonBuildExitCode
+	fi
 else
 	echo $REQS_NOT_FOUND_MSG
 fi
@@ -67,6 +79,18 @@ then
 	if [[ $pipInstallExitCode != 0 ]]
 	then
 		exit $pipInstallExitCode
+	fi
+elif [ -e "setup.py" ]
+then
+	echo
+	START_TIME=$SECONDS
+
+	echo "Running python setup.py install..."
+	python setup.py install | ts $TS_FMT
+	pythonBuildExitCode=${PIPESTATUS[0]}
+	if [[ $pythonBuildExitCode != 0 ]]
+	then
+		exit $pythonBuildExitCode
 	fi
 else
 	echo $REQS_NOT_FOUND_MSG

--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -49,9 +49,15 @@ elif [ -e "setup.py" ]
 then
 	echo
 	START_TIME=$SECONDS
-
+	pip install --upgrade pip
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Done in $ELAPSED_TIME sec(s)."
+	
 	echo "Running python setup.py install..."
-	python setup.py install | ts $TS_FMT
+	$python setup.py install --user| ts $TS_FMT
+	cd *.egg-info
+	pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r requires.txt | ts $TS_FMT
+
 	pythonBuildExitCode=${PIPESTATUS[0]}
 	if [[ $pythonBuildExitCode != 0 ]]
 	then
@@ -84,9 +90,14 @@ elif [ -e "setup.py" ]
 then
 	echo
 	START_TIME=$SECONDS
+	pip install --upgrade pip
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Done in $ELAPSED_TIME sec(s)."
 
 	echo "Running python setup.py install..."
-	python setup.py install | ts $TS_FMT
+	$python setup.py install --user| ts $TS_FMT
+	cd *.egg-info
+	pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r requires.txt | ts $TS_FMT
 	pythonBuildExitCode=${PIPESTATUS[0]}
 	if [[ $pythonBuildExitCode != 0 ]]
 	then

--- a/src/BuildScriptGenerator/Python/PythonConstants.cs
+++ b/src/BuildScriptGenerator/Python/PythonConstants.cs
@@ -18,5 +18,6 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         internal const string ZipVirtualEnvFileNameFormat = "{0}.zip";
         internal const string TarGzVirtualEnvFileNameFormat = "{0}.tar.gz";
         internal const string DefaultTargetPackageDirectory = "__oryx_packages__";
+        internal const string SetupDotPyFileName = "setup.py";
     }
 }

--- a/src/BuildScriptGenerator/Python/PythonLanguageDetector.cs
+++ b/src/BuildScriptGenerator/Python/PythonLanguageDetector.cs
@@ -41,6 +41,17 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
                     $"does not exist in source repo");
                 return null;
             }
+            else if (!sourceRepo.FileExists(PythonConstants.RequirementsFileName)
+                && sourceRepo.FileExists(PythonConstants.SetupDotPyFileName))
+            {
+                _logger.LogInformation($"'{PythonConstants.RequirementsFileName} doesn't exist in source repo.' " +
+                    $"Oryx will try to build from '{PythonConstants.SetupDotPyFileName}'that exists in source repo");
+            }
+            else
+            {
+                _logger.LogInformation($"'{PythonConstants.SetupDotPyFileName} doesn't exist in source repo.' " +
+                    $"Oryx will try to build from '{PythonConstants.RequirementsFileName}'that exists in source repo");
+            }
 
             // This detects if a runtime.txt file exists if that is a python file
             var versionFromRuntimeFile = DetectPythonVersionFromRuntimeFile(context.SourceRepo);

--- a/src/BuildScriptGenerator/Python/PythonLanguageDetector.cs
+++ b/src/BuildScriptGenerator/Python/PythonLanguageDetector.cs
@@ -34,9 +34,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         public LanguageDetectorResult Detect(RepositoryContext context)
         {
             var sourceRepo = context.SourceRepo;
-            if (!sourceRepo.FileExists(PythonConstants.RequirementsFileName))
+            if (!sourceRepo.FileExists(PythonConstants.RequirementsFileName)
+                && !sourceRepo.FileExists(PythonConstants.SetupDotPyFileName))
             {
-                _logger.LogDebug($"File '{PythonConstants.RequirementsFileName}' does not exist in source repo");
+                _logger.LogDebug($"'{PythonConstants.SetupDotPyFileName}' or '{PythonConstants.RequirementsFileName}' " +
+                    $"does not exist in source repo");
                 return null;
             }
 

--- a/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
@@ -400,6 +400,90 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 result.GetDebugInfo());
         }
 
+        // This is to test if we can build an app when there is no requirement.txt
+        // but setup.py is provided at root level
+        [Fact]
+        public void GeneratesScript_AndBuilds_WhenSetupDotPy_File_isProvided()
+        {
+            // Arrange
+            var appName = "flask-setup-py-app";
+            var volume = CreateSampleAppVolume(appName);
+            var appDir = volume.ContainerDir;
+            var appOutputDir = $"{appDir}/output";
+            var manifestFile = $"{appOutputDir}/{FilePaths.BuildManifestFileName}";
+            var script = new ShellScriptBuilder()
+                .AddBuildCommand(
+                $"{appDir} -o {appOutputDir} --platform python --platform-version {PythonVersions.Python36Version}")
+                .AddCommand($"cat {manifestFile}")
+                .ToString();
+
+            // Act
+            var result = _dockerCli.Run(new DockerRunArguments
+            {
+                ImageId = Settings.BuildImageName,
+                EnvironmentVariables = new List<EnvironmentVariable> { CreateAppNameEnvVar(appName) },
+                Volumes = new List<DockerVolume> { volume },
+                CommandToExecuteOnRun = "/bin/bash",
+                CommandArguments = new[] { "-c", script }
+            });
+
+            // Assert
+            RunAsserts(
+                () =>
+                {
+                    Assert.True(result.IsSuccess);
+                    Assert.Contains(
+                        $"Python Version: /opt/python/{PythonVersions.Python36Version}/bin/python3",
+                        result.StdOut);
+                    Assert.Contains(
+                       $"{ManifestFilePropertyKeys.PythonVersion}=\"{PythonVersions.Python36Version}\"",
+                       result.StdOut);
+                },
+                result.GetDebugInfo());
+        }
+
+        // This is to test if we can build an app when both the files requirement.txt
+        // and setup.py are provided, we tend to prioritize the root level requirement.txt
+        [Fact]
+        public void GeneratesScript_AndBuilds_With_Both_Files_areProvided()
+        {
+            // Arrange
+            var appName = "flask-app";
+            var volume = CreateSampleAppVolume(appName);
+            var appDir = volume.ContainerDir;
+            var appOutputDir = $"{appDir}/output";
+            var manifestFile = $"{appOutputDir}/{FilePaths.BuildManifestFileName}";
+            var script = new ShellScriptBuilder()
+                .AddBuildCommand(
+                $"{appDir} -o {appOutputDir} --platform python --platform-version {PythonVersions.Python36Version}")
+                .AddCommand($"cat {manifestFile}")
+                .ToString();
+
+            // Act
+            var result = _dockerCli.Run(new DockerRunArguments
+            {
+                ImageId = Settings.BuildImageName,
+                EnvironmentVariables = new List<EnvironmentVariable> { CreateAppNameEnvVar(appName) },
+                Volumes = new List<DockerVolume> { volume },
+                CommandToExecuteOnRun = "/bin/bash",
+                CommandArguments = new[] { "-c", script }
+            });
+
+            // Assert
+            RunAsserts(
+                () =>
+                {
+                    Assert.True(result.IsSuccess);
+                    Assert.Contains(
+                        $"Python Version: /opt/python/{PythonVersions.Python36Version}/bin/python3",
+                        result.StdOut);
+                    Assert.Contains(
+                       $"{ManifestFilePropertyKeys.PythonVersion}=\"{PythonVersions.Python36Version}\"",
+                       result.StdOut);
+                },
+                result.GetDebugInfo());
+        }
+
         [Fact]
         public void CanBuild_UsingScriptGeneratedBy_ScriptOnlyOption()
         {
@@ -702,6 +786,43 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 },
                 result.GetDebugInfo());
         }
+
+        [Fact]
+        public void Build_InstallsVirtualEnvironment_AndPackagesInIt_From_File_Setup_Py()
+        {
+            // Arrange
+            var appName = "flask-setup-py-app";
+            var volume = CreateSampleAppVolume(appName);
+            var appDir = volume.ContainerDir;
+            var appOutputDir = "/tmp/app-output";
+            var script = new ShellScriptBuilder()
+                .AddBuildCommand(
+                $"{appDir} -o {appOutputDir} --platform python --platform-version {PythonVersions.Python37Version}")
+                .AddDirectoryExistsCheck($"{appOutputDir}/pythonenv3.7/lib/python3.7/site-packages/flask")
+                .ToString();
+
+            // Act
+            var result = _dockerCli.Run(new DockerRunArguments
+            {
+                ImageId = Settings.BuildImageName,
+                EnvironmentVariables = new List<EnvironmentVariable> { CreateAppNameEnvVar(appName) },
+                Volumes = new List<DockerVolume> { volume },
+                CommandToExecuteOnRun = "/bin/bash",
+                CommandArguments = new[] { "-c", script }
+            });
+
+            // Assert
+            RunAsserts(
+                () =>
+                {
+                    Assert.True(result.IsSuccess);
+                    Assert.Contains(
+                        $"Python Version: /opt/python/{PythonVersions.Python37Version}/bin/python3",
+                        result.StdOut);
+                },
+                result.GetDebugInfo());
+        }
+
 
         [Fact]
         public void Build_ExecutesPreAndPostBuildScripts_UsingBuildEnvironmentFile()

--- a/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
@@ -448,7 +448,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void GeneratesScript_AndBuilds_With_Both_Files_areProvided()
         {
             // Arrange
-            var appName = "flask-app";
+            var appName = "flask-setup-py-requirement-txt";
             var volume = CreateSampleAppVolume(appName);
             var appDir = volume.ContainerDir;
             var appOutputDir = $"{appDir}/output";

--- a/tests/Oryx.Integration.Tests/Python/Python37EndToEndTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/Python37EndToEndTests.cs
@@ -97,6 +97,48 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
+        [Fact]
+        public async Task CanBuildWithSetupPy_UsingPython37_AndVirtualEnv()
+        {
+            // Arrange
+            var appName = "flask-setup-py-app";
+            var virtualEnvName = "antenv";
+            var volume = CreateAppVolume(appName);
+            var appDir = volume.ContainerDir;
+            var buildScript = new ShellScriptBuilder()
+               .AddCommand(
+                $"oryx build {appDir} -p virtualenv_name={virtualEnvName} --platform python --platform-version 3.7")
+               .ToString();
+            var runScript = new ShellScriptBuilder()
+                .AddCommand($"oryx create-script -appPath {appDir} -bindPort {ContainerPort}")
+                .AddCommand(DefaultStartupFilePath)
+                .ToString();
+
+            await EndToEndTestHelper.BuildRunAndAssertAppAsync(
+                appName,
+                _output,
+                volume,
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    buildScript
+                },
+                _imageHelper.GetTestRuntimeImage("python", "3.7"),
+                ContainerPort,
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    runScript
+                },
+                async (hostPort) =>
+                {
+                    var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
+                    Assert.Contains("Hello World!", data);
+                });
+        }
+
         [Theory]
         [InlineData("tar-gz", "tar.gz")]
         [InlineData("zip", "zip")]

--- a/tests/Oryx.Integration.Tests/Python/PythonEndToEndTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonEndToEndTests.cs
@@ -161,19 +161,14 @@ namespace Microsoft.Oryx.Integration.Tests
             var appName = "flask-setup-py-app";
             var volume = CreateAppVolume(appName);
             var appDir = volume.ContainerDir;
-            const string virtualEnvName = "antenv";
-
-            // Simulate apps that were built using package directory, and then virtual env
+            
             var buildScript = new ShellScriptBuilder()
-                .AddBuildCommand($"{appDir} --platform python --language-version {pythonVersion}")
-                .AddBuildCommand(
-                $"{appDir} -p virtualenv_name={virtualEnvName} " +
-                $"--platform python --language-version {pythonVersion}")
+                .AddBuildCommand($"{appDir} --platform python --platform-version {pythonVersion}")
                 .ToString();
 
             var runScript = new ShellScriptBuilder()
                 .AddCommand(
-                $"oryx create-script -appPath {appDir} -bindPort {ContainerPort} -virtualEnvName={virtualEnvName}")
+                $"oryx create-script -appPath {appDir} -bindPort {ContainerPort}")
                 .AddCommand(DefaultStartupFilePath)
                 .ToString();
 

--- a/tests/SampleApps/python/flask-setup-py-app/.gitignore
+++ b/tests/SampleApps/python/flask-setup-py-app/.gitignore
@@ -1,0 +1,1 @@
+pythonenv/

--- a/tests/SampleApps/python/flask-setup-py-app/app.py
+++ b/tests/SampleApps/python/flask-setup-py-app/app.py
@@ -1,0 +1,9 @@
+from flask import Flask
+from datetime import datetime
+
+app = Flask(__name__)
+
+@app.route("/")
+def hello():
+    return "Hello World! " + str(datetime.now())
+

--- a/tests/SampleApps/python/flask-setup-py-app/requirements/req.txt
+++ b/tests/SampleApps/python/flask-setup-py-app/requirements/req.txt
@@ -1,0 +1,6 @@
+click==6.7
+Flask==1.0.2
+itsdangerous==0.24
+Jinja2==2.10
+MarkupSafe==1.0
+Werkzeug==0.14.1

--- a/tests/SampleApps/python/flask-setup-py-app/setup.py
+++ b/tests/SampleApps/python/flask-setup-py-app/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import os
+from setuptools import setup, find_packages
+
+#import  testsetuppy
+
+
+def read_file(filename):
+    """Read a file into a string."""
+    path = os.path.abspath(os.path.dirname(__file__))
+    filepath = os.path.join(path, filename)
+    try:
+        return open(filepath).read()
+    except IOError:
+        return ''
+
+
+setup(
+    name="testsetuppy",
+    author="oryx",
+    author_email="oryx@oryx123.com",
+    version="0.0.1",
+    description="test",
+    url="google",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=read_file("requirements/req.txt").splitlines(),
+)

--- a/tests/SampleApps/python/flask-setup-py-requirement-txt/.gitignore
+++ b/tests/SampleApps/python/flask-setup-py-requirement-txt/.gitignore
@@ -1,0 +1,1 @@
+pythonenv/

--- a/tests/SampleApps/python/flask-setup-py-requirement-txt/app.py
+++ b/tests/SampleApps/python/flask-setup-py-requirement-txt/app.py
@@ -1,0 +1,9 @@
+from flask import Flask
+from datetime import datetime
+
+app = Flask(__name__)
+
+@app.route("/")
+def hello():
+    return "Hello World! " + str(datetime.now())
+

--- a/tests/SampleApps/python/flask-setup-py-requirement-txt/requirements.txt
+++ b/tests/SampleApps/python/flask-setup-py-requirement-txt/requirements.txt
@@ -1,0 +1,6 @@
+click==6.7
+Flask==1.0.2
+itsdangerous==0.24
+Jinja2==2.10
+MarkupSafe==1.0
+Werkzeug==0.14.1

--- a/tests/SampleApps/python/flask-setup-py-requirement-txt/requirements/req.txt
+++ b/tests/SampleApps/python/flask-setup-py-requirement-txt/requirements/req.txt
@@ -1,0 +1,3 @@
+Flask==1.0.2
+chatterbot>=0.7.1
+SQLAlchemy>=1.1.11

--- a/tests/SampleApps/python/flask-setup-py-requirement-txt/setup.py
+++ b/tests/SampleApps/python/flask-setup-py-requirement-txt/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import os
+from setuptools import setup, find_packages
+
+#import  testsetuppy
+
+
+def read_file(filename):
+    """Read a file into a string."""
+    path = os.path.abspath(os.path.dirname(__file__))
+    filepath = os.path.join(path, filename)
+    try:
+        return open(filepath).read()
+    except IOError:
+        return ''
+
+
+setup(
+    name="testsetuppy",
+    author="oryx",
+    author_email="oryx@oryx123.com",
+    version="0.0.1",
+    description="test",
+    url="google",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=read_file("requirements/req.txt").splitlines(),
+)


### PR DESCRIPTION
This PR is to support following scenarios:
1. if there is a setup.py file in the root level, and there is no requirement.txt, oryx should be able to detect it as python app and build smoothly.
2. if there is setup.py as well as requirement.txt, build from requirement.txt.

Note: we can also run build from both the files if both are present. I would like to know what's your thought on that.