### PR TITLE
remove extra _ from JAVA and RUBY build commands

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -59,12 +59,12 @@ Setting name for Java apps | Description                                        
 ---------------------------|----------------------------------------------------------------|---------|----------------
 JAVA\_VERSION              | Specify which Java version the app is using                    | ""      | "14.0.2"
 MAVEN\_VERSION             | Specify which Maven version the app is using                   | ""      | "3.6.3"
-DISABLE\_JAVA_\_BUILD      | Do not apply Java build even if repo indicates it              | `false` | `true`, `false`
+DISABLE\_JAVA\_BUILD      | Do not apply Java build even if repo indicates it              | `false` | `true`, `false`
 
 Setting name for Ruby apps | Description                                                    | Default | Example
 ---------------------------|----------------------------------------------------------------|---------|----------------
 RUBY\_VERSION              | Specify which Ruby version the app is using                    | ""      | "2.7.1"
-DISABLE\_RUBY_\_BUILD      | Do not apply Ruby build even if repo indicates it              | `false` | `true`, `false`
+DISABLE\_RUBY\_BUILD      | Do not apply Ruby build even if repo indicates it              | `false` | `true`, `false`
 
 Setting name for Hugo apps | Description                                                    | Default | Example
 ---------------------------|----------------------------------------------------------------|---------|----------------


### PR DESCRIPTION
Hi, 

I wasn't sure about this but it seems that there is an extra `_` in `DISABLE_JAVA__BUILD` and `DISABLE_RUBY__BUILD`. Was that a mistake? if so, then this PR should fix it. If that was intentional, please ignore my PR.

Cheers.