### PR TITLE
Verisign curl errors

### DIFF
--- a/images/build/Dockerfiles/gitHubActions.Dockerfile
+++ b/images/build/Dockerfiles/gitHubActions.Dockerfile
@@ -103,7 +103,8 @@ ARG AI_KEY
 COPY --from=intermediate /opt /opt
 
 # as per solution 2 https://stackoverflow.com/questions/65921037/nuget-restore-stopped-working-inside-docker-container
-RUN ${IMAGES_DIR}/retry.sh "curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates" \
+RUN ${IMAGES_DIR}/retry.sh "curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083" \
+    && update-ca-certificates \
     && echo "value of DEBIAN_FLAVOR is ${DEBIAN_FLAVOR}"
 
 # Install PHP pre-reqs	# Install PHP pre-reqs

--- a/images/build/Dockerfiles/ltsVersions.Dockerfile
+++ b/images/build/Dockerfiles/ltsVersions.Dockerfile
@@ -185,8 +185,9 @@ RUN set -ex \
     && rm -f /etc/apt/sources.list.d/buster.list \
     && echo "ltsversions" > /opt/oryx/.imagetype \
     && echo "DEBIAN|${DEBIAN_FLAVOR}" | tr '[a-z]' '[A-Z]' > /opt/oryx/.ostype \
-# as per solution 2 https://stackoverflow.com/questions/65921037/nuget-restore-stopped-working-inside-docker-container
-    && ${imagesDir}/retry.sh "curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates" \
+    # as per solution 2 https://stackoverflow.com/questions/65921037/nuget-restore-stopped-working-inside-docker-container
+    && ${imagesDir}/retry.sh "curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083" \
+    && update-ca-certificates \
     && echo "value of DEBIAN_FLAVOR is ${DEBIAN_FLAVOR}"
 
 ENTRYPOINT [ "benv" ]

--- a/images/build/Dockerfiles/ltsVersions.buster.Dockerfile
+++ b/images/build/Dockerfiles/ltsVersions.buster.Dockerfile
@@ -181,7 +181,8 @@ RUN set -ex \
     && echo "ltsversions" > /opt/oryx/.imagetype \
     && echo "DEBIAN|${DEBIAN_FLAVOR}" | tr '[a-z]' '[A-Z]' > /opt/oryx/.ostype \
     # as per solution 2 https://stackoverflow.com/questions/65921037/nuget-restore-stopped-working-inside-docker-container
-    && ${imagesDir}/retry.sh "curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates" \
+    && ${imagesDir}/retry.sh "curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083" \
+    && update-ca-certificates \
     && echo "value of DEBIAN_FLAVOR is ${DEBIAN_FLAVOR}"
 
 


### PR DESCRIPTION
Fixes the following errors, which occurred every time a github action or lts image is built, adding 1.25 minutes to each image build (adds up when building all images):
```
#16 [final 2/4] RUN /opt/tmp/images/retry.sh "curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates"     && echo "value of DEBIAN_FLAVOR is buster"
#16 sha256:e36fc93fac9f76672954859f38625137fcc21b1850f7d6b75c712c96a6d8d819
#16 0.354 retry 0
#16 0.885 curl: (6) Could not resolve host: &&
#16 5.153 curl: (6) Could not resolve host: update-ca-certificates
#16 5.154 error executing: curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates
#16 20.16 retry 1
#16 20.69 curl: (6) Could not resolve host: &&
#16 24.96 curl: (6) Could not resolve host: update-ca-certificates
#16 24.96 error executing: curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates
#16 39.97 retry 2
#16 40.51 curl: (6) Could not resolve host: &&
#16 44.58 curl: (6) Could not resolve host: update-ca-certificates
#16 44.58 error executing: curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates
#16 59.59 retry 3
#16 60.11 curl: (6) Could not resolve host: &&
#16 64.39 curl: (6) Could not resolve host: update-ca-certificates
#16 64.39 error executing: curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates
#16 79.40 retry 4
#16 79.94 curl: (6) Could not resolve host: &&
#16 84.01 curl: (6) Could not resolve host: update-ca-certificates
#16 84.01 error executing: curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates
#16 99.02 retry 5
#16 99.58 curl: (6) Could not resolve host: &&
#16 103.8 curl: (6) Could not resolve host: update-ca-certificates
#16 103.9 error executing: curl -o /usr/local/share/ca-certificates/verisign.crt -SsL https://crt.sh/?d=1039083 && update-ca-certificates
#16 118.9 value of DEBIAN_FLAVOR is buster
#16 DONE 118.9s
```

I also investigated whether we really need this (since its been broken for a while), and I _think_ we would be safe to remove if we want.

It was an issue prior to the following versions of .NET that prevented restores:
[.NET SDK 5.0.202](https://dotnet.microsoft.com/download/dotnet/5.0) -- April 6, 2021.
[.NET 6 Preview 3](https://dotnet.microsoft.com/download/dotnet/6.0) -- April 8, 2021.

According to https://github.com/NuGet/Announcements/issues/49 this has been resolved with an updated version of `ca-certificates`
Link to full context of issue: https://github.com/NuGet/Home/issues/10491

Let me know what you all think should be the correct move here. It seems to me like pulling and trusting an external cert from the internet seems risky.