### PR TITLE
Upgrade Pack to latest version 0.26.0

### DIFF
--- a/images/pack-builder/installPack.sh
+++ b/images/pack-builder/installPack.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 # --------------------------------------------------------------------------------------------
 
-declare -r PACK_VERSION='0.18.1'
+declare -r PACK_VERSION='0.26.0'
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	packPlatform='linux';


### PR DESCRIPTION
The very old pack version is not compatible with the latest builder buildpacks and causes errors like

```
ERROR: failed to build: validating stack mixins: buildpack paketo-buildpacks/bundle-install@0.5.0 does not support stack io.buildpacks.stacks.bionic
```

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
