### PR TITLE
Support ODBC Driver 17 and 18 side-by-side for Python runtimes

### DIFF
--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -48,6 +48,7 @@ apt-get update \
         apt-transport-https \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
+    && ACCEPT_EULA=Y apt-get install -y msodbcsql17 \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql18 \
     && ACCEPT_EULA=Y apt-get install -y mssql-tools18 \
     && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
@@ -61,6 +62,12 @@ cat >/etc/unixODBC/odbcinst.ini <<EOL
 [ODBC Driver 18 for SQL Server]
 Description=Microsoft ODBC Driver 18 for SQL Server
 Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.1.so.1.1
+Threading=1
+UsageCount=1
+
+[ODBC Driver 17 for SQL Server]
+Description=Microsoft ODBC Driver 17 for SQL Server
+Driver=/opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.2.so.0.1
 Threading=1
 UsageCount=1
 EOL


### PR DESCRIPTION
Python applications currently targeting the ODBC Driver 17 will report an error with the following message:

```
Raised exception caught:  ('01000', "[01000] [unixODBC][Driver Manager]Can't open lib 'ODBC Driver 17 for SQL Server' : file not found (0) (SQLDriverConnect)")
```

Allowing the ODBC Driver 17 and 18 to be installed side-by-side should enable users to target either version for their application.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
