### PR TITLE
skip some single image integration tests

### DIFF
--- a/tests/Oryx.Integration.Tests/Node/NodeOtherEndtoEndTests.cs
+++ b/tests/Oryx.Integration.Tests/Node/NodeOtherEndtoEndTests.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Fact]
+        [Fact(Skip ="get rid of single image, #1088920")]
         public async Task Node_CreateReactAppSample_SingleImage()
         {
             // Arrange
@@ -596,7 +596,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Fact]
+        [Fact(Skip = "get rid of single image, #1088920")]
         public async Task CanBuildAndRun_NodeExpressApp_UsingSingleImage_AndCustomScript()
         {
             // Arrange
@@ -640,7 +640,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Fact]
+        [Fact(Skip = "get rid of single image, #1088920")]
         public async Task CanBuildAndRun_NodeExpressApp_UsingSingleImage_AndCustomStartupCommandOnly()
         {
             // Arrange


### PR DESCRIPTION
node single image integration tests are flaky, also they are not used. So getting rid of them as they are causing ci failure