### PR TITLE
Update version of Buildpacks used by pack image

### DIFF
--- a/build/__variables.sh
+++ b/build/__variables.sh
@@ -55,7 +55,7 @@ declare -r ACR_RUNTIME_IMAGES_ARTIFACTS_FILE="$ARTIFACTS_DIR/images/runtime-imag
 declare -r PACK_IMAGE_NAME='pack'
 declare -r PACK_STACK_BASE_IMAGE_NAME="pack-stack-base"
 declare -r PACK_BUILDER_IMAGE_NAME="pack-builder"
-declare -r PACK_TOOL_VERSION="0.18.1"
+declare -r PACK_TOOL_VERSION="0.26.0"
 declare -r ORYXTESTS_BUILDIMAGE_REPO="oryxtests/build"
 
 declare -r DEVBOX_BUILD_IMAGES_REPO="oryx/build"

--- a/images/pack-builder/installPack.sh
+++ b/images/pack-builder/installPack.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 # --------------------------------------------------------------------------------------------
 
-declare -r PACK_VERSION='0.18.1'
+declare -r PACK_VERSION='0.26.0'
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	packPlatform='linux';


### PR DESCRIPTION
The version of Buildpacks that we pull for our `pack` image hasn't been updated in over a year, so this PR brings the image in line with the [latest version of Buildpacks](https://github.com/buildpacks/pack/tags).

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
