### PR TITLE
Improving the output messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,25 @@ For all options, specify `oryx --help`.
 When `oryx` is run in the runtime images it generates a start script named
 run.sh, by default in the same folder as the compiled artifact.
 
-### Support for Build Configuration File
+## Support for Build Configuration File
 
-You can provide some extra build related information in an app.yaml in your content
+You can provide some extra build related information in an appsvc.yaml in your content
 root directory. The build configuration supports 2 sections
 1. pre-build
 2. post-build
 
-This is how a sample app.yaml looks like
+This is how a sample appsvc.yaml looks like
 
+```bash
 version: 1
 
-pre-build: |
-  apt install curl
+pre-build: | 
+    apt install curl
   
-post-build: |
-  python manage.py makemigrations
-  python manage.py migrate
+post-build: | 
+    python manage.py makemigrations 
+    python manage.py migrate
+```
 
 Oryx will read the yaml and run the commands provided for pre-build and post-build.
 

--- a/src/BuildScriptGenerator/Constants.cs
+++ b/src/BuildScriptGenerator/Constants.cs
@@ -31,5 +31,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         /// the path to the installed sdks.
         /// </summary>
         public const string BenvDynamicInstallRootDirKey = "dynamic_install_root_dir";
+
+        public const string BuildConfigurationFileHelp = "https://aka.ms/troubleshoot-buildconfig";
     }
 }

--- a/src/BuildScriptGenerator/DefaultBuildScriptGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultBuildScriptGenerator.cs
@@ -318,48 +318,55 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
             // Workaround for bug in TestSourceRepo class in validation tests
             // Should be using context.SourceRepo.FileExists
-            string filePathForAppYaml = Path.Combine(context.SourceRepo.RootPath, "app.yaml");
+            string filePathForAppYaml = Path.Combine(context.SourceRepo.RootPath, "appsvc.yaml");
 
-            _logger.LogDebug("Path to app.yaml " + filePathForAppYaml);
+            _logger.LogDebug("Path to appsvc.yaml " + filePathForAppYaml);
 
             // Override the prebuild and postbuild commands if BuildConfigurationFile exists
             if (File.Exists(filePathForAppYaml))
             {
-                _logger.LogDebug("Found app.yaml");
-                _writer.WriteLine("Found app.yaml");
+                _logger.LogDebug("Found BuildConfigurationFile");
+                _writer.WriteLine(Environment.NewLine + "Found BuildConfigurationFile");
                 try
                 {
-                    BuildConfigurationFIle buildConfigFile = BuildConfigurationFIle.Create(context.SourceRepo.ReadFile("app.yaml"));
+                    BuildConfigurationFIle buildConfigFile = BuildConfigurationFIle.Create(context.SourceRepo.ReadFile("appsvc.yaml"));
                     if (!string.IsNullOrEmpty(buildConfigFile.prebuild))
                     {
                         _cliOptions.PreBuildCommand = buildConfigFile.prebuild.Replace("\r\n", ";").Replace("\n", ";");
                         _cliOptions.PreBuildScriptPath = null;
-                        _logger.LogDebug("Overriding the pre-build commands with the app.yaml section");
+                        _logger.LogDebug("Overriding the pre-build commands with the BuildConfigurationFile section");
                         _logger.LogDebug(_cliOptions.PreBuildCommand.ToString());
-                        _writer.WriteLine("Overriding the pre-build commands with the app.yaml section");
-                        _writer.WriteLine(_cliOptions.PreBuildCommand.ToString());
+                        _writer.WriteLine("Overriding the pre-build commands with the BuildConfigurationFile section");
+                        _writer.WriteLine("\t" + _cliOptions.PreBuildCommand.ToString());
                     }
 
                     if (!string.IsNullOrEmpty(buildConfigFile.postbuild))
                     {
                         _cliOptions.PostBuildCommand = buildConfigFile.postbuild.Replace("\r\n", ";").Replace("\n", ";");
                         _cliOptions.PostBuildScriptPath = null;
-                        _logger.LogDebug("Overriding the post-build commands with the app.yaml section");
+                        _logger.LogDebug("Overriding the post-build commands with the BuildConfigurationFile section");
                         _logger.LogDebug(_cliOptions.PostBuildCommand.ToString());
-                        _writer.WriteLine("Overriding the post-build commands with the app.yaml section");
-                        _writer.WriteLine(_cliOptions.PostBuildCommand.ToString());
+                        _writer.WriteLine("Overriding the post-build commands with the BuildConfigurationFile section");
+                        _writer.WriteLine("\t" + _cliOptions.PostBuildCommand.ToString());
                     }
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning("Invalid app.yaml format", ex);
-                    _writer.WriteLine("Invalid app.yaml format " + ex);
-
+                    _logger.LogWarning("Invalid BuildConfigurationFile " + ex.ToString());
+                    _writer.WriteLine(Environment.NewLine + "\"" + DateTime.UtcNow.ToString("yyyy-MM-dd hh:mm:ss") + "\" | WARNING | Invalid BuildConfigurationFile | Exit Code: 1 | Please review your appsvc.yaml | " + Constants.BuildConfigurationFileHelp);
+                    _writer.WriteLine("This is the structure of a valid appsvc.yaml");
+                    _writer.WriteLine("-------------------------------------------");
+                    _writer.WriteLine("version: 1" + Environment.NewLine);
+                    _writer.WriteLine("pre-build: apt-get install xyz" + Environment.NewLine);
+                    _writer.WriteLine("post-build: |");
+                    _writer.WriteLine("  python manage.py makemigrations");
+                    _writer.WriteLine("  python manage.py migrate");
+                    _writer.WriteLine("-------------------------------------------");
                 }
             }
             else
             {
-                _logger.LogDebug("No app.yaml found");
+                _logger.LogDebug("No appsvc.yaml found");
             }
 
             (var preBuildCommand, var postBuildCommand) = PreAndPostBuildCommandHelper.GetPreAndPostBuildCommands(


### PR DESCRIPTION
Based on feedback, improving the messages being sent to console if the yaml is invalid. 

This is how the console output looks like if appsvc.yaml is invalid

"2022-03-02 04:21:50" | WARNING | Invalid BuildConfigurationFile | Exit Code: 1 | Please review your appsvc.yaml | https://aka.ms/troubleshoot-buildconfig
This is the structure of a valid appsvc.yaml
-------------------------------------------
version: 1

pre-build: apt-get install xyz

post-build: |
  python manage.py makemigrations
  python manage.py migrate
-------------------------------------------