### PR TITLE
Lock version of afero to 1.8.2 to revert bug with 1.9.0

### DIFF
--- a/src/startupscriptgenerator/src/common/Gopkg.toml
+++ b/src/startupscriptgenerator/src/common/Gopkg.toml
@@ -37,6 +37,10 @@
   name = "github.com/stretchr/testify"
   version = "1.3.0"
 
+[[override]]
+  name = "github.com/spf13/afero"
+  version = "=1.8.2"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
+++ b/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
@@ -33,6 +33,10 @@
   name = "github.com/stretchr/testify"
   version = "1.3.0"
 
+[[override]]
+  name = "github.com/spf13/afero"
+  version = "=1.8.2"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/src/startupscriptgenerator/src/node/Gopkg.toml
+++ b/src/startupscriptgenerator/src/node/Gopkg.toml
@@ -29,6 +29,10 @@
   name = "github.com/stretchr/testify"
   version = "1.3.0"
 
+[[override]]
+  name = "github.com/spf13/afero"
+  version = "=1.8.2"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/src/startupscriptgenerator/src/python/Gopkg.toml
+++ b/src/startupscriptgenerator/src/python/Gopkg.toml
@@ -29,6 +29,10 @@
   name = "github.com/stretchr/testify"
   version = "1.3.0"
 
+[[override]]
+  name = "github.com/spf13/afero"
+  version = "=1.8.2"
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1577349

Information surrounding why we hit this bug is in the work item comments.
- [ ] ~Tests are included and/or updated for code changes.~
- [ ] ~Proper license headers are included in each file.~
