### PR TITLE
Add nginx fpm config setting

### DIFF
--- a/images/runtime/php-fpm/nginx_conf/default.conf
+++ b/images/runtime/php-fpm/nginx_conf/default.conf
@@ -6,6 +6,7 @@ server {
     root /home/site/wwwroot;
     index  index.php index.html index.htm;
     server_name  example.com www.example.com; 
+    port_in_redirect off;
 
     location / {            
         index  index.php index.html index.htm hostingstart.html;


### PR DESCRIPTION
php nginx fpm image should not include nginx port in Location: header when redirecting requests.
I've validated this config change by hand in a dev stamp.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
