### PR TITLE
CUSTOM_BUILD_COMMAND env var not read for Ruby applications

### DIFF
--- a/src/BuildScriptGeneratorCli/Options/RubyScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/RubyScriptGeneratorOptionsSetup.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
         public void Configure(RubyScriptGeneratorOptions options)
         {
             options.RubyVersion = this.GetStringValue(SettingsKeys.RubyVersion);
+            options.CustomBuildCommand = this.GetStringValue(SettingsKeys.CustomBuildCommand);
         }
     }
 }


### PR DESCRIPTION
I couldn't get the CustomBuildCommand working for a Jekyll application and I think the following was missing from #1008 to get the environment variable being used.
