### PR TITLE
Revert "Remove stretch and buster multi-stage tests"

### DIFF
--- a/build/buildTestBuildImages.sh
+++ b/build/buildTestBuildImages.sh
@@ -86,6 +86,26 @@ docker build \
 echo
 echo
 
+echo "Building image that uses buster based github action as a base but doesn't have all required environment variables..."
+docker build \
+    -t "$ORYXTESTS_BUILDIMAGE_REPO:github-actions-debian-buster-base" \
+    --build-arg PARENT_IMAGE_BASE=github-actions-debian-buster \
+    -f "$ORYXTESTS_GITHUB_ACTIONS_ASBASE_BUILDIMAGE_DOCKERFILE" \
+    .
+
+echo
+echo
+
+echo "Building image that uses stretch based github action as a base but doesn't have all required environment variables..."
+docker build \
+    -t "$ORYXTESTS_BUILDIMAGE_REPO:github-actions-debian-stretch-base" \
+    --build-arg PARENT_IMAGE_BASE=github-actions-debian-stretch \
+    -f "$ORYXTESTS_GITHUB_ACTIONS_ASBASE_BUILDIMAGE_DOCKERFILE" \
+    .
+
+echo
+echo
+
 echo "Building image that uses bullseye based github action as a base and has all required environment variables..."
 docker build \
     -t "$ORYXTESTS_BUILDIMAGE_REPO:github-actions-debian-bullseye-base-withenv" \
@@ -95,5 +115,26 @@ docker build \
     .
 
 echo
+echo
 
+echo "Building image that uses buster based github action as a base and has all required environment variables..."
+docker build \
+    -t "$ORYXTESTS_BUILDIMAGE_REPO:github-actions-debian-buster-base-withenv" \
+    --build-arg PARENT_IMAGE_BASE=github-actions-debian-buster \
+    --build-arg DEBIAN_FLAVOR=buster \
+    -f "$ORYXTESTS_GITHUB_ACTIONS_ASBASE_WITHENV_BUILDIMAGE_DOCKERFILE" \
+    .
+
+echo
+echo
+
+echo "Building image that uses stretch based github action as a base and has all required environment variables..."
+docker build \
+    -t "$ORYXTESTS_BUILDIMAGE_REPO:github-actions-debian-stretch-base-withenv" \
+    --build-arg PARENT_IMAGE_BASE=github-actions-debian-stretch \
+    --build-arg DEBIAN_FLAVOR=stretch \
+    -f "$ORYXTESTS_GITHUB_ACTIONS_ASBASE_WITHENV_BUILDIMAGE_DOCKERFILE" \
+    .
+
+echo
 dockerCleanupIfRequested

--- a/tests/Oryx.BuildImage.Tests/BaseImage/BaseImageTest.cs
+++ b/tests/Oryx.BuildImage.Tests/BaseImage/BaseImageTest.cs
@@ -38,6 +38,21 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 var data = new TheoryData<string, string, string, string>();
                 var imageHelper = new ImageTestHelper();
 
+                // stretch
+                data.Add(
+                    DotNetCoreRunTimeVersions.NetCoreApp31,
+                    NetCoreApp31MvcApp,
+                    imageHelper.GetGitHubActionsAsBaseBuildImage(),
+                    "stretch");
+
+                //buster
+                data.Add(
+                    DotNetCoreRunTimeVersions.NetCoreApp31,
+                    NetCoreApp31MvcApp,
+                    imageHelper.GetGitHubActionsAsBaseBuildImage(ImageTestHelperConstants.GitHubActionsBusterBase),
+                    "buster");
+
+
                 //bullseye
                 data.Add(
                     DotNetCoreRunTimeVersions.NetCoreApp31,


### PR DESCRIPTION
Reverts microsoft/Oryx#1581

This was added temporarily to unblock our pipelines due to size constraints. Now that the better fix was pushed by @cormacpayne, we should be good to add these tests back. + @pauld-msft for FYI.