### PR TITLE
Fixed cli image tags for release

### DIFF
--- a/vsts/scripts/tagCliImagesForRelease.sh
+++ b/vsts/scripts/tagCliImagesForRelease.sh
@@ -19,8 +19,8 @@ if [ -f "$outPmeFile" ]; then
     rm $outPmeFile
 fi
 
-cliImage="$sourceImageRepo/cli:$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
-cliBusterImage="$sourceImageRepo/cli-buster:$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
+cliImage="$sourceImageRepo/cli:debian-stretch-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
+cliBusterImage="$sourceImageRepo/cli-buster:debian-buster-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
 echo "Pulling CLI image '$cliImage'..."
 docker pull "$cliImage"
 


### PR DESCRIPTION
Looks like I forgot to add the image tags to a place in the cli script: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6657576&view=logs&j=45d131ba-c8ef-5a49-68f5-8267e94c7edc&t=950aea75-59fc-52c7-17ec-2351c2a24d85