### PR TITLE
Pauld/reduce cli test time

### DIFF
--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
@@ -62,6 +62,17 @@ namespace Microsoft.Oryx.BuildImage.Tests
         {
             BuildsApplication_ByDynamicallyInstallingSDKs(
                 appName, runtimeVersion, _imageHelper.GetCliImage());
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [InlineData(NetCoreApp21WebApp, "2.1")]
+        [InlineData(NetCoreApp31MvcApp, "3.1")]
+        [InlineData(NetCoreApp50MvcApp, "5.0")]
+        [InlineData(NetCore7PreviewMvcApp, "7.0.0-preview.7.22375.6")]
+        public void BuildsApplication_ByDynamicallyInstallingSDKs_CliBuster(
+            string appName,
+            string runtimeVersion)
+        {
             BuildsApplication_ByDynamicallyInstallingSDKs(
                 appName, runtimeVersion, _imageHelper.GetCliImage("cli-buster"));
         }

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
@@ -59,8 +59,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCli()
         {
             GDIPlusLibrary_IsPresentInTheImage("cli");
-            GDIPlusLibrary_IsPresentInTheImage("cli-buster");
             Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage());
+        }
+
+        [Fact, Trait("category", "cli-buster")]
+        public void PipelineTestInvocationCliBuster()
+        {
+            GDIPlusLibrary_IsPresentInTheImage("cli-buster");
             Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage("cli-buster"));
         }
 

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
@@ -36,13 +36,18 @@ namespace Microsoft.Oryx.BuildImage.Tests
             InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetGitHubActionsBuildImage());
         }
 
-        [Theory, Trait("category", "cli")]
-        [InlineData("cli")]
-        [InlineData("cli-buster")]
+        [Fact, Trait("category", "cli")]
         public void PipelineTestInvocationCli(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();
-            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(imageTag));
+            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage("cli"));
+        }
+
+        [Fact, Trait("category", "cli-buster")]
+        public void PipelineTestInvocationCliBuster()
+        {
+            var imageTestHelper = new ImageTestHelper();
+            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage("cli-buster"));
         }
 
         private void InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(string imageName)

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Fact, Trait("category", "cli")]
-        public void PipelineTestInvocationCli(string imageTag)
+        public void PipelineTestInvocationCli()
         {
             var imageTestHelper = new ImageTestHelper();
             InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage("cli"));

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
@@ -43,13 +43,18 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuilds(imageTestHelper.GetAzureFunctionsJamStackBuildImage());
         }
 
-        [Theory, Trait("category", "cli")]
-        [InlineData("cli")]
-        [InlineData("cli-buster")]
-        public void PipelineTestInvocationCli(string imageTag)
+        [Fact, Trait("category", "cli")]
+        public void PipelineTestInvocationCli()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(imageTag));
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage("cli"));
+        }
+
+        [Fact, Trait("category", "cli-buster")]
+        public void PipelineTestInvocationCliBuster()
+        {
+            var imageTestHelper = new ImageTestHelper();
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage("cli-buster"));
         }
 
         private void GeneratesScript_AndBuilds(string buildImageName)

