### PR TITLE
Resolve build warnings for VS Preview and fix detector tests

### DIFF
--- a/src/Detector/DotNetCore/DotnetCoreConstants.cs
+++ b/src/Detector/DotNetCore/DotnetCoreConstants.cs
@@ -29,5 +29,7 @@ namespace Microsoft.Oryx.Detector.DotNetCore
         public const string AzureFunctionsPackageReference = "Microsoft.NET.Sdk.Functions";
 
         public const string AzureBlazorWasmPackageReference = "Microsoft.AspNetCore.Components.WebAssembly";
+
+        public const string DefaultOutputType = "Library";
     }
 }

--- a/src/Detector/DotNetCore/DotnetCoreDetector.cs
+++ b/src/Detector/DotNetCore/DotnetCoreDetector.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Oryx.Detector.DotNetCore
             string outputType = outputTypeElement?.Value;
 
             // default OutputType is "Library"
-            string outputTypeResult = string.IsNullOrEmpty(outputType) ? "Library" : outputType;
+            string outputTypeResult = string.IsNullOrEmpty(outputType) ? DotNetCoreConstants.DefaultOutputType : outputType;
             return outputTypeResult;
         }
 

--- a/tests/Detector.Tests/DotNetCore/DotnetCoreDetectorTest.cs
+++ b/tests/Detector.Tests/DotNetCore/DotnetCoreDetectorTest.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Oryx.Detector.Tests.DotNetCore
         [Theory]
         [InlineData("Library", "Library")]
         [InlineData("Exe", "Exe")]
-        [InlineData("randomText", "randomtext")]
+        [InlineData("randomText", "randomText")]
         [InlineData("", "Library")]
         public void Detect_ReturnsOutputType(
             string outputTypeName,
@@ -149,13 +149,12 @@ namespace Microsoft.Oryx.Detector.Tests.DotNetCore
         }
 
         [Theory]
-        [InlineData("Library", null)]
-        [InlineData("Exe", null)]
-        [InlineData("randomText", null)]
-        [InlineData("", null)]
+        [InlineData("Library")]
+        [InlineData("Exe")]
+        [InlineData("randomText")]
+        [InlineData("")]
         public void Detect_ReturnsWithoutOutputType(
-            string outputTypeName,
-            string expectedOutputType)
+            string outputTypeName)
         {
             // Arrange
             // create .csproj
@@ -183,8 +182,8 @@ namespace Microsoft.Oryx.Detector.Tests.DotNetCore
 
             Assert.NotNull(result);
 
-            // check our outputType is there
-            Assert.Equal(expectedOutputType, result.OutputType);
+            // check our outputType is the default output type
+            Assert.Equal(DotNetCoreConstants.DefaultOutputType, result.OutputType);
         }
 
         private DetectorContext CreateContext(ISourceRepo sourceRepo)

--- a/tests/Detector.Tests/DotNetCore/DotnetCoreDetectorTest.cs
+++ b/tests/Detector.Tests/DotNetCore/DotnetCoreDetectorTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Oryx.Detector.Tests.DotNetCore
         [InlineData("Library", "Library")]
         [InlineData("Exe", "Exe")]
         [InlineData("randomText", "randomText")]
-        [InlineData("", "Library")]
+        [InlineData("", DotNetCoreConstants.DefaultOutputType)]
         public void Detect_ReturnsOutputType(
             string outputTypeName,
             string expectedOutputType)

