### PR TITLE
Pinning the package versions of python code-profiler packages

### DIFF
--- a/images/runtime/python/cgmanifest.json
+++ b/images/runtime/python/cgmanifest.json
@@ -4,7 +4,7 @@
             "Component": {
                 "pip": {
                     "Name": "viztracer",
-                    "Version": "0.14.2"
+                    "Version": "0.14.5"
                 },
                 "Type": "pip"
             },
@@ -24,7 +24,7 @@
             "Component": {
                 "pip": {
                     "Name": "orjson",
-                    "Version": "3.6.4"
+                    "Version": "3.6.6"
                 },
                 "Type": "pip"
             },

--- a/images/runtime/python/cgmanifest.json
+++ b/images/runtime/python/cgmanifest.json
@@ -4,7 +4,7 @@
             "Component": {
                 "pip": {
                     "Name": "viztracer",
-                    "Version": "0.14.5"
+                    "Version": "0.14.3"
                 },
                 "Type": "pip"
             },

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -76,7 +76,7 @@ RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN pip install --upgrade pip \
     && pip install gunicorn \
     && pip install debugpy \
-    && if [ "%PYTHON_MAJOR_VERSION%" = "3" ] && [ "%PYTHON_VERSION%" != "3.6" ]; then pip install viztracer==0.14.5 \
+    && if [ "%PYTHON_MAJOR_VERSION%" = "3" ] && [ "%PYTHON_VERSION%" != "3.6" ]; then pip install viztracer==0.14.3 \
     && pip install vizplugins==0.1.2 \
     && pip install orjson==3.6.6; fi \
     && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -76,9 +76,9 @@ RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN pip install --upgrade pip \
     && pip install gunicorn \
     && pip install debugpy \
-    && if [ "%PYTHON_MAJOR_VERSION%" = "3" ] && [ "%PYTHON_VERSION%" != "3.6" ]; then pip install viztracer \
-    && pip install vizplugins \
-    && pip install orjson; fi \
+    && if [ "%PYTHON_MAJOR_VERSION%" = "3" ] && [ "%PYTHON_VERSION%" != "3.6" ]; then pip install viztracer==0.14.5 \
+    && pip install vizplugins==0.1.2 \
+    && pip install orjson==3.6.6; fi \
     && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
     && apt-get upgrade --assume-yes \


### PR DESCRIPTION
In this PR, the versions of the code-profiler packages are pinned.
- viztracer : 0.14.3
- vizplugins : 0.1.2
- orjson : 3.6.6