### PR TITLE
Split Python integration tests, remove Ruby from integration test job

### DIFF
--- a/tests/Oryx.Integration.Tests/Python/Python37EndToEndTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/Python37EndToEndTests.cs
@@ -15,7 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
+    [Trait("category", "python-37")]
     public class Python37EndToEndTests : PythonEndToEndTestsBase
     {
         public Python37EndToEndTests(ITestOutputHelper output, TestTempDirTestFixture testTempDirTestFixture)

--- a/tests/Oryx.Integration.Tests/Python/PythonBackwardCompatibilityTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonBackwardCompatibilityTests.cs
@@ -12,7 +12,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonBackwardCompatibilityTests : PythonEndToEndTestsBase
     {
         public PythonBackwardCompatibilityTests(ITestOutputHelper output, TestTempDirTestFixture testTempDirTestFixture)
@@ -21,6 +20,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact]
+        [Trait("category", "python-37")]
         public async Task CanRunPythonApp_UsingEarlierBuiltPackagesDirectoryAsync()
         {
             // This is AppService's scenario where previously built apps can still run
@@ -77,6 +77,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact]
+        [Trait("category", "python-37")]
         public async Task CanRunPythonApp_WithoutBuildManifestFileAsync()
         {
             // This is AppService's scenario where previously built apps can still run

--- a/tests/Oryx.Integration.Tests/Python/PythonCustomStartUpCommandTest.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonCustomStartUpCommandTest.cs
@@ -12,7 +12,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonCustomStartUpCommandTest : PythonEndToEndTestsBase
     {
         public PythonCustomStartUpCommandTest(ITestOutputHelper output, TestTempDirTestFixture testTempDirTestFixture)
@@ -21,6 +20,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
+        [Trait("category", "python-38")]
         [InlineData("3.8")]
         public async Task CanBuildAndRunPythonApp_UsingCustomStartUpScriptAsync(string pythonVersion)
         {
@@ -71,6 +71,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
+        [Trait("category", "python-38")]
         [InlineData("3.8")]
         public async Task CanBuildAndRunPythonApp_UsingCustomStartUpCommandAsync(string pythonVersion)
         {

--- a/tests/Oryx.Integration.Tests/Python/PythonDebuggingTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonDebuggingTests.cs
@@ -13,7 +13,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonDebuggingTests : PythonEndToEndTestsBase
     {
         private const int DefaultDebuggerPort = 5678;
@@ -24,6 +23,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
+        [Trait("category", "python-37")]
         [InlineData("3.7", 5637)] // Test with a non-default port as well
         public async Task CanBuildAndDebugFlaskAppAsync(string pythonVersion, int? debugPort = null)
         {
@@ -65,6 +65,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
+        [Trait("category", "python-37")]
         [InlineData("3.7", 5637)] // Test with a non-default port as well
         public async Task CanBuildAndDebugFlaskAppWithDebugPyAsync(string pythonVersion, int? debugPort = null)
         {

--- a/tests/Oryx.Integration.Tests/Python/PythonDjangoAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonDjangoAppTests.cs
@@ -13,7 +13,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonDjangoAppTests : PythonEndToEndTestsBase
     {
         public PythonDjangoAppTests(ITestOutputHelper output, TestTempDirTestFixture fixture)
@@ -22,6 +21,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact]
+        [Trait("category", "python-37")]
         public async Task CanBuildAndRun_MultiPlatformApp_HavingReactAndDjangoAsync()
         {
             // Arrange

--- a/tests/Oryx.Integration.Tests/Python/PythonDynamicInstallationTest.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonDynamicInstallationTest.cs
@@ -6,14 +6,12 @@
 using System.Threading.Tasks;
 using Microsoft.Oryx.BuildScriptGenerator.Common;
 using Microsoft.Oryx.BuildScriptGenerator.Python;
-using Microsoft.Oryx.BuildScriptGeneratorCli;
 using Microsoft.Oryx.Tests.Common;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonDynamicInstallationTest : PythonEndToEndTestsBase
     {
         private readonly string DefaultSdksRootDir = "/opt/python";
@@ -23,11 +21,60 @@ namespace Microsoft.Oryx.Integration.Tests
         {
         }
 
-        [Theory(Skip = "Temporarily skip, Bug#1266781")]
-        [InlineData("3.7")]
-        [InlineData("3.8")]
-        [InlineData("3.9")]
-        public async Task CanBuildAndRunPythonAppAsync(string pythonVersion)
+        [Fact]
+        [Trait("category", "python-37")]
+        public async Task RunPython37IntegrationTests()
+        {
+            // Temporarily skip - Bug #1266781
+            // await CanBuildAndRunPythonAppAsync("3.7");
+
+            // Temporarily skip - Bug #1410367
+            // await CanBuildAndRunPythonApp_UsingGitHubActionsBuildImage_AndDynamicRuntimeInstallationAsync("PythonVersions.Python37Version");
+
+            await CanBuildAndRunPythonApp_UsingScriptCommandAndSetEnvSwitchAsync();
+
+            // Temporarily skip - Bug #1266781
+            // await CanBuildAndRunPythonAppWhenUsingPackageDirSwitchAsync(true);
+            // await CanBuildAndRunPythonAppWhenUsingPackageDirSwitchAsync(false);
+        }
+
+        [Fact]
+        [Trait("category", "python-38")]
+        public async Task RunPython38IntegrationTests()
+        {
+            // Temporarily skip - Bug #1266781
+            // await CanBuildAndRunPythonAppAsync("3.8");
+
+            // Temporarily skip - Bug #1410367
+            // await CanBuildAndRunPythonApp_UsingGitHubActionsBuildImage_AndDynamicRuntimeInstallationAsync("PythonVersions.Python38Version");
+        }
+
+        [Fact]
+        [Trait("category", "python-39")]
+        public async Task RunPython39IntegrationTests()
+        {
+            // Temporarily skip - Bug #1266781
+            // await CanBuildAndRunPythonAppAsync("3.9");
+
+            // Temporarily skip - Bug #1410367
+            // await CanBuildAndRunPythonApp_UsingGitHubActionsBuildImage_AndDynamicRuntimeInstallationAsync("PythonVersions.Python39Version");
+        }
+
+        [Fact]
+        [Trait("category", "python-310")]
+        public async Task RunPython310IntegrationTests()
+        {
+            await CanBuildAndRunPythonApp_UsingGitHubActionsBullseyeBuildImage_AndDynamicRuntimeInstallationAsync("3.10");
+        }
+
+        [Fact]
+        [Trait("category", "python-311")]
+        public async Task RunPython311IntegrationTests()
+        {
+            await CanBuildAndRunPythonApp_UsingGitHubActionsBullseyeBuildImage_AndDynamicRuntimeInstallationAsync("3.11");
+        }
+
+        private async Task CanBuildAndRunPythonAppAsync(string pythonVersion)
         {
             // Arrange
             var appName = "flask-app";
@@ -66,12 +113,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Theory (Skip = "Bug 1410367")]
-        [InlineData("3")]
-        [InlineData(PythonVersions.Python37Version)]
-        [InlineData(PythonVersions.Python38Version)]
-        [InlineData(PythonVersions.Python39Version)]
-        public async Task CanBuildAndRunPythonApp_UsingGitHubActionsBuildImage_AndDynamicRuntimeInstallationAsync(
+        private async Task CanBuildAndRunPythonApp_UsingGitHubActionsBuildImage_AndDynamicRuntimeInstallationAsync(
             string pythonVersion)
         {
             // Arrange
@@ -109,10 +151,8 @@ namespace Microsoft.Oryx.Integration.Tests
                     Assert.Contains("Hello World!", data);
                 });
         }
-        [Theory]
-        [InlineData("3.10")]
-        [InlineData("3.11")]
-        public async Task CanBuildAndRunPythonApp_UsingGitHubActionsBullseyeBuildImage_AndDynamicRuntimeInstallationAsync(
+
+        private async Task CanBuildAndRunPythonApp_UsingGitHubActionsBullseyeBuildImage_AndDynamicRuntimeInstallationAsync(
             string pythonVersion)
         {
             // Arrange
@@ -160,8 +200,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Fact]
-        public async Task CanBuildAndRunPythonApp_UsingScriptCommandAndSetEnvSwitchAsync()
+        private async Task CanBuildAndRunPythonApp_UsingScriptCommandAndSetEnvSwitchAsync()
         {
             // Arrange
             var pythonVersion = "3.7";
@@ -210,10 +249,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Theory(Skip = "Temporarily skip, Bug#1266781")]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task CanBuildAndRunPythonAppWhenUsingPackageDirSwitchAsync(bool compressDestinationDir)
+        private async Task CanBuildAndRunPythonAppWhenUsingPackageDirSwitchAsync(bool compressDestinationDir)
         {
             // Arrange
             var pythonVersion = "3.7";

--- a/tests/Oryx.Integration.Tests/Python/PythonEndToEndTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonEndToEndTests.cs
@@ -13,7 +13,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonEndToEndTests : PythonEndToEndTestsBase
     {
         public PythonEndToEndTests(ITestOutputHelper output, TestTempDirTestFixture testTempDirTestFixture)
@@ -22,6 +21,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact]
+        [Trait("category", "python-37")]
         public async Task CanBuildAndRun_Tweeter3AppAsync()
         {
             // Arrange
@@ -66,6 +66,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory]
+        [Trait("category", "python-37")]
         [InlineData("3.7")]
         public async Task BuildWithVirtualEnv_RemovesOryxPackagesDir_FromOlderBuildAsync(string pythonVersion)
         {
@@ -119,11 +120,21 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        
-        [Theory (Skip = "Bug 1410367")]
-        [InlineData("3.7")]
-        [InlineData("3.8")]
-        public async Task BuildWithVirtualEnv_From_File_Requirement_TxtAsync(string pythonVersion)
+        [Fact(Skip = "Bug #1410367")]
+        [Trait("category", "python-37")]
+        public async Task BuildWithVirtualEnv_From_File_Requirement_TxtAsync_WithPython37()
+        {
+            await BuildWithVirtualEnv_From_File_Requirement_TxtAsync("3.7");
+        }
+
+        [Fact(Skip = "Bug #1410367")]
+        [Trait("category", "python-38")]
+        public async Task BuildWithVirtualEnv_From_File_Requirement_TxtAsync_WithPython38()
+        {
+            await BuildWithVirtualEnv_From_File_Requirement_TxtAsync("3.8");
+        }
+
+        private async Task BuildWithVirtualEnv_From_File_Requirement_TxtAsync(string pythonVersion)
         {
              // This is to test if we can build and run an app when both the files requirement.txt 
              // and setup.py are provided, we tend to prioritize the root level requirement.txt
@@ -162,7 +173,8 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Fact(Skip = "Bug 1410367") ]
+        [Fact(Skip = "Bug #1410367") ]
+        [Trait("category", "python-38")]
         public async Task CanBuildAndRunPythonApp_UsingOutputDirectory_NestedUnderSourceDirectoryAsync()
         {
             // Arrange
@@ -205,7 +217,8 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Fact (Skip = "Bug 1410367")]
+        [Fact (Skip = "Bug #1410367")]
+        [Trait("category", "python-38")]
         public async Task CanBuildAndRunPythonApp_UsingIntermediateDir_AndNestedOutputDirectoryAsync()
         {
             // Arrange

--- a/tests/Oryx.Integration.Tests/Python/PythonGunicornMultiWorkersTest.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonGunicornMultiWorkersTest.cs
@@ -11,7 +11,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonGunicornMultiWorkersTest : PythonEndToEndTestsBase
     {
         public PythonGunicornMultiWorkersTest(ITestOutputHelper output, TestTempDirTestFixture testTempDirTestFixture)
@@ -20,6 +19,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact(Skip = "work item #1122020")]
+        [Trait("category", "python-37")]
         public async Task CanBuildAndRunPythonApp_UsingGunicornMultipleWorkersAsync()
         {
             // Arrange

--- a/tests/Oryx.Integration.Tests/Python/PythonMySqlIntegrationTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonMySqlIntegrationTests.cs
@@ -11,7 +11,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     [Trait("db", "mysql")]
     public class PythonMySqlIntegrationTests : DatabaseTestsBase, IClassFixture<Fixtures.MySqlDbContainerFixture>
     {
@@ -21,6 +20,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory(Skip = "Bug 1410367") ]
+        [Trait("category", "python-37")]
         [InlineData("mysql-pymysql-sample", ImageTestHelperConstants.LatestStretchTag)]
         [InlineData("mysql-pymysql-sample", ImageTestHelperConstants.GitHubActionsStretch)]
         [InlineData("mysql-mysqlconnector-sample", ImageTestHelperConstants.LatestStretchTag)]
@@ -39,6 +39,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory(Skip = "Bug 1410367") ]
+        [Trait("category", "python-39")]
         [InlineData("mysql-pymysql-sample", ImageTestHelperConstants.GitHubActionsBuster)]
         [InlineData("mysql-mysqlconnector-sample", ImageTestHelperConstants.GitHubActionsBuster)]
         [InlineData("mysql-mysqlclient-sample", ImageTestHelperConstants.GitHubActionsBuster)]

--- a/tests/Oryx.Integration.Tests/Python/PythonPortEnvironmentVariableTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonPortEnvironmentVariableTests.cs
@@ -12,7 +12,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonPortEnvironmentVariableTests : PythonEndToEndTestsBase
     {
         public PythonPortEnvironmentVariableTests(ITestOutputHelper output, TestTempDirTestFixture fixture)
@@ -21,6 +20,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact]
+        [Trait("category", "python-37")]
         public async Task PythonStartupScript_UsesPortEnvironmentVariableValueAsync()
         {
             // Arrange
@@ -74,6 +74,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact]
+        [Trait("category", "python-37")]
         public async Task PythonStartupScript_UsesSuppliedBindingPort_EvenIfPortEnvironmentVariableValue_IsPresentAsync()
         {
             // Arrange

--- a/tests/Oryx.Integration.Tests/Python/PythonPostgreSqlIntegrationTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonPostgreSqlIntegrationTests.cs
@@ -11,7 +11,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     [Trait("db", "postgres")]
     public class PythonPostgreSqlIntegrationTests : DatabaseTestsBase, IClassFixture<Fixtures.PostgreSqlDbContainerFixture>
     {
@@ -21,6 +20,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory(Skip = "Bug 1410367") ]
+        [Trait("category", "python-37")]
         [InlineData(ImageTestHelperConstants.GitHubActionsStretch)]
         [InlineData(ImageTestHelperConstants.GitHubActionsBuster)]
         [InlineData(ImageTestHelperConstants.LatestStretchTag)]

--- a/tests/Oryx.Integration.Tests/Python/PythonPreRunCommandOrScriptTest.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonPreRunCommandOrScriptTest.cs
@@ -15,7 +15,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonPreRunCommandOrScriptTest : PythonEndToEndTestsBase
     {
         private readonly string RunScriptPath = "/tmp/startup.sh";
@@ -27,7 +26,8 @@ namespace Microsoft.Oryx.Integration.Tests
         {
         }
 
-        [Fact(Skip = "Bug 1410367") ]
+        [Fact(Skip = "Bug 1410367")]
+        [Trait("category", "python-37")]
         public async Task CanBuildAndRunPythonApp_UsingPreRunCommand_WithDynamicInstallAsync()
         {
             // Arrange
@@ -86,6 +86,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact(Skip = "Bug 1410367") ]
+        [Trait("category", "python-37")]
         public async Task CanBuildAndRunPythonApp_UsingPreRunScript_WithDynamicInstallAsync()
         {
             // Arrange
@@ -151,6 +152,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact (Skip = "Bug 1410367")]
+        [Trait("category", "python-38")]
         public async Task CanRunApp_UsingPreRunCommand_FromBuildEnvFileAsync()
         {
             // Arrange

--- a/tests/Oryx.Integration.Tests/Python/PythonShapelyAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonShapelyAppTests.cs
@@ -12,7 +12,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     public class PythonShapelyAppTests : PythonEndToEndTestsBase
     {
         public PythonShapelyAppTests(ITestOutputHelper output, TestTempDirTestFixture fixture)
@@ -20,9 +19,31 @@ namespace Microsoft.Oryx.Integration.Tests
         {
         }
 
-        [Theory]
-        [MemberData(nameof(TestValueGenerator.GetPythonVersions), MemberType = typeof(TestValueGenerator))]
-        public async Task CanBuildAndRun_ShapelyFlaskApp_UsingVirtualEnvAsync(string pythonVersion)
+        [Fact]
+        [Trait("category", "python-37")]
+        public async Task RunPython37ShapelyAppTests()
+        {
+            await CanBuildAndRun_ShapelyFlaskApp_UsingVirtualEnvAsync("3.7");
+            await CanBuildAndRun_ShapelyFlaskApp_PackageDirAsync("3.7");
+        }
+
+        [Fact]
+        [Trait("category", "python-38")]
+        public async Task RunPython38ShapelyAppTests()
+        {
+            await CanBuildAndRun_ShapelyFlaskApp_UsingVirtualEnvAsync("3.8");
+            await CanBuildAndRun_ShapelyFlaskApp_PackageDirAsync("3.8");
+        }
+
+        [Fact]
+        [Trait("category", "python-39")]
+        public async Task RunPython39ShapelyAppTests()
+        {
+            await CanBuildAndRun_ShapelyFlaskApp_UsingVirtualEnvAsync("3.9");
+            await CanBuildAndRun_ShapelyFlaskApp_PackageDirAsync("3.9");
+        }
+
+        private async Task CanBuildAndRun_ShapelyFlaskApp_UsingVirtualEnvAsync(string pythonVersion)
         {
             // Arrange
             var appName = "shapely-flask-app";
@@ -65,9 +86,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 });
         }
 
-        [Theory]
-        [MemberData(nameof(TestValueGenerator.GetPythonVersions), MemberType = typeof(TestValueGenerator))]
-        public async Task CanBuildAndRun_ShapelyFlaskApp_PackageDirAsync(string pythonVersion)
+        private async Task CanBuildAndRun_ShapelyFlaskApp_PackageDirAsync(string pythonVersion)
         {
             // Arrange
             const string packageDir = "orx_packages";

--- a/tests/Oryx.Integration.Tests/Python/PythonSqlServerIntegrationTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonSqlServerIntegrationTests.cs
@@ -15,7 +15,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Oryx.Integration.Tests
 {
-    [Trait("category", "python")]
     [Trait("db", "sqlserver")]
     public class PythonSqlServerIntegrationTests : PlatformEndToEndTestsBase
     {
@@ -27,6 +26,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Theory(Skip = "Bug #1274414")]
+        [Trait("category", "python-37")]
         [InlineData(ImageTestHelperConstants.GitHubActionsStretch)]
         [InlineData(ImageTestHelperConstants.GitHubActionsBuster)]
         [InlineData(ImageTestHelperConstants.LatestStretchTag)]

--- a/vsts/pipelines/templates/_integrationJobTemplate.yml
+++ b/vsts/pipelines/templates/_integrationJobTemplate.yml
@@ -2,6 +2,14 @@ parameters:
   - name: storageAccountUrl
     type: string
     default: https://oryxsdksdev.blob.core.windows.net
+  - name: pythonVersions
+    type: object
+    default:
+      - 37
+      - 38
+      - 39
+      - 310
+      - 311
   - name: nodeVersions
     type: object
     default:
@@ -35,9 +43,11 @@ parameters:
     default:
       - full
 jobs:
-- job: Job_PythonIntegrationTests
-  displayName: Run Python Integration Tests
-  dependsOn:
+# Python integration tests
+- ${{ each pythonVersion in parameters.pythonVersions }}:
+  - job:
+    displayName: 'Run Python ${{ pythonVersion }} Integration Tests'
+    dependsOn:
     - Job_BuildImage_Latest
     - Job_BuildImage_LtsVersions
     - Job_BuildImage_Jamstack
@@ -48,28 +58,28 @@ jobs:
     - Job_BuildImage_CliBuster
     - Job_BuildImage_Buildpack
     - Job_RuntimeImages
-  pool:
-    name: AzurePipelines-EO
-    demands:
-      - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
-  timeoutInMinutes: 300
-  variables:
-    skipComponentGovernanceDetection: true
-  steps:
-  - script: |
-      echo "##vso[task.setvariable variable=BuildBuildImages;]false"
-      echo "##vso[task.setvariable variable=BuildRuntimeImages;]false"
-      echo "##vso[task.setvariable variable=TestBuildImages;]false"
-      echo "##vso[task.setvariable variable=TestRuntimeImages;]false"
-      echo "##vso[task.setvariable variable=TestIntegrationCaseFilter;]category=python"
-      echo "##vso[task.setvariable variable=TestIntegration;]true"
-      echo "##vso[task.setvariable variable=PushBuildImages;]false"
-      echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
-      echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]false"
-      echo "##vso[task.setvariable variable=storageAccountUrl;]${{ parameters.storageAccountUrl }}"
-    displayName: 'Set variables'
-  - template: _setReleaseTag.yml
-  - template: _buildTemplate.yml
+    pool:
+      name: AzurePipelines-EO
+      demands:
+        - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+    variables:
+      skipComponentGovernanceDetection: true
+    timeoutInMinutes: 300
+    steps:
+        - script: |
+            echo "##vso[task.setvariable variable=BuildBuildImages;]false"
+            echo "##vso[task.setvariable variable=BuildRuntimeImages;]false"
+            echo "##vso[task.setvariable variable=TestBuildImages;]false"
+            echo "##vso[task.setvariable variable=TestRuntimeImages;]false"
+            echo "##vso[task.setvariable variable=TestIntegrationCaseFilter;]category=python-${{ pythonVersion }}"
+            echo "##vso[task.setvariable variable=TestIntegration;]true"
+            echo "##vso[task.setvariable variable=PushBuildImages;]false"
+            echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
+            echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]false"
+            echo "##vso[task.setvariable variable=storageAccountUrl;]${{ parameters.storageAccountUrl }}"
+          displayName: 'Set variables'
+        - template: _setReleaseTag.yml
+        - template: _buildTemplate.yml
 
 # DotNetCore integration tests
 - ${{ each dotNetCoreVersion in parameters.dotNetCoreVersions }}:
@@ -223,42 +233,6 @@ jobs:
           displayName: 'Set variables'
         - template: _setReleaseTag.yml
         - template: _buildTemplate.yml
-
-- job: Job_RubyIntegrationTests
-  displayName: Run Ruby Integration Tests
-  dependsOn:
-    - Job_BuildImage_Latest
-    - Job_BuildImage_LtsVersions
-    - Job_BuildImage_Jamstack
-    - Job_BuildImage_GithubActions
-    - Job_BuildImage_VsoFocal
-    - Job_BuildImage_Full
-    - Job_BuildImage_Cli
-    - Job_BuildImage_CliBuster
-    - Job_BuildImage_Buildpack
-    - Job_RuntimeImages
-  pool:
-    name: AzurePipelines-EO
-    demands:
-      - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
-  variables:
-    skipComponentGovernanceDetection: true
-  timeoutInMinutes: 300
-  steps:
-  - script: |
-      echo "##vso[task.setvariable variable=BuildBuildImages;]false"
-      echo "##vso[task.setvariable variable=BuildRuntimeImages;]false"
-      echo "##vso[task.setvariable variable=TestBuildImages;]false"
-      echo "##vso[task.setvariable variable=TestRuntimeImages;]false"
-      echo "##vso[task.setvariable variable=TestIntegrationCaseFilter;]category=ruby"
-      echo "##vso[task.setvariable variable=TestIntegration;]true"
-      echo "##vso[task.setvariable variable=PushBuildImages;]false"
-      echo "##vso[task.setvariable variable=PushRuntimeImages;]false"
-      echo "##vso[task.setvariable variable=EmbedBuildContextInImages;]false"
-      echo "##vso[task.setvariable variable=storageAccountUrl;]${{ parameters.storageAccountUrl }}"
-    displayName: 'Set variables'
-  - template: _setReleaseTag.yml
-  - template: _buildTemplate.yml
 
 - job: Job_DbIntegrationTests
   displayName: Run Database Integration Tests


### PR DESCRIPTION
This PR looks to resolve work item 1632680.

To help with the disk space issues we're seeing in pipelines that runs integration tests, this PR does the following:

- Splits up the existing Python integration tests based on their versions, ensuring that all of the runtimes won't be pulled down during the "Pull and re-tag" job, which has been using additional disk space for unused images
- Removes Ruby from being a part of the integration test job since it currently has no tests run in this suite and splitting it up into three separate flows based on the version tested would use three additional workers for no additional testing

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
