### PR TITLE
Bake Python 3.11, node 18 and PHP 8.1 into bullseye GitHub Actions build image

### DIFF
--- a/build/buildBuildImages.sh
+++ b/build/buildBuildImages.sh
@@ -187,6 +187,13 @@ function buildGitHubActionsImage() {
 	fi
 
 	buildBuildScriptGeneratorImage
+
+	# Temporary: Pass in the Oryx PATH needed for bullseye since it cannot be conditionally set in a Dockerfile
+	local tempOryxPaths=""
+	if [ "$debianFlavor" == "bullseye" ]; then
+		# Note: Double ':' is needed between each path to prevent strange Windows "path resolution" issue seen
+		tempOryxPaths="/opt/python/3.11.04b/bin::/opt/node/18.7.0/bin::/opt/php/lts/bin:"
+	fi
 	
 	echo
 	echo "-------------Creating build image for GitHub Actions-------------------"
@@ -194,6 +201,7 @@ function buildGitHubActionsImage() {
 		--build-arg AI_KEY=$APPLICATION_INSIGHTS_INSTRUMENTATION_KEY \
 		--build-arg SDK_STORAGE_BASE_URL_VALUE=$PROD_SDK_CDN_STORAGE_BASE_URL \
 		--build-arg DEBIAN_FLAVOR=$debianFlavor \
+		--build-arg TEMP_ORYX_PATHS=$tempOryxPaths \
 		--label com.microsoft.oryx="$labelContent" \
 		-f "$BUILD_IMAGES_GITHUB_ACTIONS_DOCKERFILE" \
 		.

--- a/build/buildPythonSdkByVersion.sh
+++ b/build/buildPythonSdkByVersion.sh
@@ -152,11 +152,18 @@ getPythonGpgByVersion() {
 echo
 echo "Building python 3.10 or newer from source code..."
 
-getPythonGpgByVersion "/tmp/versionsToBuild.txt" $version
 IFS='.' read -ra SPLIT_VERSION <<< "$PYTHON_VERSION"
 
 if  [ "${SPLIT_VERSION[0]}" == "3" ] && [ "${SPLIT_VERSION[1]}" -ge "10" ]
 then
+    # Temporary: We can't put Python 3.11 in versionsToBuild.txt, so handle it separately
+    if [ "${SPLIT_VERSION[1]}" == "11" ]
+    then
+        pythonVersionGPG="A035C8C19219BA821ECEA86B64E628F8D684696D"
+    else
+        getPythonGpgByVersion "/tmp/versionsToBuild.txt" $version
+    fi
+
     buildPythonfromSource $version $pythonVersionGPG
 else
     source /tmp/oryx/images/installPlatform.sh python $version --dir /opt/python/$version --links false

--- a/images/build/Dockerfiles/gitHubActions.Dockerfile
+++ b/images/build/Dockerfiles/gitHubActions.Dockerfile
@@ -97,6 +97,7 @@ RUN set -ex \
 
 FROM main AS final
 ARG SDK_STORAGE_BASE_URL_VALUE
+ARG TEMP_ORYX_PATHS
 ARG BUILD_DIR="/opt/tmp/build"
 ARG IMAGES_DIR="/opt/tmp/images"
 ARG AI_KEY
@@ -205,7 +206,7 @@ RUN tmpDir="/opt/tmp" \
 #
 # Even though this adds a new docker layer we are doing this 
 # because we want to avoid duplication (which is always error-prone)
-ENV ORYX_PATHS="/opt/python/3.11.04b/bin:/opt/node/18.7.0/bin:/opt/php/lts/bin:/opt/oryx:/opt/yarn/stable/bin:/opt/hugo/lts"
+ENV ORYX_PATHS="${TEMP_ORYX_PATHS}/opt/oryx:/opt/yarn/stable/bin:/opt/hugo/lts"
 
 ENV LANG="C.UTF-8" \
     ORIGINAL_PATH="$PATH" \

--- a/images/build/Dockerfiles/vso.focal.Dockerfile
+++ b/images/build/Dockerfiles/vso.focal.Dockerfile
@@ -86,7 +86,7 @@ RUN set -ex \
     && imagesDir="$tmpDir/images" \
     && buildDir="$tmpDir/build" \
     # https://github.com/docker-library/python/issues/147
-    && PYTHONIOENCODING="UTF-8" \    
+    && PYTHONIOENCODING="UTF-8" \
     && apt-get update \
     && apt-get upgrade -y \
     # It's not clear whether these are needed at runtime...

--- a/images/installPlatform.sh
+++ b/images/installPlatform.sh
@@ -48,6 +48,9 @@ if [ -z "$debianFlavor" ] || [ "$debianFlavor" == "stretch" ]; then
 	fileName="$PLATFORM_NAME-$VERSION.tar.gz"
 elif [ "$debianFlavor" == "buster" ] || [ "$debianFlavor" == "focal-scm" ]; then
   fileName="$PLATFORM_NAME-$debianFlavor-$VERSION.tar.gz"
+elif [ "$debianFlavor" == "bullseye" ] && [ "$PLATFORM_NAME" == "php" ] && [ "$VERSION" == "8.1.6" ]; then
+  # Temporary: Specific case for PHP 8.1.6 being used in bullseye build image
+  fileName="$PLATFORM_NAME-bullseye-$VERSION.tar.gz"
 else
   # Bullseye SDKs are not supported so using buster version for now.
   fileName="$PLATFORM_NAME-buster-$VERSION.tar.gz"


### PR DESCRIPTION
At the request of the Antares team, we are baking the following platform versions into the bullseye flavor of the GitHub Actions build image:
- Python 3.11
- node 18
- PHP 8.1

This is a temporary change until PR https://github.com/microsoft/Oryx/pull/1484 is merged to allow us to choose which Debian flavor of an SDK we dynamically install onto a build image.

The PHP 8.1 binaries needed to be published to the development storage account for easiest consumption within the build image and will be removed as soon as these changes are reverted.

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
