### PR TITLE
Enable dynamic install for Python preview version

### DIFF
--- a/images/build/Dockerfiles/Dockerfile
+++ b/images/build/Dockerfiles/Dockerfile
@@ -186,22 +186,19 @@ RUN cd ${IMAGES_DIR} \
     && ./installPlatform.sh python $PYTHON27_VERSION \
     && ./installPlatform.sh python $PYTHON36_VERSION \
     && ./installPlatform.sh python $PYTHON37_VERSION \
-    && ./installPlatform.sh python $PYTHON38_VERSION \
-    && ./installPlatform.sh python $PYTHON39_VERSION
+    && ./installPlatform.sh python $PYTHON38_VERSION
 RUN . ${BUILD_DIR}/__pythonVersions.sh && set -ex \
  && [ -d "/opt/python/$PYTHON27_VERSION" ] && echo /opt/python/$PYTHON27_VERSION/lib >> /etc/ld.so.conf.d/python.conf \
  && [ -d "/opt/python/$PYTHON36_VERSION" ] && echo /opt/python/$PYTHON36_VERSION/lib >> /etc/ld.so.conf.d/python.conf \
  && [ -d "/opt/python/$PYTHON37_VERSION" ] && echo /opt/python/$PYTHON37_VERSION/lib >> /etc/ld.so.conf.d/python.conf \
  && [ -d "/opt/python/$PYTHON38_VERSION" ] && echo /opt/python/$PYTHON38_VERSION/lib >> /etc/ld.so.conf.d/python.conf \
- && [ -d "/opt/python/$PYTHON39_VERSION" ] && echo /opt/python/$PYTHON39_VERSION/lib >> /etc/ld.so.conf.d/python.conf \
  && ldconfig
 RUN . ${BUILD_DIR}/__pythonVersions.sh && set -ex \
  && ln -sfn $PYTHON27_VERSION /opt/python/2.7 \
  && ln -sfn 2.7 /opt/python/2 \
  && ln -sfn $PYTHON36_VERSION /opt/python/3.6 \
  && ln -sfn $PYTHON37_VERSION /opt/python/3.7 \
- && ln -sfn $PYTHON38_VERSION /opt/python/3.8 \
- && ln -sfn $PYTHON39_VERSION /opt/python/3.9
+ && ln -sfn $PYTHON38_VERSION /opt/python/3.8
   
 # This stage is a no-op and exists to satisfy a pattern of building different
 # stages in buildBuildImages.sh file