--- a/tests/Oryx.BuildImage.Tests/Java/JavaDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Java/JavaDynamicInstallationTest.cs
@@ -48,6 +48,12 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void BuildsMavenArcheTypeSampleWithDynamicInstallationCli(string version)
         {
             BuildsMavenArcheTypeSampleWithDynamicInstallation(version, _imageHelper.GetCliImage());
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [MemberData(nameof(VersionsData))]
+        public void BuildsMavenArcheTypeSampleWithDynamicInstallationCliBuster(string version)
+        {
             BuildsMavenArcheTypeSampleWithDynamicInstallation(version, _imageHelper.GetCliImage("cli-buster"));
         }
 

--- a/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
@@ -35,8 +35,17 @@ namespace Microsoft.Oryx.BuildImage.Tests
 
         [Theory, Trait("category", "cli")]
         [InlineData("cli")]
-        [InlineData("cli-buster")]
         public void JavaSampleAppsTestsCli(string imageTag)
+        {
+            BuildsMavenArcheTypeSample(imageTag);
+            BuildsMavenJ2EESample(imageTag);
+            BuildsMavenSimpleJavaApp(imageTag);
+            BuildsSpringBootSampleApp(imageTag);
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [InlineData("cli-buster")]
+        public void JavaSampleAppsTestsCliBuster(string imageTag)
         {
             BuildsMavenArcheTypeSample(imageTag);
             BuildsMavenJ2EESample(imageTag);

--- a/tests/Oryx.BuildImage.Tests/Node/NodeDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeDynamicInstallationTest.cs
@@ -44,7 +44,16 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 data.Add("12.22.11", imageTestHelper.GetCliImage());
                 data.Add("14.19.1", imageTestHelper.GetCliImage());
                 data.Add("16.14.2", imageTestHelper.GetCliImage());
+                return data;
+            }
+        }
 
+        public static TheoryData<string, string> ImageNameDataCliBuster
+        {
+            get
+            {
+                var data = new TheoryData<string, string>();
+                var imageTestHelper = new ImageTestHelper();
                 data.Add("12.22.11", imageTestHelper.GetCliImage("cli-buster"));
                 data.Add("14.19.1", imageTestHelper.GetCliImage("cli-buster"));
                 data.Add("16.14.2", imageTestHelper.GetCliImage("cli-buster"));
@@ -62,6 +71,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Theory, Trait("category", "cli")]
         [MemberData(nameof(ImageNameDataCli))]
         public void GeneratesScript_AndBuildNodeAppsWithDynamicInstallationCli(string version, string buildImageName)
+        {
+            GeneratesScript_AndBuildNodeAppsWithDynamicInstallation(version, buildImageName);
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [MemberData(nameof(ImageNameDataCliBuster))]
+        public void GeneratesScript_AndBuildNodeAppsWithDynamicInstallationCliBuster(string version, string buildImageName)
         {
             GeneratesScript_AndBuildNodeAppsWithDynamicInstallation(version, buildImageName);
         }

--- a/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
@@ -49,13 +49,18 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuilds(imageTestHelper.GetAzureFunctionsJamStackBuildImage());
         }
 
-        [Theory, Trait("category", "cli")]
-        [InlineData("cli")]
-        [InlineData("cli-buster")]
-        public void PipelineTestInvocationCli(string imageTag)
+        [Fact, Trait("category", "cli")]
+        public void PipelineTestInvocationCli()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(imageTag));
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage("cli"));
+        }
+
+        [Fact, Trait("category", "cli-buster")]
+        public void PipelineTestInvocationCliBuster()
+        {
+            var imageTestHelper = new ImageTestHelper();
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage("cli-buster"));
         }
 
         private void GeneratesScript_AndBuilds(string buildImageName)

--- a/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
@@ -59,13 +59,25 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 var imageHelper = new ImageTestHelper();
                 data.Add(PhpVersions.Php73Version, imageHelper.GetCliImage(),PhpVersions.ComposerVersion);
                 data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(), PhpVersions.ComposerVersion);
+
+                // test latest php-composer version
+                data.Add(PhpVersions.Php73Version, imageHelper.GetCliImage(), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(), PhpVersions.Composer23Version);
+                return data;
+            }
+        }
+
+        public static TheoryData<string, string, string> VersionAndImageNameDataCliBuster
+        {
+            get
+            {
+                var data = new TheoryData<string, string, string>();
+                var imageHelper = new ImageTestHelper();
                 data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage("cli-buster"), PhpVersions.ComposerVersion);
                 data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage("cli-buster"), PhpVersions.ComposerVersion);
                 data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage("cli-buster"), PhpVersions.ComposerVersion);
 
                 // test latest php-composer version
-                data.Add(PhpVersions.Php73Version, imageHelper.GetCliImage(), PhpVersions.Composer23Version);
-                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(), PhpVersions.Composer23Version);
                 data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage("cli-buster"), PhpVersions.Composer23Version);
                 data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage("cli-buster"), PhpVersions.Composer23Version);
                 data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage("cli-buster"), PhpVersions.Composer23Version);
