### PR TITLE
update oryx to dotnetcore 3.1 & add dotnetcore task to pipelines

### DIFF
--- a/images/build/Dockerfiles/buildScriptGenerator.Dockerfile
+++ b/images/build/Dockerfiles/buildScriptGenerator.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 ARG AGENTBUILD=${AGENTBUILD}
 ARG GIT_COMMIT=unspecified

--- a/src/BuildScriptGenerator/BuildScriptGenerator.csproj
+++ b/src/BuildScriptGenerator/BuildScriptGenerator.csproj
@@ -21,11 +21,11 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\CommonFiles\AssemblyVersion.proj" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Nett" Version="0.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Scriban.Signed" Version="1.2.9" />

--- a/src/BuildScriptGenerator/BuildScriptGenerator.csproj
+++ b/src/BuildScriptGenerator/BuildScriptGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Oryx.BuildScriptGenerator</AssemblyName>
     <RootNamespace>Microsoft.Oryx.BuildScriptGenerator</RootNamespace>
     <ApplicationIcon />

--- a/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
+++ b/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
@@ -23,14 +23,14 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.NLogTarget" Version="2.10.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.5" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="0.4.1" />
     <PackageReference Include="NLog" Version="4.6.5" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.1" />

--- a/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
+++ b/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeFrameworkVersion>2.1</RuntimeFrameworkVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeFrameworkVersion>3.1</RuntimeFrameworkVersion>
     <AssemblyName>GenerateBuildScript</AssemblyName>
     <RootNamespace>Microsoft.Oryx.BuildScriptGeneratorCli</RootNamespace>
     <OutputType>Exe</OutputType>

--- a/src/BuildScriptGeneratorCli/Oryx_sign.signproj
+++ b/src/BuildScriptGeneratorCli/Oryx_sign.signproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\$(RuntimeIdentifier)\publish</OutDir>
-    <IntermediateOutputPath>obj\$(Configuration)\netcoreapp2.1\$(RuntimeIdentifier)</IntermediateOutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\netcoreapp3.1\$(RuntimeIdentifier)</IntermediateOutputPath>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\build\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Oryx.Common</AssemblyName>
     <LangVersion>7.3</LangVersion>
     <SignAssembly>true</SignAssembly>

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.NLogTarget" Version="2.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Detector/Detector.csproj
+++ b/src/Detector/Detector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Oryx.Detector</AssemblyName>
     <LangVersion>7.3</LangVersion>
     <SignAssembly>true</SignAssembly>
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="SemanticVersioning" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>

--- a/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
+++ b/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
+++ b/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/BuildScriptGeneratorCli.Tests/BuildScriptGeneratorCli.Tests.csproj
+++ b/tests/BuildScriptGeneratorCli.Tests/BuildScriptGeneratorCli.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/tests/Detector.Tests/Detector.Tests.csproj
+++ b/tests/Detector.Tests/Detector.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Oryx.Detector.Tests</AssemblyName>
     <RootNamespace>Microsoft.Oryx.Detector.Tests</RootNamespace>

--- a/tests/Oryx.BuildImage.Tests/Oryx.BuildImage.Tests.csproj
+++ b/tests/Oryx.BuildImage.Tests/Oryx.BuildImage.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AssemblyOriginatorKeyFile>..\..\build\TestAssembliesKey.snk</AssemblyOriginatorKeyFile>

