### PR TITLE
Update SDKS debian type for PHP and PHP composer

### DIFF
--- a/images/build/Dockerfiles/gitHubActions.Dockerfile
+++ b/images/build/Dockerfiles/gitHubActions.Dockerfile
@@ -44,7 +44,10 @@ RUN if [ "${DEBIAN_FLAVOR}" = "bullseye" ]; then \
             libicu67 \
             libcurl4 \ 
             libssl1.1 \
-        && rm -rf /var/lib/apt/lists/* ; \
+        && rm -rf /var/lib/apt/lists/* \
+        && curl -LO http://security.debian.org/debian-security/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u2_amd64.deb \
+        && dpkg -i libxml2_2.9.10+dfsg-6.7+deb11u2_amd64.deb \
+        && rm libxml2_2.9.10+dfsg-6.7+deb11u2_amd64.deb ; \
     elif [ "${DEBIAN_FLAVOR}" = "buster" ]; then \
         apt-get update \
         && apt-get install -y --no-install-recommends \

--- a/src/BuildScriptGenerator/PlatformInstallerBase.cs
+++ b/src/BuildScriptGenerator/PlatformInstallerBase.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 .AppendLine($"cd {versionDirInTemp}")
                 .AppendLine("PLATFORM_BINARY_DOWNLOAD_START=$SECONDS")
                 .AppendLine($"platformName=\"{platformName}\"")
+                // Temporarily use buster SDKs in bullseye image until bullseye SDKs are supported in storage account.
+                // Bug item: 1578477
                 .AppendLine($"if [ \"$DEBIAN_FLAVOR\" = \"bullseye\" ]; then")
                 .AppendLine($"SDK_DEBIAN_TYPE=\"buster\"")
                 .AppendLine("fi")

--- a/src/BuildScriptGenerator/PlatformInstallerBase.cs
+++ b/src/BuildScriptGenerator/PlatformInstallerBase.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 .AppendLine($"cd {versionDirInTemp}")
                 .AppendLine("PLATFORM_BINARY_DOWNLOAD_START=$SECONDS")
                 .AppendLine($"platformName=\"{platformName}\"")
+
                 // Temporarily use buster SDKs in bullseye image until bullseye SDKs are supported in storage account.
                 // Bug item: 1578477
                 .AppendLine($"if [ \"$DEBIAN_FLAVOR\" = \"bullseye\" ]; then")

--- a/src/BuildScriptGenerator/PlatformInstallerBase.cs
+++ b/src/BuildScriptGenerator/PlatformInstallerBase.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             snippet
                 .AppendLine()
                 .AppendLine("PLATFORM_SETUP_START=$SECONDS")
+                .AppendLine("SDK_DEBIAN_TYPE=$DEBIAN_FLAVOR")
                 .AppendLine("echo")
                 .AppendLine(
                 $"echo \"Downloading and extracting '{platformName}' version '{version}' to '{versionDirInTemp}'...\"")
@@ -54,10 +55,13 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 .AppendLine($"cd {versionDirInTemp}")
                 .AppendLine("PLATFORM_BINARY_DOWNLOAD_START=$SECONDS")
                 .AppendLine($"platformName=\"{platformName}\"")
+                .AppendLine($"if [ \"$DEBIAN_FLAVOR\" = \"bullseye\" ]; then")
+                .AppendLine($"SDK_DEBIAN_TYPE=\"buster\"")
+                .AppendLine("fi")
                 .AppendLine($"if [[ \"$platformName\" = \"php\" || \"$platformName\" = \"php-composer\" ]] && [[ \"$DEBIAN_FLAVOR\" != \"stretch\" ]]; then")
                 .AppendLine("echo \"Detecting image debian flavor: $DEBIAN_FLAVOR.\"")
                 .AppendLine(
-                $"curl -D headers.txt -SL \"{sdkStorageBaseUrl}/{platformName}/{platformName}-$DEBIAN_FLAVOR-{version}.tar.gz\" " +
+                $"curl -D headers.txt -SL \"{sdkStorageBaseUrl}/{platformName}/{platformName}-$SDK_DEBIAN_TYPE-{version}.tar.gz\" " +
                 $"--output {tarFile} >/dev/null 2>&1")
                 .AppendLine("else")
                 .AppendLine(

--- a/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 );
                 var imageHelper = new ImageTestHelper();
                 data.Add(PhpVersions.Php74Version, imageHelper.GetGitHubActionsBuildImage(), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php74Version, imageHelper.GetGitHubActionsBuildImage("github-actions-bullseye"), PhpVersions.ComposerVersion);
                 data.Add(PhpVersions.Php80Version, imageHelper.GetGitHubActionsBuildImage("github-actions-buster"), PhpVersions.ComposerVersion);
                 data.Add(PhpVersions.Php81Version, imageHelper.GetGitHubActionsBuildImage("github-actions-buster"), PhpVersions.ComposerVersion);
 


### PR DESCRIPTION
As we don't support bullseye SDKs for now, when pulling SDKs from a bullseye based build image, it'll look for bullseye SDKs which doesn't exist. So we replace it with buster SDKs to resolve an issue from partner team.

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