--- a/src/BuildScriptGenerator/Python/PythonPlatform.cs
+++ b/src/BuildScriptGenerator/Python/PythonPlatform.cs
@@ -434,22 +434,21 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
 
         private string GetMaxSatisfyingVersionAndVerify(string version)
         {
-            var versionInfo = _versionProvider.GetVersionInfo();
-            var versionMap = versionInfo.SupportedVersions;
+            var supportedVersions = SupportedVersions;
 
             // Since our semantic versioning library does not work with Python preview version format, here
             // we do some trivial way of finding the latest version which matches a given runtime version.
             // Preview version of sdks have alphabet letter in the version name. Such as '3.8.0b3', '3.9.0b1',etc.
-            var nonPreviewRuntimeVersions = versionMap.Where(v => !v.Any(c => char.IsLetter(c)));
+            var nonPreviewRuntimeVersions = supportedVersions.Where(v => !v.Any(c => char.IsLetter(c)));
             var maxSatisfyingVersion = SemanticVersionResolver.GetMaxSatisfyingVersion(
                 version,
                 nonPreviewRuntimeVersions);
-                
+
             // Check if a preview version is available
             if (string.IsNullOrEmpty(maxSatisfyingVersion))
             {
                 // Preview versions: '3.8.0b3', '3.9.0b1', etc
-                var previewRuntimeVersions = versionMap
+                var previewRuntimeVersions = supportedVersions
                     .Where(v => v.Any(c => char.IsLetter(c)))
                     .Where(v => v.StartsWith(version))
                     .OrderByDescending(v => v);
@@ -464,7 +463,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
                 var exc = new UnsupportedVersionException(
                     PythonConstants.PlatformName,
                     version,
-                    versionInfo.SupportedVersions);
+                    supportedVersions);
                 _logger.LogError(
                     exc,
                     $"Exception caught, the version '{version}' is not supported for the Python platform.");

--- a/src/BuildScriptGenerator/Python/PythonPlatform.cs
+++ b/src/BuildScriptGenerator/Python/PythonPlatform.cs
@@ -435,9 +435,29 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         private string GetMaxSatisfyingVersionAndVerify(string version)
         {
             var versionInfo = _versionProvider.GetVersionInfo();
+            var versionMap = versionInfo.SupportedVersions;
+
+            // Since our semantic versioning library does not work with Python preview version format, here
+            // we do some trivial way of finding the latest version which matches a given runtime version.
+            // Preview version of sdks have alphabet letter in the version name. Such as '3.8.0b3', '3.9.0b1',etc.
+            var nonPreviewRuntimeVersions = versionMap.Where(v => !v.Any(c => char.IsLetter(c)));
             var maxSatisfyingVersion = SemanticVersionResolver.GetMaxSatisfyingVersion(
                 version,
-                versionInfo.SupportedVersions);
+                nonPreviewRuntimeVersions);
+                
+            // Check if a preview version is available
+            if (string.IsNullOrEmpty(maxSatisfyingVersion))
+            {
+                // Preview versions: '3.8.0b3', '3.9.0b1', etc
+                var previewRuntimeVersions = versionMap
+                    .Where(v => v.Any(c => char.IsLetter(c)))
+                    .Where(v => v.StartsWith(version))
+                    .OrderByDescending(v => v);
+                if (previewRuntimeVersions.Any())
+                {
+                    maxSatisfyingVersion = previewRuntimeVersions.First();
+                }
+            }
 
             if (string.IsNullOrEmpty(maxSatisfyingVersion))
             {

--- a/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
@@ -21,24 +21,20 @@ namespace Microsoft.Oryx.BuildImage.Tests
         {
         }
 
-        public static TheoryData<string> ImageNameData
+        public static IEnumerable<object[]> ImageNameData()
         {
-            get
-            {
-                var imageTestHelper = new ImageTestHelper();
-                var data = new TheoryData<string>();
-                data.Add(imageTestHelper.GetLtsVersionsBuildImage());
-                data.Add(imageTestHelper.GetGitHubActionsBuildImage());
-                return data;
-            }
+            var imageTestHelper = new ImageTestHelper();
+            yield return new object[] { imageTestHelper.GetLtsVersionsBuildImage(), "3.8.1" };
+            yield return new object[] { imageTestHelper.GetLtsVersionsBuildImage(), "3.8.3" };
+            yield return new object[] { imageTestHelper.GetGitHubActionsBuildImage(), "3.8.1" };
+            yield return new object[] { imageTestHelper.GetGitHubActionsBuildImage(), "3.8.3" };
         }
 
         [Theory]
         [MemberData(nameof(ImageNameData))]
-        public void GeneratesScript_AndBuilds(string imageName)
+        public void GeneratesScript_AndBuildsPython(string imageName, string version)
         {
             // Arrange
-            var version = "3.8.1";
             var installationDir = $"{BuildScriptGenerator.Constants.TemporaryInstallationDirectoryRoot}/python/{version}";
             var appName = "flask-app";
             var volume = CreateSampleAppVolume(appName);

--- a/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
@@ -21,13 +21,18 @@ namespace Microsoft.Oryx.BuildImage.Tests
         {
         }
 
-        public static IEnumerable<object[]> ImageNameData()
+        public static TheoryData<string, string> ImageNameData
         {
-            var imageTestHelper = new ImageTestHelper();
-            yield return new object[] { imageTestHelper.GetLtsVersionsBuildImage(), "3.8.1" };
-            yield return new object[] { imageTestHelper.GetLtsVersionsBuildImage(), "3.8.3" };
-            yield return new object[] { imageTestHelper.GetGitHubActionsBuildImage(), "3.8.1" };
-            yield return new object[] { imageTestHelper.GetGitHubActionsBuildImage(), "3.8.3" };
+            get
+            {
+                var imageTestHelper = new ImageTestHelper();
+                var data = new TheoryData<string, string>();
+                data.Add(imageTestHelper.GetLtsVersionsBuildImage(), "3.8.1");
+                data.Add(imageTestHelper.GetLtsVersionsBuildImage(), "3.8.3");
+                data.Add(imageTestHelper.GetGitHubActionsBuildImage(), "3.8.1");
+                data.Add(imageTestHelper.GetGitHubActionsBuildImage(), "3.8.3");
+                return data;
+            }
         }
 
         [Theory]


### PR DESCRIPTION
- Fix python preview version not able to be dynamic installed since semanticVersion could not parse preview format.
- Remove 3.9 preview from full build image.
- Add dynamic installation test for preview versions.