### PR TITLE
Add missing hashing to file paths when logging

### DIFF
--- a/src/Detector/Hugo/HugoDetector.cs
+++ b/src/Detector/Hugo/HugoDetector.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Microsoft.Oryx.Common.Extensions;
 using Microsoft.Oryx.Detector.Exceptions;
 using Newtonsoft.Json.Linq;
 using Tomlyn.Model;
@@ -163,7 +164,7 @@ namespace Microsoft.Oryx.Detector.Hugo
             }
             catch (FailedToParseFileException ex)
             {
-                this.logger.LogError(ex, $"An error occurred when trying to parse file '{relativeFilePath}'.");
+                this.logger.LogError(ex, $"An error occurred when trying to parse file '{relativeFilePath.Hash()}'.");
                 return false;
             }
 
@@ -188,7 +189,7 @@ namespace Microsoft.Oryx.Detector.Hugo
             }
             catch (FailedToParseFileException ex)
             {
-                this.logger.LogError(ex, $"An error occurred when trying to parse file '{relativeFilePath}'.");
+                this.logger.LogError(ex, $"An error occurred when trying to parse file '{relativeFilePath.Hash()}'.");
                 return false;
             }
 
@@ -218,7 +219,7 @@ namespace Microsoft.Oryx.Detector.Hugo
             }
             catch (FailedToParseFileException ex)
             {
-                this.logger.LogError(ex, $"An error occurred when trying to parse file '{relativeFilePath}'.");
+                this.logger.LogError(ex, $"An error occurred when trying to parse file '{relativeFilePath.Hash()}'.");
                 return false;
             }
 

--- a/src/Detector/Python/PythonDetector.cs
+++ b/src/Detector/Python/PythonDetector.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Oryx.Detector.Python
 
             if (sourceRepo.FileExists(requirementsTxtPath))
             {
-                this.logger.LogInformation($"Found {requirementsTxtPath} at the root of the repo.");
+                this.logger.LogInformation($"Found {requirementsTxtPath.Hash()} at the root of the repo.");
                 hasRequirementsTxtFile = true;
 
                 // Warning if missing django module
@@ -65,7 +65,7 @@ namespace Microsoft.Oryx.Detector.Python
 
                 if (!hasDjangoModule)
                 {
-                    this.logger.LogWarning($"Missing django module in {requirementsTxtPath}");
+                    this.logger.LogWarning($"Missing django module in {requirementsTxtPath.Hash()}");
                 }
                 else
                 {
@@ -81,7 +81,7 @@ namespace Microsoft.Oryx.Detector.Python
             }
             else
             {
-                string errorMsg = $"Cound not find {requirementsTxtPath} at the root of the repo. More information: https://aka.ms/requirements-not-found";
+                string errorMsg = $"Cound not find {requirementsTxtPath.Hash()} at the root of the repo. More information: https://aka.ms/requirements-not-found";
                 this.logger.LogError(errorMsg);
             }
 
@@ -242,7 +242,7 @@ namespace Microsoft.Oryx.Detector.Python
             }
             catch (FailedToParseFileException ex)
             {
-                this.logger.LogError(ex, $"An error occurred when trying to parse file '{fileName}'.");
+                this.logger.LogError(ex, $"An error occurred when trying to parse file '{fileName.Hash()}'.");
                 return false;
             }
 


### PR DESCRIPTION
Addressing part of work item 1522232; this PR is adding some hashing to file paths that were being logged by Oryx. 

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
