### PR TITLE
Update caching packages according to latest telemetry

### DIFF
--- a/build/__nodeVersions.sh
+++ b/build/__nodeVersions.sh
@@ -1,7 +1,7 @@
 # This file was auto-generated from 'constants.yaml'. Changes may be overridden.
 
 NODE_RUNTIME_BASE_TAG='20201203.2'
-YARN_CACHE_BASE_TAG='20200810.1'
+YARN_CACHE_BASE_TAG='20210312.1'
 YARN_VERSION='1.22.10'
 YARN_MINOR_VERSION='1.17'
 YARN_MAJOR_VERSION='1'

--- a/build/constants.yaml
+++ b/build/constants.yaml
@@ -156,7 +156,7 @@
 - name: node-versions
   constants:
     node-runtime-base-tag: 20201203.2
-    yarn-cache-base-tag: 20200810.1
+    yarn-cache-base-tag: 20210312.1
     yarn-version: 1.22.10
     yarn-minor-version: 1.17
     yarn-major-version: 1

--- a/images/build/yarn-cache/cacheNodePackages.sh
+++ b/images/build/yarn-cache/cacheNodePackages.sh
@@ -46,159 +46,34 @@ function installPackage() {
 # Then, we cut the list until the total cache reaches the target size
 for pkg in \
     express \
-    cookie-parser \
     body-parser \
-    debug \
-    moment \
-    uuid \
-    morgan \
-    react \
-    mongodb \
-    http-errors \
-    express-session \
-    react-dom \
-    jsonwebtoken \
-    redis \
-    ejs \
-    request \
-    axios \
-    express-validator \
-    jade \
-    http-status \
-    ioredis \
-    cors \
-    lodash \
-    connect-redis \
     dotenv \
-    moment-timezone \
-    helmet \
-    pug \
+    axios \
+    morgan \
+    cors \
+    cookie-parser \
+    moment \
+    debug \
 ; do
     installPackage $pkg
 done;
 
 # We cache both latest versions and some specific version of most used packages to broaden the coverage.
 for pkg in \
-    express@^4.16.4 \
-    body-parser@^1.18.3 \
-    cookie-parser@~1.4.3 \
-    debug@~2.6.9 \
-    express@~4.16.0 \
-    http-errors@~1.6.2 \
-    morgan@~1.9.0 \
-    jade@~1.11.0 \
-    cors@^2.8.5 \
-    axios@^0.18.0 \
-    express-session@^1.15.6 \
-    request@^2.88.0 \
+    express@^4.17.1 \
+    express@^4.16.1 \
+    body-parser@^1.19.0 \
+    dotenv@^8.2.0 \
+    axios@0.21.1 \
+    axios@0.19.2 \
+    morgan@^1.10.0 \
     morgan@^1.9.1 \
-    dotenv@^6.2.0 \
-    passport@^0.4.0 \
-    ejs@^2.6.1 \
-    moment@^2.24.0 \
-    express@^4.16.3 \
-    moment@^2.22.2 \
-    prop-types@15.6.2 \
-    cookie-parser@^1.4.3 \
-    express@4.13.4 \
-    lodash@^4.17.11 \
-    body-parser@1.15.0 \
-    axios@0.18.0 \
-    react-dom@15.0.1 \
-    react-fa@4.0.1 \
-    classname@0.0.0 \
-    uuid@2.0.2 \
-    mongodb@2.1.14 \
-    flux@2.1.1 \
-    react@15.0.1 \
-    mongodb-uri@0.9.7 \
-    node-uuid@1.4.8 \
-    pug@2.0.0-rc.1 \
-    uuid@^3.3.2 \
-    jquery@^3.3.1 \
-    jsonwebtoken@^8.4.0 \
-    bcryptjs@^2.4.3 \
-    react-router-dom@^4.3.1 \
-    redis@^2.8.0 \
-    pug@2.0.0-beta11 \
-    core-js@^2.5.4 \
-    multer@^1.4.1 \
-    rxjs@~6.3.3 \
-    passport-local@^1.0.0 \
-    path@^0.12.7 \
-    tslib@^1.9.0 \
-    mysql@^2.16.0 \
-    pug@^2.0.3 \
-    azure-storage@^2.10.2 \
+    cors@^2.8.5 \
+    cookie-parser@^1.4.5 \
     cookie-parser@^1.4.4 \
-    express-validator@^5.3.1 \
-    compression@^1.7.3 \
-    jsonwebtoken@^8.5.0 \
-    body-parser@^1.18.2 \
-    nodemon@^1.18.10 \
-    cross-env@^5.2.0 \
-    express@4.16.4 \
-    react-dom@^16.8.3 \
-    helmet@^3.15.0 \
-    react-dom@^16.8.4 \
-    moment-timezone@^0.5.23 \
-    react@^16.8.4 \
-    mongodb@^3.1.13 \
-    graphql@^14.1.1 \
-    @sendgrid/mail@^6.3.1 \
-    react@^16.8.3 \
-    font-awesome@^4.7.0 \
-    @angular/common@~7.2.0 \
-    @angular/router@~7.2.0 \
-    @angular/compiler@~7.2.0 \
-    nodemailer@^5.1.1 \
-    @angular/core@~7.2.0 \
-    @angular/forms@~7.2.0 \
-    @angular/platform-browser@~7.2.0 \
-    @angular/platform-browser-dynamic@~7.2.0 \
-    bcrypt-nodejs@0.0.3 \
-    redux-thunk@^2.3.0 \
-    react-scripts@2.1.5 \
-    jsonwebtoken@^8.3.0 \
-    helmet@^3.15.1 \
-    bootstrap@^4.1.3 \
-    bootstrap@^4.3.1 \
-    jwt-decode@^2.2.0 \
-    redux@^4.0.1 \
-    serve-favicon@^2.5.0 \
-    react-dom@^16.7.0 \
-    react@^16.7.0 \
-    morgan@^1.9.0 \
-    debug@^3.2.6 \
-    ejs@~2.5.7 \
-    passport-azure-ad@^4.0.0 \
-    mssql@^4.3.0 \
-    ioredis@^3.2.2 \
-    fs@0.0.1-security \
-    cors@^2.8.4 \
-; do
-    installPackage $pkg
-done;
-
-# Cache some dev-dependencies
-for pkg in \
-    autoprefixer@6.3.6 \
-    babel@6.5.2 \
-    babel-core@6.24.0 \
-    babel-eslint@7.2.3 \
-    babel-loader@6.2.4 \
-    babel-preset-es2015@6.6.0 \
-    babel-preset-react@6.5.0 \
-    css-loader@0.23.1 \
-    del@2.2.0 \
-    extract-text-webpack-plugin@1.0.1 \
-    file-loader@0.8.5 \
-    gulp@3.9.1 \
-    gulp-eslint@2.0.0 \
-    lodash@4.15.0 \
-    style-loader@0.13.1 \
-    url-loader@0.5.7 \
-    webpack@1.12.14 \
+    moment@^2.29.1 \
+    moment@^2.24.0 \
+    debug@~2.6.9 \
 ; do
     installPackage $pkg
 done;

--- a/src/BuildScriptGenerator/Node/NodeVersions.cs
+++ b/src/BuildScriptGenerator/Node/NodeVersions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
     public static class NodeVersions
     {
         public const string NodeRuntimeBaseTag = "20201203.2";
-        public const string YarnCacheBaseTag = "20200810.1";
+        public const string YarnCacheBaseTag = "20210312.1";
         public const string YarnVersion = "1.22.10";
         public const string YarnMinorVersion = "1.17";
         public const string YarnMajorVersion = "1";


### PR DESCRIPTION
Update caching packages be the latest, top frequently used packages. 
Total cache size now is 13M and the yarn-cache-base image itself still has 919MB.
Yarn package manager usage is a small portion compared to NPM usage(almost 1:10). So we're going to discuss further if we need to remove this image entirely.