### PR TITLE
Add document for supported runtime versions

### DIFF
--- a/doc/supportedRuntimeVersions.md
+++ b/doc/supportedRuntimeVersions.md
@@ -1,0 +1,95 @@
+# Supported Runtime Versions for Oryx
+
+Below are the supported runtime versions for Oryx that can be pulled via Microsoft Container Registry following the format
+`mcr.microsoft.com/oryx/{platform}:{version}`.
+
+_Note_: the `{version}` used as the tag of the runtime image corresponds to the latest minor _or_ patch version supported by Oryx, _i.e._, `node:8`
+corresponds to the latest version of node `8.x.x` supported by Oryx, and `node:8.0` corresponds to the latest version of node `8.0.x` supported.
+
+The full list of supported platform versions for Oryx can be found [here](supportedPlatformVerions.md).
+
+## .NET
+
+The following are supported runtime versions for the image `mcr.microsoft.com/oryx/dotnetcore:{version}`.
+
+- `1.0`
+- `1.1`
+- `2.0`
+- `2.1`
+- `2.2`
+- `3.0`
+- `3.1`
+- `3.2`
+- `5.0`
+- `6.0`
+- `7.0`
+
+## node
+
+The following are supported runtime versions for the image `mcr.microsoft.com/oryx/node:{version}`.
+
+- `4.4`
+- `4.5`
+- `4.8`
+- `6`
+- `6.2`
+- `6.6`
+- `6.9`
+- `6.10`
+- `6.11`
+- `8`
+- `8.0`
+- `8.1`
+- `8.2`
+- `8.8`
+- `8.9`
+- `8.11`
+- `8.12`
+- `8.16`
+- `9.4`
+- `10`
+- `10.1`
+- `10.10`
+- `10.12`
+- `10.14`
+- `10.16`
+- `10.17`
+- `12`
+- `12.7`
+- `12.8`
+- `12.9`
+- `12.12`
+- `12.13`
+- `14`
+- `16`
+
+## PHP
+
+The following are supported runtime versions for the image `mcr.microsoft.com/oryx/php:{version}`.
+
+- `5.6`
+- `7.0`
+- `7.2`
+- `7.3`
+- `7.4`
+- `8.0`
+- `8.1`
+
+## Python
+
+The following are supported runtime versions for the image `mcr.microsoft.com/oryx/python:{version}`.
+
+- `2.7`
+- `3.6`
+- `3.7`
+- `3.8`
+- `3.9`
+- `3.10`
+
+## Ruby
+
+The following are supported runtime versions for the image `mcr.microsoft.com/oryx/ruby:{version}`.
+
+- `2.5`
+- `2.6`
+- `2.7`


### PR DESCRIPTION
Introduce a document that lists all runtime versions supported by Oryx to be present alongside the existing `supportedPlatformVersions.md` document that lists all platform versions in our storage account.

In the future, we should work to make this document dynamic like the platform versions document by pulling the versions from  `https://mcr.microsoft.com/v2/oryx/{platform}/tags/list`

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
