### PR TITLE
Add metadata to runtime images needed for Oryx++ Builder

### DIFF
--- a/images/runtime/dotnetcore/template.Dockerfile
+++ b/images/runtime/dotnetcore/template.Dockerfile
@@ -23,6 +23,10 @@ ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 ENV DOTNET_VERSION=%DOTNET_VERSION%
 ENV ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS=true
 
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN echo $USER_DOTNET_AI_VERSION && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \

--- a/images/runtime/node/template.Dockerfile
+++ b/images/runtime/node/template.Dockerfile
@@ -19,6 +19,10 @@ FROM mcr.microsoft.com/oryx/base:%RUNTIME_BASE_IMAGE_TAG%
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 
 # Node wrapper is used to debug apps when node is executed indirectly, e.g. by npm.

--- a/images/runtime/php-fpm/template.Dockerfile
+++ b/images/runtime/php-fpm/template.Dockerfile
@@ -19,6 +19,10 @@ FROM mcr.microsoft.com/oryx/base:%RUNTIME_BASE_IMAGE_TAG%
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx
 

--- a/images/runtime/php/template.Dockerfile
+++ b/images/runtime/php/template.Dockerfile
@@ -21,6 +21,10 @@ FROM mcr.microsoft.com/oryx/base:%RUNTIME_BASE_IMAGE_TAG%
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && rm -rf /tmp/oryx \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -67,6 +67,10 @@ ENV PATH="/opt/python/%PYTHON_MAJOR_VERSION%/bin:${PATH}"
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
 
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN pip install --upgrade pip \
     && pip install gunicorn \

--- a/images/runtime/ruby/template.Dockerfile
+++ b/images/runtime/ruby/template.Dockerfile
@@ -28,6 +28,11 @@ ENV PATH="/opt/ruby/%RUBY_MAJOR_VERSION%/bin:${PATH}"
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
+
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 RUN ${IMAGES_DIR}/runtime/ruby/install-dependencies.sh
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \


### PR DESCRIPTION
In order for our runtime images to be used with the Oryx++ Builder, we need to add a piece of metadata and set an environment variable to each of our supported runtime images.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
