### PR TITLE
Move validation builds to official ado agents

### DIFF
--- a/build/__variables.sh
+++ b/build/__variables.sh
@@ -17,7 +17,7 @@ declare -r BUILD_NUMBER="$BUILD_BUILDNUMBER"
 declare -r BUILD_CONFIGURATION="${BUILDCONFIGURATION:-Debug}"
 declare -r RELEASE_TAG_NAME="${RELEASE_TAG_NAME:-$BUILD_NUMBER}"
 
-declare -r BUILD_IMAGES_BUILD_CONTEXT_DIR="$REPO_DIR/"
+declare -r BUILD_IMAGES_BUILD_CONTEXT_DIR="$REPO_DIR"
 declare -r BUILD_IMAGES_DOCKERFILE="$REPO_DIR/images/build/Dockerfiles/Dockerfile"
 declare -r BUILD_IMAGES_LTS_VERSIONS_DOCKERFILE="$REPO_DIR/images/build/Dockerfiles/ltsVersions.Dockerfile"
 declare -r BUILD_IMAGES_LTS_VERSIONS_BUSTER_DOCKERFILE="$REPO_DIR/images/build/Dockerfiles/ltsVersions.buster.Dockerfile"

--- a/build/buildBuildImages.sh
+++ b/build/buildBuildImages.sh
@@ -147,8 +147,6 @@ function buildTemporaryFilesImage() {
 }
 
 function buildBuildScriptGeneratorImage() {
-	pwd
-	ls -la
 	buildTemporaryFilesImage
 
 	# Create the following image so that it's contents can be copied to the rest of the images below

--- a/build/buildBuildImages.sh
+++ b/build/buildBuildImages.sh
@@ -147,6 +147,8 @@ function buildTemporaryFilesImage() {
 }
 
 function buildBuildScriptGeneratorImage() {
+	pwd
+	ls -la
 	buildTemporaryFilesImage
 
 	# Create the following image so that it's contents can be copied to the rest of the images below

--- a/images/build/Dockerfiles/buildScriptGenerator.Dockerfile
+++ b/images/build/Dockerfiles/buildScriptGenerator.Dockerfile
@@ -11,12 +11,12 @@ ENV RELEASE_TAG_NAME=${RELEASE_TAG_NAME}
 
 WORKDIR /usr/oryx
 COPY build build
-COPY src src
-COPY build/FinalPublicKey.snk build/
-
 # This statement copies signed oryx binaries from during agent build.
 # For local/dev contents of blank/empty directory named binaries are getting copied
 COPY binaries /opt/buildscriptgen/
+COPY src src
+COPY build/FinalPublicKey.snk build/
+
 RUN if [ -z "$AGENTBUILD" ]; then \
         dotnet publish \
             -r linux-x64 \

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -149,7 +149,7 @@ steps:
 
 - script: |
     docker images && docker system prune -fa && docker images && echo
-  displayName: 'clean docker unknown layers and containers'
+  displayName: 'clean docker layers and containers'
   
 - task: CopyFiles@2
   displayName: 'Copy source projects output to artifacts folder'

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -29,6 +29,14 @@ steps:
     startsWith(variables['Build.SourceBranch'],'refs/heads/patch/'),
     startsWith(variables['Build.SourceBranch'],'refs/heads/exp/')))
 
+- script: |
+    sudo rm -rf /usr/share/dotnet
+    sudo rm -rf /opt/ghc
+    sudo rm -rf "/usr/local/share/boost"
+    sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    docker images && docker system prune -fa && df -h && echo
+  displayName: 'clean docker images'
+
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 3.1.x'
   inputs:
@@ -37,10 +45,6 @@ steps:
 - script: |
     dotnet --version && dotnet msbuild -version && echo
   displayName: 'Print dotnet and msbuild version'
-
-- script: |
-    df -h && echo && docker images && docker system prune -fa && echo
-  displayName: 'clean docker images'
 
 - task: ShellScript@2
   displayName: 'Build Oryx.sln'
@@ -91,6 +95,10 @@ steps:
     scriptPath: ./build/buildRunTimeImages.sh
     args: buster
   condition: and(succeeded(), eq(variables['BuildRuntimeImages'], 'true'))
+
+- script: |
+    docker images && docker system prune -f && df -h && echo
+  displayName: 'clean docker unknown layers'
 
 - task: ShellScript@2
   displayName: 'Test build images'

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -147,6 +147,10 @@ steps:
     SQLSERVER_DATABASE_PASSWORD: $(SQLSERVER-DATABASE-PASSWORD)
   condition: and(succeeded(), eq(variables['TestIntegration'], 'true'))
 
