### PR TITLE
skip php 8 integration tests temporarily

### DIFF
--- a/tests/Oryx.Integration.Tests/Php/PhpGreetingsAppTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpGreetingsAppTest.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
-        [InlineData("8.0")]
+        // skipping php 8 tests as its incompatible with composer 1.9
+        //[InlineData("8.0")]
         [InlineData("7.4")]
         [InlineData("7.3")]
         [InlineData("7.2")]
@@ -63,7 +64,8 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
-        [InlineData("8.0")]
+        // Skipping php 8 as it's incompatible with composer 1.9
+        //[InlineData("8.0")]
         [InlineData("7.4")]
         [InlineData("7.3")]
         [InlineData("7.2")]

--- a/tests/Oryx.Integration.Tests/Php/PhpWordPressTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpWordPressTest.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
-        [InlineData("8.0-fpm")]
+        //skipping php-8 test as it is not compatible with composer 1.9
+        //[InlineData("8.0-fpm")]
         [InlineData("7.4-fpm")]
         [InlineData("7.3")]
         [InlineData("7.2")]


### PR DESCRIPTION
skipping php-fpm 8 and php 8 integration tests as the sample apps are not compatible with php 8 and composer 1.9.