### PR TITLE
Build script hard fail when ostype file does not exist

### DIFF
--- a/src/BuildScriptGenerator/BaseBashBuildScript.sh.tpl
+++ b/src/BuildScriptGenerator/BaseBashBuildScript.sh.tpl
@@ -222,7 +222,8 @@ then
 	echo "Copying .ostype to manifest output directory."
 	cp "$OS_TYPE_SOURCE_DIR" "$MANIFEST_DIR/.ostype"
 else
-	echo "File $OS_TYPE_SOURCE_DIR does not exist. Cannot copy to manifest directory."
+	echo "File $OS_TYPE_SOURCE_DIR does not exist. Cannot copy to manifest directory." 1>&2
+	exit 1
 fi
 
 TOTAL_EXECUTION_ELAPSED_TIME=$(($SECONDS - $TOTAL_EXECUTION_START_TIME))

--- a/tests/BuildScriptGeneratorCli.Tests/BuildCommandTest.cs
+++ b/tests/BuildScriptGeneratorCli.Tests/BuildCommandTest.cs
@@ -716,6 +716,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
             Directory.CreateDirectory(outputFolder);
             if (createOsTypeFile)
             {
+                Directory.CreateDirectory(Path.GetDirectoryName(OS_TYPE_FILE_PATH));
                 File.Create(OS_TYPE_FILE_PATH).Dispose();
             }
             var servicesBuilder = new ServiceProviderBuilder()


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
https://github.com/microsoft/Oryx/pull/1451#discussion_r910344791
We want the build script to fail when ostype is not present, as that represents an invalid state for the container
- [x] Tests are included and/or updated for code changes.
- [ ] ~Proper license headers are included in each file.~
