### PR TITLE
Bugfix: locked in the go sys/unix package

### DIFF
--- a/src/startupscriptgenerator/src/common/Gopkg.toml
+++ b/src/startupscriptgenerator/src/common/Gopkg.toml
@@ -41,6 +41,10 @@
   name = "github.com/spf13/afero"
   version = "=1.8.2"
 
+[[override]]
+  name = "golang.org/x/sys"
+  version = "=v0.0.0-20220908164124-27713097b956"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
+++ b/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
@@ -36,6 +36,10 @@
 [[override]]
   name = "github.com/spf13/afero"
   version = "=1.8.2"
+  
+[[override]]
+  name = "golang.org/x/sys"
+  version = "=v0.0.0-20220908164124-27713097b956"
 
 [prune]
   go-tests = true

--- a/src/startupscriptgenerator/src/node/Gopkg.toml
+++ b/src/startupscriptgenerator/src/node/Gopkg.toml
@@ -33,6 +33,10 @@
   name = "github.com/spf13/afero"
   version = "=1.8.2"
 
+[[override]]
+  name = "golang.org/x/sys"
+  version = "=v0.0.0-20220908164124-27713097b956"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/src/startupscriptgenerator/src/python/Gopkg.toml
+++ b/src/startupscriptgenerator/src/python/Gopkg.toml
@@ -33,6 +33,10 @@
   name = "github.com/spf13/afero"
   version = "=1.8.2"
 
+[[override]]
+  name = "golang.org/x/sys"
+  version = "=v0.0.0-20220908164124-27713097b956"
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
`testStartupScriptGenerators.sh` [fails in our pipelines](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6667762&view=logs&j=ce9f4668-24eb-5cfd-6098-e022b48f7cad&t=f7c6b046-0d39-5ecb-b6a3-37609ea07a09) and locally. 

Looks like [this commit](https://github.com/golang/sys/commit/aba9fc2a8ff2c9439446386f616b860442f0cf9a) was just pushed to the unix package a few hours ago, causing the issue. This locks the version in to before that change. We should probably eventually migrate from golang 1.15