--- a/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
@@ -1407,11 +1407,10 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory]
-        [InlineData("lts-versions", "3")]
-        [InlineData("vso-focal", "3")]
-        [InlineData("latest", "2")]
-        [InlineData("latest", "3")]
-        public void JamSpell_CanBe_Installed_In_The_BuildImage(string tagName, string pythonVersion)
+        [InlineData("lts-versions")]
+        [InlineData("vso-focal")]
+        [InlineData("latest")]
+        public void JamSpell_CanBe_Installed_In_The_BuildImage(string tagName)
         {
             // Arrange
             var expectedPackage = "jamspell";

--- a/tests/Oryx.Integration.Tests/Php/PhpDynamicInstallationTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpDynamicInstallationTest.cs
@@ -24,15 +24,15 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {   
-            CanBuildAndRunApp("8.0");
+            await CanBuildAndRunApp("8.0");
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
-            CanBuildAndRunApp("7.4");
+            await CanBuildAndRunApp("7.4");
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpExifTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpExifTest.cs
@@ -26,19 +26,19 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {   
             string phpVersion80 = "8.0";
-            ExifExample(phpVersion80);
-            PhpFpmExifExample(phpVersion80);
+            await ExifExample(phpVersion80);
+            await PhpFpmExifExample(phpVersion80);
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            ExifExample(phpVersion74);
-            PhpFpmExifExample(phpVersion74);
+            await ExifExample(phpVersion74);
+            await PhpFpmExifExample(phpVersion74);
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpGdTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpGdTest.cs
@@ -24,19 +24,19 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {   
             string phpVersion80 = "8.0";
-            GdExample(phpVersion80);
-            PhpFpmGdExample(phpVersion80);
+            await GdExample(phpVersion80);
+            await PhpFpmGdExample(phpVersion80);
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            GdExample(phpVersion74);
-            PhpFpmGdExample(phpVersion74);
+            await GdExample(phpVersion74);
+            await PhpFpmGdExample(phpVersion74);
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpGreetingsAppTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpGreetingsAppTest.cs
@@ -25,19 +25,19 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {   
             string phpVersion80 = "8.0";
-            GreetingsAppTest(phpVersion80);
-            PhpFpmGreetingsAppTest(phpVersion80);
+            await GreetingsAppTest(phpVersion80);
+            await PhpFpmGreetingsAppTest(phpVersion80);
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            GreetingsAppTest(phpVersion74);
-            PhpFpmGreetingsAppTest(phpVersion74);
+            await GreetingsAppTest(phpVersion74);
+            await PhpFpmGreetingsAppTest(phpVersion74);
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpImagickExampleTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpImagickExampleTest.cs
@@ -24,19 +24,19 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {   
             string phpVersion80 = "8.0";
-            ImagickExample(phpVersion80);
-            PhpFpmImagickExample(phpVersion80);
+            await ImagickExample(phpVersion80);
+            await PhpFpmImagickExample(phpVersion80);
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            ImagickExample(phpVersion74);
-            PhpFpmImagickExample(phpVersion74);
+            await ImagickExample(phpVersion74);
+            await PhpFpmImagickExample(phpVersion74);
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpMySqlIntegrationTests.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpMySqlIntegrationTests.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            PhpApp_UsingMysqli(phpVersion74, "latest");
-            PhpApp_UsingMysqli(phpVersion74, "github-actions");
+            await PhpApp_UsingMysqli(phpVersion74, "latest");
+            await PhpApp_UsingMysqli(phpVersion74, "github-actions");
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpSqlServerIntegrationTests.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpSqlServerIntegrationTests.cs
@@ -29,21 +29,21 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {   
             string phpVersion80 = "8.0";
-            PhpApp_UsingPdo(phpVersion80, "github-actions");
-            PhpApp_UsingPdo(phpVersion80, "github-buster");
-            PhpApp_UsingPdo(phpVersion80, "latest");
+            await PhpApp_UsingPdo(phpVersion80, "github-actions");
+            await PhpApp_UsingPdo(phpVersion80, "github-buster");
+            await PhpApp_UsingPdo(phpVersion80, "latest");
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            PhpApp_UsingPdo(phpVersion74, "github-actions");
-            PhpApp_UsingPdo(phpVersion74, "github-buster");
-            PhpApp_UsingPdo(phpVersion74, "latest");
+            await PhpApp_UsingPdo(phpVersion74, "github-actions");
+            await PhpApp_UsingPdo(phpVersion74, "github-buster");
+            await PhpApp_UsingPdo(phpVersion74, "latest");
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpTwigExampleTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpTwigExampleTest.cs
@@ -24,19 +24,19 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {   
             string phpVersion80 = "8.0";
-            TwigExample(phpVersion80);
-            PhpFpmTwigExample(phpVersion80);
+            await TwigExample(phpVersion80);
+            await PhpFpmTwigExample(phpVersion80);
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            TwigExample(phpVersion74);
-            PhpFpmTwigExample(phpVersion74);
+            await TwigExample(phpVersion74);
+            await PhpFpmTwigExample(phpVersion74);
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpWordPressFpmTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpWordPressFpmTest.cs
@@ -27,15 +27,15 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {
-            PhpFpmWithWordPress56("8.0-fpm");
+            await PhpFpmWithWordPress56("8.0-fpm");
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void PipelineTestInvocationsPhp74()
+        public async void PipelineTestInvocationsPhp74()
         {
-            PhpFpmWithWordPress56("7.4-fpm");
+            await PhpFpmWithWordPress56("7.4-fpm");
         }
 
         [Theory]

--- a/tests/Oryx.Integration.Tests/Php/PhpWordPressTest.cs
+++ b/tests/Oryx.Integration.Tests/Php/PhpWordPressTest.cs
@@ -27,19 +27,19 @@ namespace Microsoft.Oryx.Integration.Tests
         // platform-version in it's own pipeline agent. This is
         // because our agents currently a space limit of 10GB.
         [Fact, Trait("category", "php-8.0")]
-        public void PipelineTestInvocationsPhp80()
+        public async void PipelineTestInvocationsPhp80()
         {
             string phpVersion80 = "8.0";
-            PhpWithWordPress51(phpVersion80);
-            CanBuildAndRun_Wordpress_SampleApp(phpVersion80);
+            await PhpWithWordPress51(phpVersion80);
+            await CanBuildAndRun_Wordpress_SampleApp(phpVersion80);
         }
 
         [Fact, Trait("category", "php-7.4")]
-        public void  PipelineTestInvocationsPhp74()
+        public async void  PipelineTestInvocationsPhp74()
         {
             string phpVersion74 = "7.4";
-            PhpWithWordPress51(phpVersion74);
-            CanBuildAndRun_Wordpress_SampleApp(phpVersion74);
+            await PhpWithWordPress51(phpVersion74);
+            await CanBuildAndRun_Wordpress_SampleApp(phpVersion74);
         }
 
         [Theory]


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] *The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.*

This pull request resolves 3 separate issues that were throwing up warnings during the build of the Oryx solution on the Visual Studio Preview. 
1. Async functions being called without a `.Result` or `await`
2. Failing tests in the detector due to [default for dotnet projects](https://github.com/microsoft/Oryx/compare/main...pauld/resolve-build-warnings#diff-11fd637ee1899af09fa227e573e8ff0df83f4683ae8078c40ea72a7162b64dabR114) being `Library` and the tests assuming empty string.
3. [Removed unused parameter](https://github.com/microsoft/Oryx/compare/main...pauld/resolve-build-warnings#diff-c5d03228c1b28cf1dc5357b65481c01ad6cd3c0a1041c7b31ec26ff57710b6d7L1414) from a test method, which changed a while back to no longer need the python version as an argument.
- [x] *Tests are included and/or updated for code changes.*
- [ ] *~Proper license headers are included in each file.~*
