### PR TITLE
Add build image and bind port options for Dockerfile command

### DIFF
--- a/src/BuildScriptGenerator/Dockerfile.oryx.tpl
+++ b/src/BuildScriptGenerator/Dockerfile.oryx.tpl
@@ -9,5 +9,5 @@ RUN oryx build /app --output /output
 FROM mcr.microsoft.com/oryx/${RUNTIME}
 WORKDIR /app
 COPY --from=build /output .
-RUN oryx create-script
+RUN oryx create-script {{ CreateScriptArguments }}
 ENTRYPOINT ["/app/run.sh"]

--- a/src/BuildScriptGenerator/DockerfileProperties.cs
+++ b/src/BuildScriptGenerator/DockerfileProperties.cs
@@ -26,5 +26,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         /// Gets or sets the tag of the image used to build the application in the Dockerfile.
         /// </summary>
         public string BuildImageTag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional arguments that should be provided to the 'oryx create-script' command
+        /// in the runtime image of the Dockerfile.
+        /// </summary>
+        public string CreateScriptArguments { get; set; }
     }
 }

--- a/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
+++ b/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
         public string DestinationDir { get; set; }
 
+        public string BindPort { get; set; }
+
+        public string BuildImage { get; set; }
+
         public string PlatformName { get; set; }
 
         public string PlatformVersion { get; set; }

--- a/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
         {
             // "config.GetValue" call will get the most closest value provided based on the order of
             // configuration sources added to the ConfigurationBuilder above.
+            options.BindPort = this.GetStringValue(SettingsKeys.BindPort);
+            options.BuildImage = this.GetStringValue(SettingsKeys.BuildImage);
             options.PlatformName = this.GetStringValue(SettingsKeys.PlatformName);
             options.PlatformVersion = this.GetStringValue(SettingsKeys.PlatformVersion);
             options.RuntimePlatformName = this.GetStringValue(SettingsKeys.RuntimePlatformName);

--- a/src/BuildScriptGeneratorCli/SettingsKeys.cs
+++ b/src/BuildScriptGeneratorCli/SettingsKeys.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
 {
     public static class SettingsKeys
     {
+        public const string BindPort = "BIND_PORT";
+        public const string BuildImage = "BUILD_IMAGE";
         public const string PlatformName = "PLATFORM_NAME";
         public const string PlatformVersion = "PLATFORM_VERSION";
         public const string RuntimePlatformName = "RUNTIME_PLATFORM_NAME";

--- a/tests/BuildScriptGeneratorCli.Tests/DockerfileCommandTest.cs
+++ b/tests/BuildScriptGeneratorCli.Tests/DockerfileCommandTest.cs
@@ -64,5 +64,53 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
             Assert.False(isValidInput);
             Assert.Contains("Cannot use platform version without specifying platform name also.", testConsole.StdError);
         }
+
+        [Fact]
+        public void IsValidInput_IsFalse_WhenBindPortSpecified_NotInteger()
+        {
+            // Arrange
+            var invalidBindPort = "foo";
+            var dockerfileCommand = new DockerfileCommand { SourceDir = string.Empty, BindPort = invalidBindPort };
+            var testConsole = new TestConsole();
+
+            // Act
+            var isValidInput = dockerfileCommand.IsValidInput(null, testConsole);
+
+            // Assert
+            Assert.False(isValidInput);
+            Assert.Contains($"Provided bind port '{invalidBindPort}' is not valid.", testConsole.StdError);
+        }
+
+        [Fact]
+        public void IsValidInput_IsFalse_WhenBindPortSpecified_NotValidPort()
+        {
+            // Arrange
+            var invalidBindPort = "1000000";
+            var dockerfileCommand = new DockerfileCommand { SourceDir = string.Empty, BindPort = invalidBindPort };
+            var testConsole = new TestConsole();
+
+            // Act
+            var isValidInput = dockerfileCommand.IsValidInput(null, testConsole);
+
+            // Assert
+            Assert.False(isValidInput);
+            Assert.Contains($"Provided bind port '{invalidBindPort}' is not valid.", testConsole.StdError);
+        }
+
+        [Fact]
+        public void IsValidInput_IsFalse_WhenBuildImageSpecified_NotValid()
+        {
+            // Arrange
+            var invalidBuildImage = "build";
+            var dockerfileCommand = new DockerfileCommand { SourceDir = string.Empty, BuildImage = invalidBuildImage };
+            var testConsole = new TestConsole();
+
+            // Act
+            var isValidInput = dockerfileCommand.IsValidInput(null, testConsole);
+
+            // Assert
+            Assert.False(isValidInput);
+            Assert.Contains($"Provided build image must be in the format '<image>:<tag>'.", testConsole.StdError);
+        }
     }
 }


### PR DESCRIPTION
Resolves work item 1585919 -- adds `--build-image` and `--bind-port` arguments to the `oryx dockerfile` command to allow users to specify the build image and binding port, respectively, to the generated Dockerfile.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
~- [ ] Proper license headers are included in each file.~
