### PR TITLE
Fix python3 packages test pipeline failure

### DIFF
--- a/tests/Oryx.BuildImage.Tests/Python/PythonPackageTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonPackageTest.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Oryx.BuildImage.Tests.Python
 
         public static IEnumerable<object[]> PythonPackageExamples => new object[][]
         {
-            new object[] { "boto3", "1.14.44",
-                "https://github.com/boto/boto3.git" },
             new object[] { "botocore", "1.17.44",
                 "https://github.com/boto/botocore.git" },
             new object[] { "pyasn1", "0.4.8",

--- a/tests/Oryx.BuildImage.Tests/Python/PythonPackageTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonPackageTest.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Oryx.BuildImage.Tests.Python
 
         public static IEnumerable<object[]> PythonPackageExamples => new object[][]
         {
+            new object[] { "boto3", "1.21.20",
+                "https://github.com/boto/boto3.git" },
             new object[] { "botocore", "1.17.44",
                 "https://github.com/boto/botocore.git" },
             new object[] { "pyasn1", "0.4.8",


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as https://devdiv.visualstudio.com/DevDiv/_boards/board/t/Oryx/Stories/?workitem=1501576
- [x] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.

Fix recent validation pipeline failure:
 
Microsoft.Oryx.BuildImage.Tests.Python.PythonPackageTest.CanBuildPython3Packages(pkgName: "boto3", pkgVersion: "1.14.44", gitRepoUrl: "[https://github.com/boto/boto3.git",](https://github.com/boto/boto3.git%22,) pkgTag: null, requiredOsPackages: null) [27s 804ms]
  Error Message:
   System.IndexOutOfRangeException : Index was outside the bounds of the array.
  Stack Trace:
     at Microsoft.Oryx.BuildImage.Tests.Python.PythonPackageTest.CanBuildPython3Packages(String pkgName, String pkgVersion, String gitRepoUrl, String pkgTag, String[] requiredOsPackages) 
