### PR TITLE
Improve CLI size: trim self-contained apps and migrate .NET 3.1 to 6 in pipelines

### DIFF
--- a/src/BuildScriptGenerator.Common/BuildScriptGenerator.Common.csproj
+++ b/src/BuildScriptGenerator.Common/BuildScriptGenerator.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Oryx.BuildScriptGenerator.Common</AssemblyName>
     <RootNamespace>Microsoft.Oryx.BuildScriptGenerator.Common</RootNamespace>
     <LangVersion>7.3</LangVersion>
@@ -11,6 +11,7 @@
     <AssemblyVersion>0.2</AssemblyVersion>
     <!-- Remove when proper XML documentation is added to the project. -->
     <DisableDocRequirement>true</DisableDocRequirement>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\..\CommonFiles\AssemblyVersion.proj" />

--- a/src/BuildScriptGenerator.Common/ProcessHelper.cs
+++ b/src/BuildScriptGenerator.Common/ProcessHelper.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Common
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "NoPlatformNeeded")]
         public static Process StartProcess(
             string fileName,
             IEnumerable<string> arguments,

--- a/src/BuildScriptGenerator/BuildScriptGenerator.csproj
+++ b/src/BuildScriptGenerator/BuildScriptGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Oryx.BuildScriptGenerator</AssemblyName>
     <RootNamespace>Microsoft.Oryx.BuildScriptGenerator</RootNamespace>
     <ApplicationIcon />
@@ -16,6 +16,7 @@
     <!-- Remove when proper XML documentation is added to the project. -->
     <DisableDocRequirement>true</DisableDocRequirement>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\..\CommonFiles\AssemblyVersion.proj" />

--- a/src/BuildScriptGenerator/BuildScriptGeneratorServiceCollectionExtensions.cs
+++ b/src/BuildScriptGenerator/BuildScriptGeneratorServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 // --------------------------------------------------------------------------------------------
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -17,6 +18,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 {
     public static class BuildScriptGeneratorServiceCollectionExtensions
     {
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "<Pending>")]
         public static IServiceCollection AddBuildScriptGeneratorServices(this IServiceCollection services)
         {
             services

--- a/src/BuildScriptGenerator/Node/NodeDependencyChecker.cs
+++ b/src/BuildScriptGenerator/Node/NodeDependencyChecker.cs
@@ -4,6 +4,7 @@
 // --------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Oryx.Common.Extensions;
@@ -28,6 +29,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
             this.logger = logger;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Using dynamic types might cause types or members to be removed by trimmer.", Justification = "<Pending>")]
         public IEnumerable<ICheckerMessage> CheckSourceRepo(ISourceRepo repo)
         {
             dynamic packageJson = NodePlatform.GetPackageJsonObject(repo, this.logger);

--- a/src/BuildScriptGenerator/Node/NodePackageScriptsChecker.cs
+++ b/src/BuildScriptGenerator/Node/NodePackageScriptsChecker.cs
@@ -4,6 +4,7 @@
 // --------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
@@ -38,6 +39,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
             return result;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Using dynamic types might cause types or members to be removed by trimmer.", Justification = "<Pending>")]
         public IEnumerable<ICheckerMessage> CheckSourceRepo(ISourceRepo repo)
         {
             // Installing packages globally is problematic only in the App Service envelope

--- a/src/BuildScriptGenerator/Node/NodePlatform.cs
+++ b/src/BuildScriptGenerator/Node/NodePlatform.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -143,6 +144,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
         }
 
         /// <inheritdoc/>
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Using dynamic types might cause types or members to be removed by trimmer.", Justification = "<Pending>")]
         public BuildScriptSnippet GenerateBashBuildScriptSnippet(
             BuildScriptGeneratorContext ctx,
             PlatformDetectorResult detectorResult)

--- a/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
+++ b/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RuntimeFrameworkVersion>3.1</RuntimeFrameworkVersion>
     <AssemblyName>GenerateBuildScript</AssemblyName>
     <RootNamespace>Microsoft.Oryx.BuildScriptGeneratorCli</RootNamespace>
@@ -15,6 +15,7 @@
     <HighEntropyVA>true</HighEntropyVA>
     <!-- Remove when proper XML documentation is added to the project. -->
     <DisableDocRequirement>true</DisableDocRequirement>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\..\CommonFiles\AssemblyVersion.proj" />
@@ -37,7 +38,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BuildScriptGenerator\BuildScriptGenerator.csproj" />
-    <ProjectReference Include="..\BuildServer\BuildServer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BuildServer/BuildServer.csproj
+++ b/src/BuildServer/BuildServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\build\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
@@ -11,6 +11,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- Remove when proper XML documentation is added to the project. -->
     <DisableDocRequirement>true</DisableDocRequirement>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Detector/Detector.csproj
+++ b/src/Detector/Detector.csproj
@@ -24,6 +24,7 @@
     <!-- Remove when proper XML documentation is added to the project. -->
     <DisableDocRequirement>true</DisableDocRequirement>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
   
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\detector\__detectorNugetPackagesVersions.props" />

--- a/src/Oryx.Common/Common.csproj
+++ b/src/Oryx.Common/Common.csproj
@@ -11,6 +11,7 @@
     <LangVersion>7.3</LangVersion>
     <!-- Remove when proper XML documentation is added to the project. -->
     <DisableDocRequirement>true</DisableDocRequirement>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
 

--- a/tests/BuildScriptGenerator.Common.Tests/BuildScriptGenerator.Common.Tests.csproj
+++ b/tests/BuildScriptGenerator.Common.Tests/BuildScriptGenerator.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Oryx.BuildScriptGenerator.Common.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
+++ b/tests/BuildScriptGenerator.Tests/BuildScriptGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/tests/BuildScriptGeneratorCli.Tests/BuildScriptGeneratorCli.Tests.csproj
+++ b/tests/BuildScriptGeneratorCli.Tests/BuildScriptGeneratorCli.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>

--- a/tests/BuildServer.Tests/BuildServer.Tests.csproj
+++ b/tests/BuildServer.Tests/BuildServer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- XML documentation not needed for test projects. -->
     <DisableDocRequirement>true</DisableDocRequirement>

--- a/tests/Detector.Tests/Detector.Tests.csproj
+++ b/tests/Detector.Tests/Detector.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Oryx.Detector.Tests</AssemblyName>
     <RootNamespace>Microsoft.Oryx.Detector.Tests</RootNamespace>

--- a/tests/Oryx.BuildImage.Tests/Oryx.BuildImage.Tests.csproj
+++ b/tests/Oryx.BuildImage.Tests/Oryx.BuildImage.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AssemblyOriginatorKeyFile>..\..\build\TestAssembliesKey.snk</AssemblyOriginatorKeyFile>

--- a/tests/Oryx.Common.Tests/Common.Tests.csproj
+++ b/tests/Oryx.Common.Tests/Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Oryx.Common.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Oryx.Integration.Tests/Oryx.Integration.Tests.csproj
+++ b/tests/Oryx.Integration.Tests/Oryx.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	  <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
+++ b/tests/Oryx.RuntimeImage.Tests/Oryx.RuntimeImage.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/tests/Oryx.Tests.Common/Oryx.Tests.Common.csproj
+++ b/tests/Oryx.Tests.Common/Oryx.Tests.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Oryx.Tests.Common</RootNamespace>
     <AssemblyName>Microsoft.Oryx.Tests.Common</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\build\TestAssembliesKey.snk</AssemblyOriginatorKeyFile>

--- a/vsts/pipelines/autoUpdater.yml
+++ b/vsts/pipelines/autoUpdater.yml
@@ -6,9 +6,9 @@ steps:
   clean: true
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 3.1.x'
+  displayName: 'Use .NET Core sdk 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection - OSS Compliance'

--- a/vsts/pipelines/copyAllBlobsToProd.yml
+++ b/vsts/pipelines/copyAllBlobsToProd.yml
@@ -32,9 +32,9 @@ jobs:
           ignoreDirectories: '$(Build.SourcesDirectory)/tests'
 
       - task: UseDotNet@2
-        displayName: 'Use .NET Core sdk 3.1.x'
+        displayName: 'Use .NET Core sdk 6.x'
         inputs:
-          version: 3.1.x
+          version: 6.x
 
       - task: ShellScript@2
         displayName: 'Copy all blobs from a source storage account to the prod storage account'

--- a/vsts/pipelines/copySdksFromProdToStorageAccount.yml
+++ b/vsts/pipelines/copySdksFromProdToStorageAccount.yml
@@ -27,9 +27,9 @@ jobs:
           ignoreDirectories: '$(Build.SourcesDirectory)/tests'
 
       - task: UseDotNet@2
-        displayName: 'Use .NET Core sdk 3.1.x'
+        displayName: 'Use .NET Core sdk 6.x'
         inputs:
-          version: 3.1.x
+          version: 6.x
 
       - task: ShellScript@2
         displayName: 'Copy SDKs from the prod storage account to a destination storage account'

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -40,9 +40,9 @@ steps:
     startsWith(variables['Build.SourceBranch'],'refs/heads/exp/')))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 3.1.x'
+  displayName: 'Use .NET Core sdk 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - script: |
     dotnet --version && dotnet msbuild -version && echo

--- a/vsts/pipelines/templates/_buildTemplateDetector.yml
+++ b/vsts/pipelines/templates/_buildTemplateDetector.yml
@@ -3,9 +3,9 @@ steps:
   clean: true
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.1.x'
+  displayName: 'Use .NET Core SDK 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - task: ShellScript@2
   displayName: 'Build Detector.sln'

--- a/vsts/pipelines/templates/_integrationJobTemplate.yml
+++ b/vsts/pipelines/templates/_integrationJobTemplate.yml
@@ -306,9 +306,9 @@ jobs:
     skipComponentGovernanceDetection: true
   steps:
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 3.1.x'
+    displayName: 'Use .NET Core sdk 6.x'
     inputs:
-      version: 3.1.x
+      version: 6.x
   - task: ShellScript@2
     displayName: 'Test Dev storage account'
     env:

--- a/vsts/pipelines/templates/_platformBinariesReleaseTemplate.yml
+++ b/vsts/pipelines/templates/_platformBinariesReleaseTemplate.yml
@@ -27,9 +27,9 @@ steps:
     args: ${{ parameters.destinationSdkStorageAccountName }}
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.1.x'
+  displayName: 'Use .NET Core SDK 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - task: ShellScript@2
   displayName: 'Test Dev storage account'

--- a/vsts/pipelines/templates/_platformBinariesTemplate.yml
+++ b/vsts/pipelines/templates/_platformBinariesTemplate.yml
@@ -13,9 +13,9 @@ steps:
     ignoreDirectories: '$(Build.SourcesDirectory)/tests'
     
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 3.1.x'
+  displayName: 'Use .NET Core sdk 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - task: ShellScript@2
   displayName: 'Building platform binaries'

--- a/vsts/pipelines/templates/_releaseStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseStepTemplate.yml
@@ -103,9 +103,9 @@ steps:
   condition: and(succeeded(), eq(variables['ReleaseBuildImages'], 'true'))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 3.1.x'
+  displayName: 'Use .NET Core sdk 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - task: ShellScript@2
   displayName: 'Test runtime images for pme staging registry'

--- a/vsts/pipelines/templates/_securityChecks.yml
+++ b/vsts/pipelines/templates/_securityChecks.yml
@@ -14,6 +14,12 @@ steps:
     debugMode: false
   condition: always()
 
+- task: NuGetToolInstaller@1
+  displayName: 'Install NuGet >=6.3.0-0'
+  inputs:
+    versionSpec: '>=6.3.0-0'
+    checkLatest: true
+
 - task: NuGetCommand@2
   displayName: 'Run "nuget restore" on Oryx solution'
   inputs:

--- a/vsts/pipelines/templates/_signBinary.yml
+++ b/vsts/pipelines/templates/_signBinary.yml
@@ -32,9 +32,9 @@ steps:
   condition: and(succeeded(), eq(variables['setSignTypeVariable.SignType'], 'real'))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 3.1.x'
+  displayName: 'Use .NET Core sdk 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - powershell: |
     Write-Host "Setting up git_commit and build_number as env variable"

--- a/vsts/pipelines/templates/_signBinaryDetector.yml
+++ b/vsts/pipelines/templates/_signBinaryDetector.yml
@@ -13,9 +13,9 @@ steps:
     signType: 'Real'
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.1.x'
+  displayName: 'Use .NET Core SDK 6.x'
   inputs:
-    version: 3.1.x
+    version: 6.x
 
 - powershell: |
     Write-Host "Setting up git_commit and build_number as env variable"


### PR DESCRIPTION
Improve Oryx CLI size by adding trimming option to .csproj and migrate .NET Core 3.1 to .NET 6 for apps and pipelines.
The size of output folder **/opt/buildscriptgen** where project binaries published:
104MB -> 63MB

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
