### PR TITLE
Added Build Image tag for full-bullseye

### DIFF
--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -50,6 +50,7 @@ tagBuildImageForIntegrationTest "$imagefilter/build" "github-actions-debian-bust
 tagBuildImageForIntegrationTest "$imagefilter/build" "github-actions-debian-bullseye"
 tagBuildImageForIntegrationTest "$imagefilter/build" "vso-ubuntu-focal"
 tagBuildImageForIntegrationTest "$imagefilter/build" "full-debian-buster"
+tagBuildImageForIntegrationTest "$imagefilter/build" "full-debian-bullseye"
 tagBuildImageForIntegrationTest "$imagefilter/cli" "debian-stretch"
 tagBuildImageForIntegrationTest "$imagefilter/cli-buster" "debian-buster"
 tagBuildImageForIntegrationTest "$imagefilter/pack" ""

--- a/vsts/scripts/tagBuildImagesForRelease.sh
+++ b/vsts/scripts/tagBuildImagesForRelease.sh
@@ -57,6 +57,7 @@ tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:github-actions-debian-bus
 tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:github-actions-debian-bullseye-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "github-actions-debian-bullseye" "github-actions-debian-bullseye-$RELEASE_TAG_NAME"
 tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:vso-ubuntu-focal-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "vso-ubuntu-focal" "vso-ubuntu-focal-$RELEASE_TAG_NAME"
 tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:full-debian-buster-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "full-debian-buster" "full-debian-buster-$RELEASE_TAG_NAME"
+tagBuildImage "oryxdevmcr.azurecr.io/public/oryx/build:full-debian-bullseye-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "full-debian-bullseye" "full-debian-bullseye-$RELEASE_TAG_NAME"
 
 echo "printing pme tags from $outPmeFileMCR"
 cat $outPmeFileMCR


### PR DESCRIPTION
Looks like I missed these changes in - https://github.com/microsoft/Oryx/pull/1533 and build image tags for full-bullseye have not been released to https://mcr.microsoft.com/v2/oryx/build/tags/list