### PR TITLE
Add performance flags to Python build script

### DIFF
--- a/platforms/python/prereqs/build.sh
+++ b/platforms/python/prereqs/build.sh
@@ -78,6 +78,8 @@ else
         --build=$(dpkg-architecture --query DEB_BUILD_GNU_TYPE) \
         --enable-loadable-sqlite-extensions \
         --enable-shared \
+	--enable-optimizations \
+	--with-lto \
         --with-system-expat \
         --with-system-ffi \
         --without-ensurepip


### PR DESCRIPTION
See https://docs.python.org/3/using/configure.html#performance-options

This enables PGO and LTO, which improves runtime performance by about 20%.

These flags are already enabled for "official" binaries from python.org.

It does also extend the build time by a couple of minutes, because it has to run the profiler to optimize the binary.