### PR TITLE
Add wait before Roslyn Analyzers

### DIFF
--- a/vsts/pipelines/templates/_securityChecks.yml
+++ b/vsts/pipelines/templates/_securityChecks.yml
@@ -28,6 +28,12 @@ steps:
     createLogFile: true
     logFileVerbosity: diagnostic
 
+- task: PowerShell@2
+  displayName: 'Wait 30 seconds after building solution'
+  inputs:
+    targetType: 'inline'
+    script: 'Start-Sleep -Seconds 30'
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
   displayName: 'Run Roslyn Analyzers'
   condition: always()


### PR DESCRIPTION
There has been cases where the step to run the Roslyn Analyzers has failed due to the previous step's build not having the output artifacts ready, so this PR introduces a 30 second wait once the build has completed to ensure that enough time has passed for the artifacts to be ready for the analyzer.

~- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.~
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
