### PR TITLE
Unlock rogue coverage reports

### DIFF
--- a/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
+++ b/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
@@ -13,8 +13,8 @@ jobs:
 
   steps:
 
-  - script: echo `pwd`; ls -la; find . -type d -name coverage.cobertura.xml -print -exec chmod +w {} \;
+  - script: echo Cleaning `pwd`; find . -type d -name coverage.cobertura.xml -print -exec chmod +w {} \;
     workingDirectory: $(System.DefaultWorkingDirectory)/../..
-    displayName: Clean rogue coverage reports
+    displayName: Unlock rogue coverage reports
 
   - template: _cleanImageCacheTemplate.yml

--- a/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
+++ b/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
 
   - script: echo `pwd`; ls -la; chmod +w ./**/coverage.cobertura.xml
-    workingDirectory: $(System.DefaultWorkingDirectory)/..
+    workingDirectory: $(System.DefaultWorkingDirectory)/../..
     displayName: Clean rogue coverage reports
 
   - template: _cleanImageCacheTemplate.yml

--- a/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
+++ b/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
@@ -13,8 +13,8 @@ jobs:
 
   steps:
 
-  - template: _cleanImageCacheTemplate.yml
-
-  - script: chmod +w ./**/coverage.cobertura.xml
+  - script: echo `pwd`; ls -la; chmod +w ./**/coverage.cobertura.xml
     workingDirectory: $(System.DefaultWorkingDirectory)
     displayName: Clean rogue coverage reports
+
+  - template: _cleanImageCacheTemplate.yml

--- a/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
+++ b/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
@@ -2,6 +2,7 @@ parameters:
   agentName: ''
 
 jobs:
+
 - job: Cleaning_${{ parameters.agentName }}
   displayName: ${{ parameters.agentName }}
   pool:
@@ -9,5 +10,11 @@ jobs:
     demands:
     - agent.name -equals ${{ parameters.agentName }}
   timeoutInMinutes: 30
+
   steps:
+
   - template: _cleanImageCacheTemplate.yml
+
+  - script: chmod +w ./**/coverage.cobertura.xml
+    workingDirectory: $(System.DefaultWorkingDirectory)
+    displayName: Clean rogue coverage reports

--- a/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
+++ b/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
@@ -14,7 +14,7 @@ jobs:
   steps:
 
   - script: echo `pwd`; ls -la; chmod +w ./**/coverage.cobertura.xml
-    workingDirectory: $(System.DefaultWorkingDirectory)
+    workingDirectory: $(System.DefaultWorkingDirectory)/..
     displayName: Clean rogue coverage reports
 
   - template: _cleanImageCacheTemplate.yml

--- a/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
+++ b/vsts/pipelines/templates/_agentCleanUpJobTemplate.yml
@@ -13,7 +13,7 @@ jobs:
 
   steps:
 
-  - script: echo `pwd`; ls -la; chmod +w ./**/coverage.cobertura.xml
+  - script: echo `pwd`; ls -la; find . -type d -name coverage.cobertura.xml -print -exec chmod +w {} \;
     workingDirectory: $(System.DefaultWorkingDirectory)/../..
     displayName: Clean rogue coverage reports
 


### PR DESCRIPTION
these fail the Checkout step in DevOps if left with wrong permissions.