--- a/tests/Oryx.Common.Tests/Oryx.Common.Tests.csproj
+++ b/tests/Oryx.Common.Tests/Oryx.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Oryx.Integration.Tests/Oryx.Integration.Tests.csproj
+++ b/tests/Oryx.Integration.Tests/Oryx.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
+++ b/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/tests/Oryx.Tests.Common/Oryx.Tests.Common.csproj
+++ b/tests/Oryx.Tests.Common/Oryx.Tests.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Microsoft.Oryx.Tests.Common</RootNamespace>
     <AssemblyName>Microsoft.Oryx.Tests.Common</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\build\TestAssembliesKey.snk</AssemblyOriginatorKeyFile>

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -27,6 +27,11 @@ steps:
     or(in(variables['SIGNTYPE'], 'real', 'Real'), in(variables['SignType'], 'real', 'Real')),
     or(startsWith(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/heads/patch/' )))
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x
+
 - task: ShellScript@2
   displayName: 'Build Oryx.sln'
   inputs:

--- a/vsts/pipelines/templates/_platformBinariesTemplate.yml
+++ b/vsts/pipelines/templates/_platformBinariesTemplate.yml
@@ -5,6 +5,11 @@ steps:
 - checkout: self
   clean: true
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x
+
 - task: ShellScript@2
   displayName: 'Building platform binaries'
   inputs:

--- a/vsts/pipelines/templates/_signBinary.yml
+++ b/vsts/pipelines/templates/_signBinary.yml
@@ -34,6 +34,11 @@ steps:
     restoreSolution: Oryx.sln
   condition: and(succeeded(), eq(variables['setSignTypeVariable.SignType'], 'real'))
 
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x
+
 - powershell: |
     Write-Host "Setting up git_commit and build_number as env variable"
     $env:GIT_COMMIT=$(git rev-parse HEAD)
@@ -41,12 +46,7 @@ steps:
     dotnet publish -r linux-x64 -c Release src\BuildScriptGeneratorCLI\BuildScriptGeneratorCli.csproj
   displayName: 'dotnet publish and after setting git_commit and build_number as env variable'
   condition: and(succeeded(), eq(variables['setSignTypeVariable.SignType'], 'real'))
-
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 3.1.x'
-  inputs:
-    version: 3.1.x
-      
+  
 - task: VSBuild@1
   displayName: 'Sign Oryx Binaries'
   inputs:

--- a/vsts/pipelines/templates/_signBinary.yml
+++ b/vsts/pipelines/templates/_signBinary.yml
@@ -41,7 +41,12 @@ steps:
     dotnet publish -r linux-x64 -c Release src\BuildScriptGeneratorCLI\BuildScriptGeneratorCli.csproj
   displayName: 'dotnet publish and after setting git_commit and build_number as env variable'
   condition: and(succeeded(), eq(variables['setSignTypeVariable.SignType'], 'real'))
-  
+
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x
+      
 - task: VSBuild@1
   displayName: 'Sign Oryx Binaries'
   inputs:

--- a/vsts/scripts/cleanDocker.sh
+++ b/vsts/scripts/cleanDocker.sh
@@ -45,6 +45,7 @@ docker images
 # - We still keep the tags of the following pattern because we still need some cache so that next builds are faster
 #	a. oryxdevmcr.azurecr.io/public/oryx/*:latest
 # - We should untag these images only after they have been pushed to a remote repository.
+UntagImages "alpine"
 UntagImages "test-*"
 UntagImages "oryxdevms/*:*.*"
 UntagImages "oryxdevms/*:latest"

--- a/vsts/scripts/removeDockerArtifacts.sh
+++ b/vsts/scripts/removeDockerArtifacts.sh
@@ -27,5 +27,5 @@ echo
 if [ -d "$mountedDirs" ]; then
     echo
     echo "Cleaning up files created by test containers ..."
-    docker run -v $mountedDirs:/tempDirs oryxdevmcr.azurecr.io/public/oryx/build /bin/bash -c "rm -rf /tempDirs/* && ls /tempDirs"
+    docker run -v $mountedDirs:/tempDirs alpine /bin/sh -c "rm -rf /tempDirs/* && ls /tempDirs"
 fi


### PR DESCRIPTION
This PR is to verify migrating smoothly to dotnetcore 3.1..
There are lot of dependency issues in buster with DotNetCore 2.1. DotNetCore 2.1 doesn't support libss1.1  that comes with buster. Some other compatibility issues are there as well.

This PR will enable us to avoid the compatibility issue as well as it will enable the oryx blessed buster based build images (the PR in draft)