### PR TITLE
Fix typo, buildManifest.PythonVersion

### DIFF
--- a/src/startupscriptgenerator/src/node/main.go
+++ b/src/startupscriptgenerator/src/node/main.go
@@ -120,7 +120,7 @@ func main() {
 		finalScript := scriptBuilder.String()
 		fmt.Println(fmt.Sprintf(
 			"Setting up the environment with 'NodeJS' version '%s'...\n",
-			buildManifest.PythonVersion))
+			buildManifest.NodeVersion))
 		common.SetupEnv(finalScript)
 	}
 }


### PR DESCRIPTION
This fixes what appears to be a typo in the output of the Node startup script generator.

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [X] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [X] Proper license headers are included in each file.
