### PR TITLE
Adding code profiler packages needed for Python

### DIFF
--- a/images/runtime/python/cgmanifest.json
+++ b/images/runtime/python/cgmanifest.json
@@ -1,0 +1,34 @@
+{
+    "Registrations": [
+        {
+            "Component": {
+                "pip": {
+                    "Name": "viztracer",
+                    "Version": "0.14.2"
+                },
+                "Type": "pip"
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "pip": {
+                    "Name": "vizplugins",
+                    "Version": "0.1.2"
+                },
+                "Type": "pip"
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "pip": {
+                    "Name": "orjson",
+                    "Version": "3.6.4"
+                },
+                "Type": "pip"
+            },
+            "DevelopmentDependency": false
+        }
+    ]
+}

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -39,9 +39,9 @@ RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN pip install --upgrade pip \
     && pip install gunicorn \
     && pip install debugpy \
-    && pip install viztracer \
+    && if [ "%PYTHON_MAJOR_VERSION%" = "3" ] && [ "%PYTHON_VERSION%" != "3.6" ]; then pip install viztracer \
     && pip install vizplugins \
-    && pip install orjson \
+    && pip install orjson ;fi \
     && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
     && apt-get upgrade --assume-yes \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -41,7 +41,7 @@ RUN pip install --upgrade pip \
     && pip install debugpy \
     && if [ "%PYTHON_MAJOR_VERSION%" = "3" ] && [ "%PYTHON_VERSION%" != "3.6" ]; then pip install viztracer \
     && pip install vizplugins \
-    && pip install orjson ;fi \
+    && pip install orjson; fi \
     && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
     && apt-get upgrade --assume-yes \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -39,6 +39,9 @@ RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN pip install --upgrade pip \
     && pip install gunicorn \
     && pip install debugpy \
+    && pip install viztracer \
+    && pip install vizplugins \
+    && pip install orjson \
     && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
     && apt-get upgrade --assume-yes \


### PR DESCRIPTION
The goal of this Pull request is to add the necessary packages for the code profiler viztracer along with Oryx runtime image.

**Packages needed:**
1. viztracer : this is the code profiler package
2. vizplugins : these help in adding cpu and memory stats to the trace
3. orjson: viztracer package dumps the trace as a json. In their official repo, it is explained that if orjson package is available viztracer would use it as it is better performant when compared to json package.
