### PR TITLE
Lock in nuget version as 5.8 for security pipeline

### DIFF
--- a/vsts/pipelines/templates/_securityChecks.yml
+++ b/vsts/pipelines/templates/_securityChecks.yml
@@ -14,6 +14,10 @@ steps:
     debugMode: false
   condition: always()
 
+- task: NuGetToolInstaller@1
+  inputs:
+    versionSpec: 5.8.x
+
 - task: NuGetCommand@2
   displayName: 'Run "nuget restore" on Oryx solution'
   inputs:


### PR DESCRIPTION
Nuget task we have was upgraded from [2.208.1 here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6714555&view=logs&j=acfcedc3-2643-55ae-33a9-df8f603004bf&t=680e7a52-896b-50a4-bb45-195dfd1bc34f) to [2.10.0 here](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6719408&view=logs&j=acfcedc3-2643-55ae-33a9-df8f603004bf&t=680e7a52-896b-50a4-bb45-195dfd1bc34f). This for some reason downgrades nuget from 5.8 to 4.1

This change should lock us into using 5.8