### PR TITLE
Version updates - Hugo | Conda | Yarn 

### DIFF
--- a/build/__condaConstants.sh
+++ b/build/__condaConstants.sh
@@ -1,6 +1,6 @@
 # This file was auto-generated from 'constants.yaml'. Changes may be overridden.
 
-CONDA_VERSION='4.8.3-0'
+CONDA_VERSION='4.11.0-0'
 CONDA_ENVIRONMENT_YML_FILE_NAME='environment.yml'
 ORYX_GENERATED_ENVIRONMENT_YML_FILE_NAME='oryx.environment.yml'
 DEFAULT_CONDA_ENVIRONMENT_YML_FILE_TEMPLATE_NAME='default.envrionment.yml.template'

--- a/build/__hugoConstants.sh
+++ b/build/__hugoConstants.sh
@@ -1,6 +1,6 @@
 # This file was auto-generated from 'constants.yaml'. Changes may be overridden.
 
-VERSION='0.90.1'
+VERSION='0.96.0'
 PLATFORM_NAME='hugo'
 INSTALLED_HUGO_VERSIONS_DIR='/opt/hugo'
 INSTALLATION_URL_FORMAT='https://github.com/gohugoio/hugo/releases/download/v#VERSION#/#TAR_FILE#'

--- a/build/__nodeVersions.sh
+++ b/build/__nodeVersions.sh
@@ -1,8 +1,8 @@
 # This file was auto-generated from 'constants.yaml'. Changes may be overridden.
 
 NODE_RUNTIME_BASE_TAG='20220128.5'
-YARN_VERSION='1.22.15'
-YARN_MINOR_VERSION='1.17'
+YARN_VERSION='1.22.18'
+YARN_MINOR_VERSION='1.22'
 YARN_MAJOR_VERSION='1'
 NODE6_VERSION='6.17.1'
 NODE8_VERSION='8.17.0'

--- a/build/constants.yaml
+++ b/build/constants.yaml
@@ -202,8 +202,8 @@
 - name: node-versions
   constants:
     node-runtime-base-tag: 20220128.5
-    yarn-version: 1.22.15
-    yarn-minor-version: 1.17
+    yarn-version: 1.22.18
+    yarn-minor-version: 1.22
     yarn-major-version: 1
     node6-version: 6.17.1
     node8-version: 8.17.0
@@ -257,7 +257,7 @@
       directory: src/startupscriptgenerator/src/common/consts
 - name: hugo-constants
   constants:
-    version: 0.90.1
+    version: 0.96.0
     platform-name: hugo
     installed-hugo-versions-dir: /opt/hugo
     installation-url-format: https://github.com/gohugoio/hugo/releases/download/v#VERSION#/#TAR_FILE#
@@ -303,7 +303,7 @@
       file-name-prefix: __
 - name: conda-constants
   constants:
-    conda-version: 4.8.3-0
+    conda-version: 4.11.0-0
     conda-environment-yml-file-name: environment.yml
     oryx-generated-environment-yml-file-name: oryx.environment.yml
     default-conda-environment-yml-file-template-name: default.envrionment.yml.template

--- a/doc/runtimes/hugo.md
+++ b/doc/runtimes/hugo.md
@@ -26,7 +26,7 @@ The following process is applied for each build:
 # Version support
 
 The Hugo project defines this [release schedule][]. Oryx supports all actively supported
-releases (v0.90.1).
+releases (v0.96.0).
 
 We will update the `patch` version of a release at least once every 3 months,
 replacing the previous `patch` version for that release.

--- a/images/build/Dockerfiles/vso.focal.Dockerfile
+++ b/images/build/Dockerfiles/vso.focal.Dockerfile
@@ -112,9 +112,6 @@ RUN set -ex \
     && DOTNET_SDK_VER=$DOT_NET_60_SDK_VERSION \
        INSTALL_PACKAGES="true" \
        $imagesDir/build/installDotNetCore.sh \
-    && DOTNET_SDK_VER=$DOT_NET_50_SDK_VERSION \
-       INSTALL_PACKAGES="true" \
-       $imagesDir/build/installDotNetCore.sh \
     && rm -rf /tmp/NuGetScratch \
     && find $nugetPackagesDir -type d -exec chmod 777 {} \; \
     && cd /opt/dotnet \

--- a/src/BuildScriptGenerator/Hugo/HugoConstants.cs
+++ b/src/BuildScriptGenerator/Hugo/HugoConstants.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Hugo
 {
     public static class HugoConstants
     {
-        public const string Version = "0.90.1";
+        public const string Version = "0.96.0";
         public const string PlatformName = "hugo";
         public const string InstalledHugoVersionsDir = "/opt/hugo";
         public const string InstallationUrlFormat = "https://github.com/gohugoio/hugo/releases/download/v#VERSION#/#TAR_FILE#";

--- a/src/BuildScriptGenerator/Node/NodeVersions.cs
+++ b/src/BuildScriptGenerator/Node/NodeVersions.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
     public static class NodeVersions
     {
         public const string NodeRuntimeBaseTag = "20220128.5";
-        public const string YarnVersion = "1.22.15";
-        public const string YarnMinorVersion = "1.17";
+        public const string YarnVersion = "1.22.18";
+        public const string YarnMinorVersion = "1.22";
         public const string YarnMajorVersion = "1";
         public const string Node6Version = "6.17.1";
         public const string Node8Version = "8.17.0";

--- a/src/BuildScriptGenerator/Python/CondaConstants.cs
+++ b/src/BuildScriptGenerator/Python/CondaConstants.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
 {
     public static class CondaConstants
     {
-        public const string CondaVersion = "4.8.3-0";
+        public const string CondaVersion = "4.11.0-0";
         public const string CondaEnvironmentYmlFileName = "environment.yml";
         public const string OryxGeneratedEnvironmentYmlFileName = "oryx.environment.yml";
         public const string DefaultCondaEnvironmentYmlFileTemplateName = "default.envrionment.yml.template";


### PR DESCRIPTION
Updating versions for the following packages -
- Hugo 0.96.0
- Conda 4.11.0
- Yarn 1.22.18

Removing .NET 5 from vso.focal.Dockerfile

Tested locally.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/24955913/162026629-e19e60fd-41d8-4fbf-aa52-e396076f6790.png">


- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
