### PR TITLE
add an debug yaml to troubleshoot ci-releases quickly in case of failures etc

### DIFF
--- a/build/tools/SharedCodeGenerator/SharedCodeGenerator.csproj
+++ b/build/tools/SharedCodeGenerator/SharedCodeGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
   <PropertyGroup>

--- a/vsts/pipelines/ciDebug.yml
+++ b/vsts/pipelines/ciDebug.yml
@@ -1,0 +1,127 @@
+resources:
+- repo: self
+
+variables:
+- group: Oryx
+
+stages:
+  - stage: CreateReleaseTag
+    jobs:
+    - job: CreateReleaseTag
+      pool:
+        name: OryxLinux
+      variables:
+        skipComponentGovernanceDetection: true
+      steps:
+      - task: ShellScript@2
+        inputs:
+          scriptPath: ./vsts/scripts/createReleaseTag.sh
+        displayName: 'Create release tag'
+      - script: |
+          set -ex
+          sourcesArtifactsDir="$(Build.SourcesDirectory)/artifacts"
+          mkdir -p "$sourcesArtifactsDir"
+          echo "$(RELEASE_TAG_NAME)" > "$sourcesArtifactsDir/releaseTag.txt"
+        displayName: 'Write release tag name to an artifact file'
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish artifact file having the release tag name'
+        inputs:
+          targetPath: $(Build.SourcesDirectory)/artifacts/releaseTag.txt
+          artifactName: releaseTag
+
+  - stage: Build
+    displayName: Build Stage
+    jobs:
+    - job: Job_Security
+      displayName: Security
+      condition: succeeded()
+      pool:
+        name: Hosted VS2017
+      steps:
+      - template: templates/_securityChecks.yml
+
+    - job: Job_BuildImage
+      displayName: Build and Test Build Image
+      timeoutInMinutes: 300
+      pool:
+        name: OryxLinux
+      variables:
+        SignType: 'real' 
+        skipComponentGovernanceDetection: true
+
+      steps:
+      - script: |
+          echo "##vso[task.setvariable variable=BuildBuildImages;]true"
+          echo "##vso[task.setvariable variable=TestBuildImages;]true"
+          echo "##vso[task.setvariable variable=BuildRuntimeImages;]false"
+          echo "##vso[task.setvariable variable=TestRuntimeImages;]false"
+          echo "##vso[task.setvariable variable=PushBuildImages;]true"
+          echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
+          echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]true"
+        displayName: 'Set variables'
+
+      - template: templates/_setReleaseTag.yml
+
+      - template: templates/_buildTemplate.yml
+
+    - job: Job_RuntimeImages
+      displayName: Build and Test Runtime Images
+      timeoutInMinutes: 300
+      pool:
+        name: OryxLinux
+      variables:
+        SignType: 'real'
+        skipComponentGovernanceDetection: true
+
+      steps:
+      - script: |
+          echo "##vso[task.setvariable variable=BuildBuildImages;]false"
+          echo "##vso[task.setvariable variable=TestBuildImages;]false"
+          echo "##vso[task.setvariable variable=BuildRuntimeImages;]true"
+          echo "##vso[task.setvariable variable=TestRuntimeImages;]true"
+          echo "##vso[task.setvariable variable=PushRuntimeImages;]true"
+          echo "##vso[task.setvariable variable=PushBuildImages;]false"
+          echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]true"
+        displayName: 'Set variables'
+
+      - template: templates/_setReleaseTag.yml
+
+      - template: templates/_buildTemplate.yml
+ 
+  - stage: Release
+    displayName: Release Stage
+    dependsOn: Build
+    condition: succeeded()
+
+    jobs:
+    - job: Release_BuildImage
+      displayName: Push Build Image to MCR
+      pool:
+        name: OryxLinux
+      variables:
+        skipComponentGovernanceDetection: true
+      timeoutInMinutes: 300
+      steps:
+      - script: |
+          echo "##vso[task.setvariable variable=ReleaseBuildImages;]true"
+          echo "##vso[task.setvariable variable=ReleaseRuntimeImages;]false"
+        displayName: 'Set variables'
+      
+      - template: templates/_releaseStepTemplate.yml
+
+    - job: Release_RuntimeImages
+      displayName: Push Runtime Images to MCR
+      pool:
+        name: OryxLinux
+      variables:
+        skipComponentGovernanceDetection: true
+      timeoutInMinutes: 400
+      steps:
+      - script: |
+          echo "##vso[task.setvariable variable=ReleaseBuildImages;]false"
+          echo "##vso[task.setvariable variable=ReleaseRuntimeImages;]true"
+        displayName: 'Set variables'
+      
+      - template: templates/_releaseStepTemplate.yml
+
+trigger: none

