### PR TITLE
fix build break by changing python2.7 link by pip

### DIFF
--- a/images/build/Dockerfiles/vso.focal.Dockerfile
+++ b/images/build/Dockerfiles/vso.focal.Dockerfile
@@ -47,8 +47,8 @@ RUN LANG="C.UTF-8" \
     && add-apt-repository universe \
     && apt-get install -y --no-install-recommends python2 \
     && rm -rf /var/lib/apt/lists/* \
-    # 'get-pip.py' has been moved from 'https://bootstrap.pypa.io/get-pip.py' to 'https://bootstrap.pypa.io/2.7/get-pip.py'
-    && curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py \
+    # 'get-pip.py' has been moved to ' https://bootstrap.pypa.io/pip/2.7/get-pip.py' from 'https://bootstrap.pypa.io/2.7/get-pip.py'
+    && curl  https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
     && python2 get-pip.py \
     && pip install pip --upgrade \
     && pip3 install pip --upgrade \


### PR DESCRIPTION
Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!

- Pradyun, on behalf of the volunteers who maintain pip.