@@ -83,6 +95,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Theory, Trait("category", "cli")]
         [MemberData(nameof(VersionAndImageNameDataCli))]
         public void BuildsAppByInstallingSdkDynamicallyCli(string phpVersion, string imageName, string phpComposerVersion)
+        {
+            BuildsAppByInstallingSdkDynamically(phpVersion, imageName, phpComposerVersion, "/opt/php");
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [MemberData(nameof(VersionAndImageNameDataCliBuster))]
+        public void BuildsAppByInstallingSdkDynamicallyCliBuster(string phpVersion, string imageName, string phpComposerVersion)
         {
             BuildsAppByInstallingSdkDynamically(phpVersion, imageName, phpComposerVersion, "/opt/php");
         }

--- a/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
@@ -99,8 +99,17 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Theory, Trait("category", "cli")]
         [InlineData(PhpVersions.Php74Version, "cli")]
         [InlineData(PhpVersions.Php73Version, "cli")]
+        public void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation_Cli(string phpVersion, string imageTag) {
+            GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(phpVersion, imageTag);
+        }
+
+        [Theory, Trait("category", "cli-buster")]
         [InlineData(PhpVersions.Php80Version, "cli-buster")]
-        public void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(string phpVersion, string imageTag)
+        public void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation_CliBuster(string phpVersion, string imageTag) {
+            GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(phpVersion, imageTag);
+        }
+
+        private void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(string phpVersion, string imageTag)
         {
             // Arrange
             var appName = "twig-example";

--- a/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Oryx.BuildImage.Tests
             var imageTestHelper = new ImageTestHelper();
             GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(), "3.8.1", "/opt");
             GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(), "3.8.3", "/opt");
+        }
+
+        [Fact, Trait("category", "cli-buster")]
+        public void PipelineTestInvocationCliBuster()
+        {
+            var imageTestHelper = new ImageTestHelper();
             GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage("cli-buster"), "3.9.0", "/opt");
         }
 

--- a/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
@@ -58,8 +58,16 @@ namespace Microsoft.Oryx.BuildImage.Tests
 
         [Theory, Trait("category", "cli")]
         [InlineData("cli")]
-        [InlineData("cli-buster")]
         public void PipelineTestInvocationCli(string imageTag)