--- a/vsts/pipelines/ciDebug.yml
+++ b/vsts/pipelines/ciDebug.yml
@@ -46,13 +46,13 @@ stages:
       pool:
         name: OryxLinux
       variables:
-        SignType: 'real' 
+        SignType: 'test'
         skipComponentGovernanceDetection: true
 
       steps:
       - script: |
           echo "##vso[task.setvariable variable=BuildBuildImages;]true"
-          echo "##vso[task.setvariable variable=TestBuildImages;]true"
+          echo "##vso[task.setvariable variable=TestBuildImages;]false"
           echo "##vso[task.setvariable variable=BuildRuntimeImages;]false"
           echo "##vso[task.setvariable variable=TestRuntimeImages;]false"
           echo "##vso[task.setvariable variable=PushBuildImages;]true"
@@ -70,7 +70,7 @@ stages:
       pool:
         name: OryxLinux
       variables:
-        SignType: 'real'
+        SignType: 'test'
         skipComponentGovernanceDetection: true
 
       steps:
@@ -78,7 +78,7 @@ stages:
           echo "##vso[task.setvariable variable=BuildBuildImages;]false"
           echo "##vso[task.setvariable variable=TestBuildImages;]false"
           echo "##vso[task.setvariable variable=BuildRuntimeImages;]true"
-          echo "##vso[task.setvariable variable=TestRuntimeImages;]true"
+          echo "##vso[task.setvariable variable=TestRuntimeImages;]false"
           echo "##vso[task.setvariable variable=PushRuntimeImages;]true"
           echo "##vso[task.setvariable variable=PushBuildImages;]false"
           echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]true"

--- a/vsts/pipelines/templates/_platformBinariesReleaseTemplate.yml
+++ b/vsts/pipelines/templates/_platformBinariesReleaseTemplate.yml
@@ -14,6 +14,11 @@ steps:
     azureSubscription: oryxSP
     scriptPath: ./vsts/scripts/publishFilesToAzureStorage.sh
     arguments: oryxsdksdev
+
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x
   
 - task: ShellScript@2
   displayName: 'Test Dev storage account'

--- a/vsts/pipelines/templates/_releaseStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseStepTemplate.yml
@@ -148,7 +148,7 @@ steps:
 - task: Docker@2
   displayName: Login to PME ACR
   inputs: 
-    commands: login
+    command: login
     containerRegistry: ${{ parameters.acrPmeProdSrvConnection }}
 
 - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
@@ -186,8 +186,8 @@ steps:
 - task: Docker@2
   displayName: Logout from PME ACR
   inputs: 
-    commands: logout
-    containerRegistry: ${{ parameters.acrPmeProdSrvConnection }}
+    command: logout
+    containerRegistry: '${{ parameters.acrPmeProdSrvConnection }}'
 
 - task: ShellScript@2
   displayName: 'Clean up Docker containers and images'

--- a/vsts/pipelines/templates/_releaseStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseStepTemplate.yml
@@ -131,6 +131,20 @@ steps:
     enforceDockerNamingConvention: false
   condition: and(succeeded(), eq(variables['ReleaseRuntimeImages'], 'true'))
 
+- task: Docker@1
+  displayName: Dev Container registry logout
+  inputs:
+    command: logout
+    azureSubscriptionEndpoint: ${{ parameters.ascName }}
+    azureContainerRegistry: ${{ parameters.acrDevName }}
+
+- task: Docker@1
+  displayName: Non-pme Prod Container registry logout
+  inputs:
+    command: logout
+    azureSubscriptionEndpoint: ${{ parameters.ascName }}
+    azureContainerRegistry: ${{ parameters.acrProdName }}.azurecr.io
+    
 - task: Docker@2
   displayName: Login to PME ACR
   inputs: 

--- a/vsts/scripts/tagBuildImagesForRelease.sh
+++ b/vsts/scripts/tagBuildImagesForRelease.sh
@@ -60,11 +60,11 @@ function tagBuildImage() {
     echo -------------------------------------------------------------------------------
 }
 
-tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:Oryx-CI.$RELEASE_TAG_NAME" "latest" "$RELEASE_TAG_NAME"
-tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:lts-versions-Oryx-CI.$RELEASE_TAG_NAME" "lts-versions" "lts-versions-$RELEASE_TAG_NAME"
-tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:azfunc-jamstack-Oryx-CI.$RELEASE_TAG_NAME" "azfunc-jamstack" "azfunc-jamstack-$RELEASE_TAG_NAME"
-tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:github-actions-Oryx-CI.$RELEASE_TAG_NAME" "github-actions" "github-actions-$RELEASE_TAG_NAME"
-tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:vso-Oryx-CI.$RELEASE_TAG_NAME" "vso" "vso-$RELEASE_TAG_NAME"
+tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "latest" "$RELEASE_TAG_NAME"
+tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:lts-versions-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "lts-versions" "lts-versions-$RELEASE_TAG_NAME"
+tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:azfunc-jamstack-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "azfunc-jamstack" "azfunc-jamstack-$RELEASE_TAG_NAME"
+tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:github-actions-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "github-actions" "github-actions-$RELEASE_TAG_NAME"
+tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:vso-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "vso" "vso-$RELEASE_TAG_NAME"
 
 echo "printing pme tags from $outPmeFileMCR"
 cat $outPmeFileMCR

--- a/vsts/scripts/tagBuildImagesForRelease.sh
+++ b/vsts/scripts/tagBuildImagesForRelease.sh
@@ -10,6 +10,17 @@ set -o pipefail
 declare -r REPO_DIR=$( cd $( dirname "$0" ) && cd .. && cd .. && pwd )
 source $REPO_DIR/build/__variables.sh
 
+outPmeFileMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/oryxprodmcr-build-images-mcr.txt"
+outNonPmeFileMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/oryxmcr-build-images-mcr.txt"
+
+if [ -f "$outPmeFileMCR" ]; then
+    rm $outPmeFileMCR
+fi
+
+if [ -f "$outNonPmeFileMCR" ]; then
+    rm $outNonPmeFileMCR
+fi
+
 function tagBuildImage() {
     local devRegistryImageName="$1"
     local prodRegistryLatestTagName="$2"
@@ -17,9 +28,7 @@ function tagBuildImage() {
     local prodNonPmeRegistryRepoName="oryxmcr.azurecr.io/public/oryx/build"
     local prodPmeRegistryRepoName="oryxprodmcr.azurecr.io/public/oryx/build"
     sourceBranchName=$BUILD_SOURCEBRANCHNAME
-    outPmeFileMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/oryxprodmcr-build-images-mcr.txt"
-    outNonPmeFileMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/oryxmcr-build-images-mcr.txt"
-
+    
     echo "Pulling the source image $devRegistryImageName..."
     docker pull "$devRegistryImageName" | sed 's/^/     /'
 
@@ -47,7 +56,7 @@ function tagBuildImage() {
     else
         echo "Not creating 'latest' tag as source branch is not 'master'. Current branch is $sourceBranchName"
     fi
-
+    
     echo -------------------------------------------------------------------------------
 }
 
@@ -56,3 +65,10 @@ tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:lts-versions-Oryx-CI.$REL
 tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:azfunc-jamstack-Oryx-CI.$RELEASE_TAG_NAME" "azfunc-jamstack" "azfunc-jamstack-$RELEASE_TAG_NAME"
 tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:github-actions-Oryx-CI.$RELEASE_TAG_NAME" "github-actions" "github-actions-$RELEASE_TAG_NAME"
 tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:vso-Oryx-CI.$RELEASE_TAG_NAME" "vso" "vso-$RELEASE_TAG_NAME"
+
+echo "printing pme tags from $outPmeFileMCR"
+cat $outPmeFileMCR
+echo -------------------------------------------------------------------------------
+echo "printing non-pme tags from $outNonPmeFileMCR"
+cat $outNonPmeFileMCR
+echo -------------------------------------------------------------------------------

--- a/vsts/scripts/tagBuildpacksImagesForRelease.sh
+++ b/vsts/scripts/tagBuildpacksImagesForRelease.sh
@@ -17,6 +17,14 @@ declare -r prodPmeImageRepo="oryxprodmcr.azurecr.io/public/oryx"
 
 sourceBranchName=$BUILD_SOURCEBRANCHNAME
 
+if [ -f "$outPmeFile" ]; then
+    rm $outPmeFile
+fi
+
+if [ -f "$outNonPmeFile" ]; then
+    rm $outNonPmeFile
+fi
+
 packImage="$sourceImageRepo/pack:Oryx-CI.$RELEASE_TAG_NAME"
 echo "Pulling pack image '$packImage'..."
 docker pull "$packImage"
@@ -37,3 +45,10 @@ if [ "$sourceBranchName" == "master" ]; then
 else
     echo "Not creating 'stable' or 'latest' tags as source branch is not 'master'. Current branch is $sourceBranchName"
 fi
+
+echo "printing pme tags from $outPmeFile"
+cat $outPmeFile
+echo -------------------------------------------------------------------------------
+echo "printing non-pme tags from $outNonPmeFile"
+cat $outNonPmeFile
+echo -------------------------------------------------------------------------------

--- a/vsts/scripts/tagBuildpacksImagesForRelease.sh
+++ b/vsts/scripts/tagBuildpacksImagesForRelease.sh
@@ -25,7 +25,7 @@ if [ -f "$outNonPmeFile" ]; then
     rm $outNonPmeFile
 fi
 
-packImage="$sourceImageRepo/pack:Oryx-CI.$RELEASE_TAG_NAME"
+packImage="$sourceImageRepo/pack:$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
 echo "Pulling pack image '$packImage'..."
 docker pull "$packImage"
 echo "Retagging pack image with '$RELEASE_TAG_NAME'..."

--- a/vsts/scripts/tagCliImagesForRelease.sh
+++ b/vsts/scripts/tagCliImagesForRelease.sh
@@ -17,6 +17,14 @@ declare -r prodNonPmeImageRepo="oryxmcr.azurecr.io/public/oryx"
 
 sourceBranchName=$BUILD_SOURCEBRANCHNAME
 
+if [ -f "$outPmeFile" ]; then
+    rm $outPmeFile
+fi
+
+if [ -f "$outNonPmeFile" ]; then
+    rm $outNonPmeFile
+fi
+
 cliImage="$sourceImageRepo/cli:Oryx-CI.$RELEASE_TAG_NAME"
 echo "Pulling CLI image '$cliImage'..."
 docker pull "$cliImage"
@@ -38,3 +46,10 @@ if [ "$sourceBranchName" == "master" ]; then
 else
     echo "Not creating 'stable' or 'latest' tags as source branch is not 'master'. Current branch is $sourceBranchName"
 fi
+
+echo "printing pme tags from $outPmeFile"
+cat $outPmeFile
+echo -------------------------------------------------------------------------------
+echo "printing non-pme tags from $outNonPmeFile"
+cat $outNonPmeFile
+echo -------------------------------------------------------------------------------

--- a/vsts/scripts/tagCliImagesForRelease.sh
+++ b/vsts/scripts/tagCliImagesForRelease.sh
@@ -25,7 +25,7 @@ if [ -f "$outNonPmeFile" ]; then
     rm $outNonPmeFile
 fi
 
-cliImage="$sourceImageRepo/cli:Oryx-CI.$RELEASE_TAG_NAME"
+cliImage="$sourceImageRepo/cli:$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
 echo "Pulling CLI image '$cliImage'..."
 docker pull "$cliImage"
 echo "Retagging CLI image for $prodNonPmeImageRepo with '$RELEASE_TAG_NAME'..."

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -37,7 +37,7 @@ while read sourceImage; do
     read -ra imageNameParts <<< "$sourceImage"
     repo=${imageNameParts[0]}
     tag=${imageNameParts[1]}
-    replaceText="Oryx-CI."
+    replaceText="$BUILD_DEFINITIONNAME."
     releaseTagName=$(echo $tag | sed "s/$replaceText//g")
 
     IFS='-'

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -14,6 +14,14 @@ outFileNonPmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrNonPmeProdRepo
 outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runtime-images-mcr.txt"
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
 
+if [ -f "$outFilePmeMCR" ]; then
+    rm $outFilePmeMCR
+fi
+
+if [ -f "$outFileNonPmeMCR" ]; then
+    rm $outFileNonPmeMCR
+fi
+
 while read sourceImage; do
   # Always use specific build number based tag and then use the same tag to create a 'latest' tag and push it
   if [[ $sourceImage == *:*-* ]]; then
@@ -66,3 +74,10 @@ while read sourceImage; do
     echo -------------------------------------------------------------------------------
   fi
 done <"$sourceFile"
+
+echo "printing pme tags from $outFilePmeMCR"
+cat $outFilePmeMCR
+echo -------------------------------------------------------------------------------
+echo "printing non-pme tags from $outFileNonPmeMCR"
+cat $outFileNonPmeMCR
+echo -------------------------------------------------------------------------------


### PR DESCRIPTION
This is PR to add an extra ci yaml that helps in debugging.

This CI does end to end (build images and push them to prod mcr) without the following
No restriction in master/patch
No integration test
No signing

Without this PR today we have to create a patch branch (which is a production branch and  difficult to control), also if we just want to troubleshoot release stage we can skip integration test phase quickly.
Note: This should be used only during troubleshooting release failures etc. and immediately corresponding images needs to be deleted from the prod repo by the person who trigger this.