### PR TITLE
Bugfix: platform binaries job requires defaultVersion.txt file deletion

### DIFF
--- a/vsts/scripts/publishFilesToAzureStorage.sh
+++ b/vsts/scripts/publishFilesToAzureStorage.sh
@@ -41,7 +41,7 @@ uploadFiles() {
             checksum=$(sha256sum $fileToUpload | cut -d " " -f 1)
         fi
         
-        if shouldOverwriteSdk || shouldOverwritePlatformSdk $platform; then
+        if shouldOverwriteSdk || shouldOverwritePlatformSdk $platform || [[ "$fileToUpload" == defaultVersion* ]]; then
             az storage blob upload \
             --name $fileName \
             --file "$fileToUpload" \


### PR DESCRIPTION
This pull request should keep us from having to delete default version files when releasing platform binaries, as it will allow them to be overwritten.

Examples of the error this should resolve:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6534004&view=results
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6537900&view=results
