### PR TITLE
Removed duplicate package reference from build server csproj file

### DIFF
--- a/src/BuildServer/BuildServer.csproj
+++ b/src/BuildServer/BuildServer.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="JsonFlatFileDataStore" Version="2.2.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.4" />
-    <PackageReference Include="JsonFlatFileDataStore" Version="2.2.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] **The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.**

In the preview version of VS2022, I am seeing the following error:
```
Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: JsonFlatFileDataStore 2.2.3, JsonFlatFileDataStore 2.2.3.
```
This pull request removes the duplicate package reference item from the csproj file.

- [ ] ~Tests are included and/or updated for code changes.~

Minor change, additional testing should not be needed.

- [ ] ~Proper license headers are included in each file.~

N/A, no new files.


