### PR TITLE
Point python 3.6 get-pip to new source

### DIFF
--- a/platforms/python/prereqs/build.sh
+++ b/platforms/python/prereqs/build.sh
@@ -47,6 +47,10 @@ if [ "$debianFlavor" == "stretch" ]; then
     echo "Hack flavor is: "$debianHackFlavor
 
     pythonSdkFileName=python-$PYTHON_VERSION.tar.gz
+
+    if [[ $PYTHON_VERSION == 3.6* ]]; then
+        PYTHON_GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
+    fi
     PYTHON_GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
     PIP_VERSION="20.2.3"
 else

--- a/platforms/python/prereqs/build.sh
+++ b/platforms/python/prereqs/build.sh
@@ -47,11 +47,12 @@ if [ "$debianFlavor" == "stretch" ]; then
     echo "Hack flavor is: "$debianHackFlavor
 
     pythonSdkFileName=python-$PYTHON_VERSION.tar.gz
-
+    PYTHON_GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
+    
     if [[ $PYTHON_VERSION == 3.6* ]]; then
         PYTHON_GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
     fi
-    PYTHON_GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
+
     PIP_VERSION="20.2.3"
 else
 	pythonSdkFileName=python-$debianFlavor-$PYTHON_VERSION.tar.gz


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6490101&view=logs&j=949f3752-01a7-599c-273e-99de61b000fe&t=46adcf0e-eea5-5352-25f6-dcd70cf91fc3

failing because 3.6's get-pip was removed from the original source