### PR TITLE
Remove zend opcach warning message

### DIFF
--- a/images/runtime/php-fpm/template.base.Dockerfile
+++ b/images/runtime/php-fpm/template.base.Dockerfile
@@ -103,31 +103,13 @@ RUN { \
                 echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# NOTE: zend_extension=opcache is already configured via docker-php-ext-install, above
 RUN { \
                 echo 'error_log=/var/log/apache2/php-error.log'; \
                 echo 'display_errors=Off'; \
                 echo 'log_errors=On'; \
                 echo 'display_startup_errors=Off'; \
                 echo 'date.timezone=UTC'; \
-                echo 'zend_extension=opcache'; \
-    } > /usr/local/etc/php/conf.d/php.ini
-
-RUN { \
-                echo 'opcache.memory_consumption=128'; \
-                echo 'opcache.interned_strings_buffer=8'; \
-                echo 'opcache.max_accelerated_files=4000'; \
-                echo 'opcache.revalidate_freq=60'; \
-                echo 'opcache.fast_shutdown=1'; \
-                echo 'opcache.enable_cli=1'; \
-    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
-
-RUN { \
-                echo 'error_log=/var/log/apache2/php-error.log'; \
-                echo 'display_errors=Off'; \
-                echo 'log_errors=On'; \
-                echo 'display_startup_errors=Off'; \
-                echo 'date.timezone=UTC'; \
-                echo 'zend_extension=opcache'; \
     } > /usr/local/etc/php/conf.d/php.ini
 
 RUN set -x \

--- a/images/runtime/php/7.4/base.bullseye.Dockerfile
+++ b/images/runtime/php/7.4/base.bullseye.Dockerfile
@@ -123,13 +123,13 @@ RUN { \
                 echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# NOTE: zend_extension=opcache is already configured via docker-php-ext-install, above
 RUN { \
                 echo 'error_log=/var/log/apache2/php-error.log'; \
                 echo 'display_errors=Off'; \
                 echo 'log_errors=On'; \
                 echo 'display_startup_errors=Off'; \
                 echo 'date.timezone=UTC'; \
-                echo 'zend_extension=opcache'; \
     } > /usr/local/etc/php/conf.d/php.ini
 
 RUN set -x \

--- a/images/runtime/php/8.0/base.buster.Dockerfile
+++ b/images/runtime/php/8.0/base.buster.Dockerfile
@@ -117,13 +117,13 @@ RUN { \
                 echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# NOTE: zend_extension=opcache is already configured via docker-php-ext-install, above
 RUN { \
                 echo 'error_log=/var/log/apache2/php-error.log'; \
                 echo 'display_errors=Off'; \
                 echo 'log_errors=On'; \
                 echo 'display_startup_errors=Off'; \
                 echo 'date.timezone=UTC'; \
-                echo 'zend_extension=opcache'; \
     } > /usr/local/etc/php/conf.d/php.ini
 
 RUN set -x \

--- a/images/runtime/php/8.1/base.buster.Dockerfile
+++ b/images/runtime/php/8.1/base.buster.Dockerfile
@@ -118,13 +118,13 @@ RUN { \
                 echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# NOTE: zend_extension=opcache is already configured via docker-php-ext-install, above
 RUN { \
                 echo 'error_log=/var/log/apache2/php-error.log'; \
                 echo 'display_errors=Off'; \
                 echo 'log_errors=On'; \
                 echo 'display_startup_errors=Off'; \
                 echo 'date.timezone=UTC'; \
-                echo 'zend_extension=opcache'; \
     } > /usr/local/etc/php/conf.d/php.ini
 
 RUN set -x \

--- a/images/runtime/php/template.base.Dockerfile
+++ b/images/runtime/php/template.base.Dockerfile
@@ -123,13 +123,13 @@ RUN { \
                 echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# NOTE: zend_extension=opcache is already configured via docker-php-ext-install, above
 RUN { \
                 echo 'error_log=/var/log/apache2/php-error.log'; \
                 echo 'display_errors=Off'; \
                 echo 'log_errors=On'; \
                 echo 'display_startup_errors=Off'; \
                 echo 'date.timezone=UTC'; \
-                echo 'zend_extension=opcache'; \
     } > /usr/local/etc/php/conf.d/php.ini
 
 RUN set -x \


### PR DESCRIPTION
- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as https://devdiv.visualstudio.com/DevDiv/_boards/board/t/Oryx/Stories/?workitem=1554458
Stems from: https://github.com/microsoft/Oryx/pull/1445
There was a false positive [ICM ](https://portal.microsofticm.com/imp/v3/incidents/details/309842082/home)filed due to a PHP warning message which is confusing for a customer:
Cannot load Zend OPcach - it was already loaded

This is where Oryx creates the 2 .ini files
https://github.com/microsoft/Oryx/blob/main/images/runtime/php/7.4/base.buster.Dockerfile#L127
https://github.com/microsoft/Oryx/blob/main/platforms/php/prereqs/docker-php-ext-enable.sh#L106
This was set back in 2020
Warning message
https://github.com/microsoft/Oryx/blob/main/platforms/php/prereqs/docker-php-ext-enable.sh#L101

Investigate if we can remove this message that is confusing for our customers, without breaking any changes. If this is possible please remove. More details can be found in the [ICM](https://portal.microsofticm.com/imp/v3/incidents/details/309842082/home)
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
