### PR TITLE
add liblzma-dev to python build

### DIFF
--- a/images/build/Dockerfiles/vso.Dockerfile
+++ b/images/build/Dockerfiles/vso.Dockerfile
@@ -30,7 +30,7 @@ RUN buildDir="/opt/tmp/build" \
     # Install Conda and related tools
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        apt-transport-https \
+    apt-transport-https \
     && rm -rf /var/lib/apt/lists/* \
     && curl https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > conda.gpg \
     && install -o root -g root -m 644 conda.gpg /usr/share/keyrings/conda-archive-keyring.gpg \
@@ -39,7 +39,7 @@ RUN buildDir="/opt/tmp/build" \
     && . $buildDir/__condaConstants.sh \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        conda=${CONDA_VERSION} \
+    conda=${CONDA_VERSION} \
     && rm -rf /var/lib/apt/lists/* \
     && . $CONDA_SCRIPT \
     && conda config --add channels conda-forge \

--- a/images/build/Dockerfiles/vso.focal.Dockerfile
+++ b/images/build/Dockerfiles/vso.focal.Dockerfile
@@ -42,6 +42,7 @@ RUN LANG="C.UTF-8" \
         sqlite3 \
         libsqlite3-dev \
         software-properties-common \
+        liblzma-dev \
     && rm -rf /var/lib/apt/lists/* \
     # This is the folder containing 'links' to benv and build script generator
     && apt-get update \

--- a/platforms/python/prereqs/build.sh
+++ b/platforms/python/prereqs/build.sh
@@ -28,6 +28,7 @@ PYTHON_GET_PIP_URL="https://github.com/pypa/get-pip/raw/3cb8888cc2869620f57d5d2d
         libreadline-dev \
         libbz2-dev \
         libgdm-dev \
+	liblzma-dev \
         libbluetooth-dev \
         tk-dev \
         uuid-dev


### PR DESCRIPTION
Relevant issue: https://github.com/microsoft/vscode-dev-containers/issues/1477

The build of oryx that is consumed by Codespaces has a version of python where the `lzma` library was seemingly not present at compile-time, causing issues seen above.

I believe this is the right place to put a build-time dependency for the build we get in the `vso` image. Please correct me if i'm wrong @william-msft !