### PR TITLE
Added purge tasks for repos that now exist

### DIFF
--- a/acr-tasks/purge-dev-acr-tasks.sh
+++ b/acr-tasks/purge-dev-acr-tasks.sh
@@ -14,14 +14,14 @@ az acr task create --name weeklyBuildImagePurgeTask -r oryxdevmcr --cmd "$PURGE_
 PURGE_CMD="acr purge  --filter 'public/oryx/cli:.*'  --ago 30d --untagged"
 az acr task create --name weeklyCliImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
 
+PURGE_CMD="acr purge  --filter 'public/oryx/cli-buster:.*'  --ago 30d --untagged"
+az acr task create --name weeklyCliBusterImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
+
 PURGE_CMD="acr purge  --filter 'public/oryx/base:.*'  --ago 30d --untagged"
 az acr task create --name weeklyBaseImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
 
 PURGE_CMD="acr purge  --filter 'public/oryx/pack:.*'  --ago 30d --untagged"
 az acr task create --name weeklyBuildPackImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
-
-PURGE_CMD="acr purge  --filter 'public/oryx/pack-builder:.*'  --ago 30d --untagged"
-az acr task create --name weeklyPackBuilderImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
 
 PURGE_CMD="acr purge  --filter 'public/oryx/pack-stack-base:.*'  --ago 30d --untagged"
 az acr task create --name weeklyBuildPackStackBaseImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
@@ -37,3 +37,6 @@ az acr task create --name weeklyPhpImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CM
 
 PURGE_CMD="acr purge  --filter 'public/oryx/python:.*'  --ago 30d --untagged"
 az acr task create --name weeklyPythonImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
+
+PURGE_CMD="acr purge  --filter 'public/oryx/ruby:.*'  --ago 30d --untagged"
+az acr task create --name weeklyRubyImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null


### PR DESCRIPTION
I don't think this is being run by any automated process, so I will need to run this manually. I'm not sure whether the [task create](https://docs.microsoft.com/en-us/cli/azure/acr/task?view=azure-cli-latest#az-acr-task-create) is idempotent, so I'll comment out the other `az acr task create` calls before running it

Existing tasks https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/e13e3c2a-b6ed-4969-875a-28bec9f4513f/resourceGroups/oryx-automation/providers/Microsoft.ContainerRegistry/registries/oryxdevmcr/task