### PR TITLE
Update ruby sample app to fix nightly build

### DIFF
--- a/tests/SampleApps/ruby/ruby-on-rails-app/Gemfile.lock
+++ b/tests/SampleApps/ruby/ruby-on-rails-app/Gemfile.lock
@@ -95,7 +95,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -213,4 +215,4 @@ RUBY VERSION
    ruby 2.7.1
 
 BUNDLED WITH
-   2.1.4
+   2.2.15


### PR DESCRIPTION
A ruby app test currently failed in nightly build, upgrade sample ruby app dependencies for fixing the test.