### PR TITLE
Bugfix: Clean up remaining reference to 3.1.419

### DIFF
--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
@@ -822,7 +822,9 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 () =>
                 {
                     Assert.True(result.IsSuccess);
-                    Assert.Contains(string.Format(SdkVersionMessageFormat, "3.1.419"), result.StdOut);
+                    Assert.Contains(
+                        string.Format(SdkVersionMessageFormat, DotNetCoreSdkVersions.DotNetCore31SdkVersion),
+                        result.StdOut);
                 },
                 result.GetDebugInfo());
         }

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
@@ -822,7 +822,9 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 () =>
                 {
                     Assert.True(result.IsSuccess);
-                    Assert.Contains(string.Format(SdkVersionMessageFormat, "3.1.419"), result.StdOut);
+                    Assert.Contains(
+                        string.Format(SdkVersionMessageFormat, DotNetCoreSdkVersions.DotNetCore31SdkVersion), 
+                        result.StdOut);
                 },
                 result.GetDebugInfo());
         }

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
@@ -822,9 +822,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 () =>
                 {
                     Assert.True(result.IsSuccess);
-                    Assert.Contains(
-                        string.Format(SdkVersionMessageFormat, DotNetCoreSdkVersions.DotNetCore31SdkVersion), 
-                        result.StdOut);
+                    Assert.Contains(string.Format(SdkVersionMessageFormat, "3.1.419"), result.StdOut);
                 },
                 result.GetDebugInfo());
         }


### PR DESCRIPTION
…k version

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
Clean up remaining reference to 3.1.419 sdk, ensuring that it is no longer hardcoded in the tests. We now use the constant version number in the tests to ensure that we no longer have to manually update these tests when we release a new version of the 3.1 SDK
- [x] Tests are included and/or updated for code changes.
- [ ] ~Proper license headers are included in each file.~
