### PR TITLE
Fix yarn cache folder issue

### DIFF
--- a/images/build/Dockerfiles/Dockerfile
+++ b/images/build/Dockerfiles/Dockerfile
@@ -79,6 +79,9 @@ RUN set -ex \
     && ln -s 10.14.2 10.14 \
     && ln -s 10.21.0 10.21 \
     && ln -s 12.18.2 12.18 \
+    && yarnCacheFolder="/usr/local/share/yarn-cache" \
+    && mkdir -p $yarnCacheFolder \
+    && chmod 777 $yarnCacheFolder \
     # Install Python SDKs
     && PYTHONIOENCODING="UTF-8" \
     && . $buildDir/__pythonVersions.sh \

--- a/images/build/Dockerfiles/gitHubActions.Dockerfile
+++ b/images/build/Dockerfiles/gitHubActions.Dockerfile
@@ -63,6 +63,9 @@ ARG BUILD_DIR="/opt/tmp/build"
 ARG IMAGES_DIR="/opt/tmp/images"
 RUN ${IMAGES_DIR}/build/installHugo.sh
 RUN set -ex \
+ && yarnCacheFolder="/usr/local/share/yarn-cache" \
+ && mkdir -p $yarnCacheFolder \
+ && chmod 777 $yarnCacheFolder \
  && . ${BUILD_DIR}/__nodeVersions.sh \
  && ${IMAGES_DIR}/receiveGpgKeys.sh 6A010C5166006599AA17F08146C2130DFD2497F5 \
  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \


### PR DESCRIPTION
Resolve a CRI issue caused by removing yarn-cache folder from full build image.