+        {
+            GeneratesScript_AndBuilds(_imageHelper.GetCliImage(imageTag));
+            JamSpell_CanBe_Installed_In_The_BuildImage(imageTag);
+            DoesNotGenerateCondaBuildScript_IfImageDoesNotHaveCondaInstalledInIt(imageTag);
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [InlineData("cli-buster")]
+        public void PipelineTestInvocationCliBuster(string imageTag)
         {
             GeneratesScript_AndBuilds(_imageHelper.GetCliImage(imageTag));
             JamSpell_CanBe_Installed_In_The_BuildImage(imageTag);

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
@@ -43,8 +43,18 @@ namespace Microsoft.Oryx.BuildImage.Tests
 
         [Theory, Trait("category", "cli")]
         [InlineData("cli")]
-        [InlineData("cli-buster")]
         public void PipelineTestInvocationCli(string imageTag)
+        {
+            var imageTestHelper = new ImageTestHelper();
+            GeneratesScript_AndBuildSinatraAppWithDynamicInstall(
+                RubyVersions.Ruby30Version, imageTestHelper.GetCliImage(imageTag));
+            GeneratesScript_AndBuildSinatraAppWithDynamicInstall(
+                RubyVersions.Ruby31Version, imageTestHelper.GetCliImage(imageTag));
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [InlineData("cli-buster")]
+        public void PipelineTestInvocationCliBuster(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();
             GeneratesScript_AndBuildSinatraAppWithDynamicInstall(

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
@@ -42,8 +42,17 @@ namespace Microsoft.Oryx.BuildImage.Tests
 
         [Theory, Trait("category", "cli")]
         [InlineData("cli")]
-        [InlineData("cli-buster")]
         public void PipelineTestInvocationCli(string imageTag)
+        {
+            var imageTestHelper = new ImageTestHelper();
+            Builds_JekyllStaticWebApp_UsingCustomBuildCommand(
+                imageTestHelper.GetCliImage(imageTag));
+            GeneratesScript_AndBuildRailsApp(imageTestHelper.GetCliImage(imageTag));
+        }
+
+        [Theory, Trait("category", "cli-buster")]
+        [InlineData("cli-buster")]
+        public void PipelineTestInvocationCliBuster(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();
             Builds_JekyllStaticWebApp_UsingCustomBuildCommand(

--- a/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
@@ -42,12 +42,16 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetLtsVersionsBuildImage());
         }
 
-        [Theory, Trait("category", "cli")]
-        [InlineData("cli")]
-        [InlineData("cli-buster")]
-        public void GeneratesScript_AndBuildGolangAppWithDynamicInstall_Cli(string imageTag)
+        [Fact, Trait("category", "cli")]
+        public void GeneratesScript_AndBuildGolangAppWithDynamicInstall_Cli()
         {
-            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(imageTag));
+            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage("cli"));
+        }
+
+        [Fact, Trait("category", "cli-buster")]
+        public void GeneratesScript_AndBuildGolangAppWithDynamicInstall_CliBuster()
+        {
+            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage("cli-buster"));
         }
 
         private void GeneratesScript_AndBuildGolangAppWithDynamicInstall(string imageName)

--- a/vsts/pipelines/nightly.yml
+++ b/vsts/pipelines/nightly.yml
@@ -24,6 +24,9 @@ parameters:
         key: Cli
         value: cli
       - 
+        key: CliBuster
+        value: cli-buster
+      - 
         key: Buildpack
         value: buildpack
 

--- a/vsts/pipelines/templates/_integrationJobTemplate.yml
+++ b/vsts/pipelines/templates/_integrationJobTemplate.yml
@@ -42,6 +42,7 @@ jobs:
     - Job_BuildImage_VsoFocal
     - Job_BuildImage_Full
     - Job_BuildImage_Cli
+    - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
   pool:
@@ -78,6 +79,7 @@ jobs:
     - Job_BuildImage_VsoFocal
     - Job_BuildImage_Full
     - Job_BuildImage_Cli
+    - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
     pool:
@@ -114,6 +116,7 @@ jobs:
     - Job_BuildImage_VsoFocal
     - Job_BuildImage_Full
     - Job_BuildImage_Cli
+    - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
     pool:
@@ -150,6 +153,7 @@ jobs:
     - Job_BuildImage_VsoFocal
     - Job_BuildImage_Full
     - Job_BuildImage_Cli
+    - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
     pool:
@@ -186,6 +190,7 @@ jobs:
     - Job_BuildImage_VsoFocal
     - Job_BuildImage_Full
     - Job_BuildImage_Cli
+    - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
     pool:
@@ -220,6 +225,7 @@ jobs:
     - Job_BuildImage_VsoFocal
     - Job_BuildImage_Full
     - Job_BuildImage_Cli
+    - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
   pool:
@@ -254,6 +260,7 @@ jobs:
     - Job_BuildImage_VsoFocal
     - Job_BuildImage_Full
     - Job_BuildImage_Cli
+    - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
   pool:

--- a/vsts/pipelines/validation.yml
+++ b/vsts/pipelines/validation.yml
@@ -24,6 +24,9 @@ parameters:
         key: Cli
         value: cli
       - 
+        key: CliBuster
+        value: cli-buster
+      - 
         key: Buildpack
         value: buildpack
 


### PR DESCRIPTION
The CLI tests introduced in https://github.com/microsoft/Oryx/pull/1492 have been taking about 20-30 min longer than the next longest category, increasing our validation and nightly tests by that length. This splits up those cli tests into 2 categories for the 2 different base OSs, which allows for parallelization