+- script: |
+    docker images && docker system prune -fa && docker images && echo
+  displayName: 'clean docker unknown layers and containers'
+  
 - task: CopyFiles@2
   displayName: 'Copy source projects output to artifacts folder'
   inputs:

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -38,6 +38,10 @@ steps:
     dotnet --version && dotnet msbuild -version && echo
   displayName: 'Print dotnet and msbuild version'
 
+- script: |
+    df -h && echo && docker images && docker system prune -fa && echo
+  displayName: 'clean docker images'
+
 - task: ShellScript@2
   displayName: 'Build Oryx.sln'
   inputs:

--- a/vsts/pipelines/validation.yml
+++ b/vsts/pipelines/validation.yml
@@ -16,7 +16,7 @@ jobs:
 - job: Job_BuildImage
   displayName: Build and Test Build Images
   pool:
-    name: OryxLinux
+    vmImage: 'ubuntu-latest'
   timeoutInMinutes: 480
   steps:
   - script: |
@@ -32,7 +32,7 @@ jobs:
 - job: Job_RuntimeImages
   displayName: Build and Test Runtime Images
   pool:
-    name: OryxLinux
+    vmImage: 'ubuntu-latest'
   timeoutInMinutes: 300
   steps:
   - script: |

--- a/vsts/pipelines/validation.yml
+++ b/vsts/pipelines/validation.yml
@@ -29,20 +29,20 @@ jobs:
     displayName: 'Set variables'
   - template: templates/_buildTemplate.yml
 
-- job: Job_RuntimeImages
-  displayName: Build and Test Runtime Images
-  pool:
-    vmImage: 'ubuntu-latest'
-  timeoutInMinutes: 300
-  steps:
-  - script: |
-      echo "##vso[task.setvariable variable=BuildRuntimeImages;]true"
-      echo "##vso[task.setvariable variable=TestRuntimeImages;]true"
-      echo "##vso[task.setvariable variable=PushBuildImages;]false"
-      echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
-      echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]true"
-      echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
-    displayName: 'Set variables'
-  - template: templates/_buildTemplate.yml
+#- job: Job_RuntimeImages
+  #displayName: Build and Test Runtime Images
+  #pool:
+  #  vmImage: 'ubuntu-latest'
+  #timeoutInMinutes: 300
+  #steps:
+  #- script: |
+  #    echo "##vso[task.setvariable variable=BuildRuntimeImages;]true"
+  #    echo "##vso[task.setvariable variable=TestRuntimeImages;]true"
+  #    echo "##vso[task.setvariable variable=PushBuildImages;]false"
+  #    echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
+  #    echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]true"
+  #    echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
+  #  displayName: 'Set variables'
+  #- template: templates/_buildTemplate.yml
 
 trigger: none

--- a/vsts/pipelines/validation.yml
+++ b/vsts/pipelines/validation.yml
@@ -29,20 +29,20 @@ jobs:
     displayName: 'Set variables'
   - template: templates/_buildTemplate.yml
 
-#- job: Job_RuntimeImages
-  #displayName: Build and Test Runtime Images
-  #pool:
-  #  vmImage: 'ubuntu-latest'
-  #timeoutInMinutes: 300
-  #steps:
-  #- script: |
-  #    echo "##vso[task.setvariable variable=BuildRuntimeImages;]true"
-  #    echo "##vso[task.setvariable variable=TestRuntimeImages;]true"
-  #    echo "##vso[task.setvariable variable=PushBuildImages;]false"
-  #    echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
-  #    echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]true"
-  #    echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
-  #  displayName: 'Set variables'
-  #- template: templates/_buildTemplate.yml
+- job: Job_RuntimeImages
+  displayName: Build and Test Runtime Images
+  pool:
+    vmImage: 'ubuntu-latest'
+  timeoutInMinutes: 480
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=BuildRuntimeImages;]true"
+      echo "##vso[task.setvariable variable=TestRuntimeImages;]true"
+      echo "##vso[task.setvariable variable=PushBuildImages;]false"
+      echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
+      echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]true"
+      echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
+    displayName: 'Set variables'
+  - template: templates/_buildTemplate.yml
 
 trigger: none


### PR DESCRIPTION
We will have multiple PRs  to get rid of oryxlinux pool .... first phase was base image builds, detector builds and platform binaries builds. We already have done that, this is our second phase. Next will be nightly builds and at the end we will move ci build.

We are taking phase wise approach as we dont want to block ci/cd for this