### PR TITLE
remove publish sdk job as part of CI-job 

### DIFF
--- a/vsts/pipelines/templates/_releaseJobTemplate.yml
+++ b/vsts/pipelines/templates/_releaseJobTemplate.yml
@@ -29,34 +29,6 @@ jobs:
       
   - template: _releaseStepTemplate.yml
 
-- job: Release_PlatformSDKs
-  displayName: Publish SDKs from dev to prod storage account
-  dependsOn: 
-    - Release_BuildImage
-    - Release_RuntimeImages
-  pool:
-    name: OryxLinux
-  variables:
-    skipComponentGovernanceDetection: true
-  timeoutInMinutes: 300
-  steps:
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 3.1.x'
-    inputs:
-      version: 3.1.x
-  - task: ShellScript@2
-    displayName: 'Publish SDKs from dev to prod storage account'
-    env:
-      DEV_STORAGE_SAS_TOKEN: $(DEV-STORAGE-SAS-TOKEN)
-      PROD_STORAGE_SAS_TOKEN: $(PROD-STORAGE-SAS-TOKEN)
-    inputs:
-      scriptPath: ./vsts/scripts/publishSdksFromDevToProdStorageAccount.sh
-  - task: ShellScript@2
-    displayName: 'Test Prod storage account'
-    inputs:
-      scriptPath: ./build/testIntegration.sh
-      args: StorageAccountTests=Prod
-
 - job: Release_GitHub
   displayName: Create GitHub release
   dependsOn: 


### PR DESCRIPTION
We already have a seperate pipeline for this, it will be better to keep this separated as azcopy is bit flaky and we dont want to block our release for this job.

I have scheduled the publishsdk to prod as a scheduled pipeline (like we have our nightly builds/CI build) every Monday morning after CI build 