### PR TITLE
Change .NET OutputType to return raw value

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -110,7 +110,7 @@ OperationId                     | Used to correlate with logs. Track telemetries
 SourceDirectoryInBuildContainer | Directory inside Docker container contaiing source code                                   | "nodejs/helloworld-nuxtjs/" 
 PlatformName                    | Name of Oryx supported platform name                                                      |   "dotnet"       
 CompressDestinationDir          | Determines whether app is compressed to allow decompression, for performance improvements | "false"
-OutputType                      | Optional field that helps identify isolated a function app, based on app's `.csproj`. Exe/Library .csproj field maps to isolated/in-process respectively. | "in-process" 
+OutputType                      | `OutputType` specified in .csproj | "Library" 
 
 Php fields                      |       Description                                                                         |      Example
 --------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------------

--- a/src/Detector/DotNetCore/DotnetCoreDetector.cs
+++ b/src/Detector/DotNetCore/DotnetCoreDetector.cs
@@ -90,18 +90,8 @@ namespace Microsoft.Oryx.Detector.DotNetCore
         private string GetOutputType(XElement outputTypeElement)
         {
             string outputType = outputTypeElement?.Value;
-            string outputTypeResult = null;
-            if (!string.IsNullOrEmpty(outputType))
-            {
-                if (outputType.ToLower() == "library")
-                {
-                    outputTypeResult = "in-process";
-                }
-                else if (outputType.ToLower() == "exe")
-                {
-                    outputTypeResult = "isolated";
-                }
-            }
+            // default OutputType is "Library"
+            string outputTypeResult = string.IsNullOrEmpty(outputType) ? "Library" : outputType;
             return outputTypeResult;
         }
 

--- a/tests/Detector.Tests/DotNetCore/DotnetCoreDetectorTest.cs
+++ b/tests/Detector.Tests/DotNetCore/DotnetCoreDetectorTest.cs
@@ -79,10 +79,10 @@ namespace Microsoft.Oryx.Detector.Tests.DotNetCore
         }
 
         [Theory]
-        [InlineData("Library", "in-process")]
-        [InlineData("Exe", "isolated")]
-        [InlineData("randomText", null)]
-        [InlineData("", null)]
+        [InlineData("Library", "Library")]
+        [InlineData("Exe", "Exe")]
+        [InlineData("randomText", "randomtext")]
+        [InlineData("", "Library")]
         public void Detect_ReturnsOutputType(
             string outputTypeName,
             string expectedOutputType)


### PR DESCRIPTION
With the current logic, .NET apps that are not Azure Functions apps will still output OutputTypes of "isolated" or "in-process". It'd be better for Oryx to write the OutputType from the csproj without transforming the value. Static Web Apps can use the OutputType to determine function app type.

In addition, OutputType is optional in a .csproj. It defaults to "Library".

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
