### PR TITLE
update oryx generated conda-env yml location

### DIFF
--- a/src/BuildScriptGenerator/Python/JupyterNotebookBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/JupyterNotebookBashBuildSnippet.sh.tpl
@@ -6,7 +6,7 @@ conda info
 {{ if EnvironmentYmlFile | IsNotBlank }}
 envFile="{{ EnvironmentYmlFile }}"
 {{ else }}
-envFile="oryx.environment.yml"
+envFile="/opt/oryx/conda/oryx.environment.yml"
 envFileTemplate="/opt/oryx/conda/{{ EnvironmentTemplateFileName }}"
 sed 's/PYTHON_VERSION/{{ EnvironmentTemplatePythonVersion }}/g' "$envFileTemplate" > $envFile
 {{ end }}


### PR DESCRIPTION
this is to redirect the oryx generated conda env yml to non-source location so that user doesn't have to change their git settings (adding it to gitignore or manually delete it)