### PR TITLE
Use specified npm version spec from package.json during build

### DIFF
--- a/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
@@ -15,6 +15,14 @@ echo "Node Build Command Manifest file created."
 {{ end }}
 {{ end }}
 
+{{ if NpmVersionSpec | IsNotBlank }}
+echo
+echo "Found npm version spec to follow in package.json: '{{ NpmVersionSpec }}'"
+echo "Updating version of npm installed to meet the above version spec."
+npm install -g npm@'{{ NpmVersionSpec }}'
+echo
+{{ end }}
+
 echo
 echo "Using Node version:"
 node --version

--- a/src/BuildScriptGenerator/Node/NodeBashBuildSnippetProperties.cs
+++ b/src/BuildScriptGenerator/Node/NodeBashBuildSnippetProperties.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
 
         public string CustomBuildCommand { get; set; }
 
+        public string NpmVersionSpec { get; set; }
+
         /// <summary>
         /// Gets or sets a list of commands for the build.
         /// </summary>

--- a/src/BuildScriptGenerator/Node/NodePlatform.cs
+++ b/src/BuildScriptGenerator/Node/NodePlatform.cs
@@ -260,6 +260,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
                 hasDevDependencies = true;
             }
 
+            var npmVersionSpec = packageJson?.engines?.npm?.Value as string;
+
             var productionOnlyPackageInstallCommand = string.Format(
                 NodeConstants.ProductionOnlyPackageInstallCommandTemplate, packageInstallCommand);
 
@@ -394,6 +396,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
                 LageRunBuildCommand = runBuildLageCommand,
                 NodeBuildProperties = nodeCommandManifestFileProperties,
                 NodeBuildCommandsFile = nodeBuildCommandsFile,
+                NpmVersionSpec = npmVersionSpec,
             };
             string script = TemplateHelper.Render(
                 TemplateHelper.TemplateResource.NodeBuildSnippet,

--- a/tests/BuildScriptGenerator.Tests/Node/NodeBuildScriptGenerationTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Node/NodeBuildScriptGenerationTest.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Node
                     {"PlatformWithVersion", "Node.js 10.10.10" },
                 },
                 NodeBuildCommandsFile = FilePaths.BuildCommandsFileName,
+                NpmVersionSpec = "5.4.2",
             };
 
             // Act


### PR DESCRIPTION
Resolves work item 1501504 -- uses the `engines` field within a node project's `package.json` file to update the version of npm used during a build. This allows the user to use a version different from the default version set by Oryx during the build.
 
- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
~- [ ] Proper license headers are included in each file.~
