### PR TITLE
Bugfix: storage account tests stopping at first empty line

### DIFF
--- a/tests/Oryx.Integration.Tests/StorageAccountSanityTestBase.cs
+++ b/tests/Oryx.Integration.Tests/StorageAccountSanityTestBase.cs
@@ -331,10 +331,10 @@ namespace Oryx.Integration.Tests
             using (var streamReader = new StreamReader(versionFile))
             {
                 string line = null;
-                while ((line = streamReader.ReadLine()) != null && !string.IsNullOrEmpty(line))
+                while ((line = streamReader.ReadLine()) != null)
                 {
-                    // ignore comments
-                    if (line.StartsWith("#"))
+                    // ignore comments or empty lines
+                    if (line.StartsWith("#") || string.IsNullOrEmpty(line))
                     {
                         continue;
                     }
@@ -363,10 +363,10 @@ namespace Oryx.Integration.Tests
             using (var streamReader = new StreamReader(file))
             {
                 string line = null;
-                while ((line = streamReader.ReadLine()) != null && !string.IsNullOrEmpty(line))
+                while ((line = streamReader.ReadLine()) != null)
                 {
-                    // ignore comments
-                    if (line.StartsWith("#"))
+                    // ignore comments or empty lines
+                    if (line.StartsWith("#") || string.IsNullOrEmpty(line))
                     {
                         continue;
                     }

--- a/tests/Oryx.Integration.Tests/StorageAccountSanityTestBase.cs
+++ b/tests/Oryx.Integration.Tests/StorageAccountSanityTestBase.cs
@@ -333,6 +333,9 @@ namespace Oryx.Integration.Tests
                 string line = null;
                 while ((line = streamReader.ReadLine()) != null)
                 {
+                    // Remove extraneous whitespace
+                    line = line.Trim();
+
                     // ignore comments or empty lines
                     if (line.StartsWith("#") || string.IsNullOrEmpty(line))
                     {
@@ -365,6 +368,9 @@ namespace Oryx.Integration.Tests
                 string line = null;
                 while ((line = streamReader.ReadLine()) != null)
                 {
+                    // Remove extraneous whitespace
+                    line = line.Trim();
+
                     // ignore comments or empty lines
                     if (line.StartsWith("#") || string.IsNullOrEmpty(line))
                     {


### PR DESCRIPTION
This pull request addresses a bug where we stop checking the `versionsToBuild.txt` file after the first empty line, which as you can imagine is an issue for [a version file like our dotnet one](https://github.com/microsoft/Oryx/blob/main/platforms/dotnet/versionsToBuild.txt).

------
This PR is marked as draft because I am additionally looking for some feedback from the team as to how we should address rollout cases, which will make these tests fail as they assert that every version in the versionsToBuild.txt exists in the dev and prod storage accounts.
1. Leave test as is, and reformat the versionsToBuild files to be like:
```# version, sha, download url
3.1.811, sha,
5.0.203, sha,

# newest version
7.0.100-preview.5.22307.18, sha
```
This format, with the whitespace between the other versions and the version we rollout will cause the test to stop checking before it gets to the newest version.

2. Hardcode versions that are rolling out in the test and add a step to the version release instructions to make sure that the list is up to date.

4. Add some sort of a threshold to allow for failing versions that are rolling out. Cons are that we could hide issues up to that threshold, and we would not be able to roll out more than that number of versions at the same time.

More than open to any other suggestions as to how we could get around this issue! 