### PR TITLE
Add support for bindPort2 parameter for .NET

### DIFF
--- a/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
@@ -69,6 +69,10 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 {
                     createScriptArguments.Add("bindPort", this.commonOptions.BindPort);
                 }
+                if (!string.IsNullOrEmpty(this.commonOptions.BindPort2))
+                {
+                    createScriptArguments.Add("bindPort2", this.commonOptions.BindPort2);
+                }
 
                 var compatiblePlatforms = this.GetCompatiblePlatforms(ctx);
                 if (!compatiblePlatforms.Any())

--- a/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 {
                     createScriptArguments.Add("bindPort", this.commonOptions.BindPort);
                 }
-                
+
                 if (!string.IsNullOrEmpty(this.commonOptions.BindPort2))
                 {
                     createScriptArguments.Add("bindPort2", this.commonOptions.BindPort2);

--- a/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 {
                     createScriptArguments.Add("bindPort", this.commonOptions.BindPort);
                 }
+                
                 if (!string.IsNullOrEmpty(this.commonOptions.BindPort2))
                 {
                     createScriptArguments.Add("bindPort2", this.commonOptions.BindPort2);

--- a/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
+++ b/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
         public string BindPort { get; set; }
 
+        public string BindPort2 { get; set; }
+
         public string BuildImage { get; set; }
 
         public string PlatformName { get; set; }

--- a/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
             // "config.GetValue" call will get the most closest value provided based on the order of
             // configuration sources added to the ConfigurationBuilder above.
             options.BindPort = this.GetStringValue(SettingsKeys.BindPort);
+            options.BindPort2 = this.GetStringValue(SettingsKeys.BindPort2);
             options.BuildImage = this.GetStringValue(SettingsKeys.BuildImage);
             options.PlatformName = this.GetStringValue(SettingsKeys.PlatformName);
             options.PlatformVersion = this.GetStringValue(SettingsKeys.PlatformVersion);

--- a/src/BuildScriptGeneratorCli/SettingsKeys.cs
+++ b/src/BuildScriptGeneratorCli/SettingsKeys.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
     public static class SettingsKeys
     {
         public const string BindPort = "BIND_PORT";
+        public const string BindPort2 = "BIND_PORT2";
         public const string BuildImage = "BUILD_IMAGE";
         public const string PlatformName = "PLATFORM_NAME";
         public const string PlatformVersion = "PLATFORM_VERSION";

--- a/src/startupscriptgenerator/src/dotnetcore/main.go
+++ b/src/startupscriptgenerator/src/dotnetcore/main.go
@@ -41,7 +41,7 @@ func main() {
 		"[Optional] Path to the directory where build manifest file can be found. If no value is provided, then "+
 			"it is assumed to be under the directory specified by 'appPath'.")
 	bindPortPtr := scriptCommand.String("bindPort", "", "[Optional] Port where the application will bind to. Default is 8080")
-	bindPort2Ptr := scriptCommand.String("bindPort2", "", "[Optional] .NET only - HTTP/2 port where the application will bind to. By default, no binding will be made if this is not set")
+	bindPort2Ptr := scriptCommand.String("bindPort2", "", "[Optional] .NET only - HTTP/2 port where the application will bind to. By default, no HTTP/2 binding will be made")
 	userStartupCommandPtr := scriptCommand.String(
 		"userStartupCommand",
 		"",

--- a/src/startupscriptgenerator/src/dotnetcore/main.go
+++ b/src/startupscriptgenerator/src/dotnetcore/main.go
@@ -41,7 +41,7 @@ func main() {
 		"[Optional] Path to the directory where build manifest file can be found. If no value is provided, then "+
 			"it is assumed to be under the directory specified by 'appPath'.")
 	bindPortPtr := scriptCommand.String("bindPort", "", "[Optional] Port where the application will bind to. Default is 8080")
-	bindPort2Ptr := scriptCommand.String("bindPort2", "", "[Optional] Port 2 where the application will bind to.")
+	bindPort2Ptr := scriptCommand.String("bindPort2", "", "[Optional] .NET only - HTTP/2 port where the application will bind to. By default, no binding will be made if this is not set")
 	userStartupCommandPtr := scriptCommand.String(
 		"userStartupCommand",
 		"",

--- a/src/startupscriptgenerator/src/dotnetcore/main.go
+++ b/src/startupscriptgenerator/src/dotnetcore/main.go
@@ -41,6 +41,7 @@ func main() {
 		"[Optional] Path to the directory where build manifest file can be found. If no value is provided, then "+
 			"it is assumed to be under the directory specified by 'appPath'.")
 	bindPortPtr := scriptCommand.String("bindPort", "", "[Optional] Port where the application will bind to. Default is 8080")
+	bindPort2Ptr := scriptCommand.String("bindPort2", "", "[Optional] Port where the application will bind to. Default is 8080")
 	userStartupCommandPtr := scriptCommand.String(
 		"userStartupCommand",
 		"",
@@ -118,6 +119,7 @@ func main() {
 			AppPath:            fullAppPath,
 			RunFromPath:        fullRunFromPath,
 			BindPort:           *bindPortPtr,
+			BindPort2:          *bindPort2Ptr,
 			UserStartupCommand: *userStartupCommandPtr,
 			DefaultAppFilePath: fullDefaultAppFilePath,
 			Manifest:           buildManifest,

--- a/src/startupscriptgenerator/src/dotnetcore/main.go
+++ b/src/startupscriptgenerator/src/dotnetcore/main.go
@@ -41,7 +41,7 @@ func main() {
 		"[Optional] Path to the directory where build manifest file can be found. If no value is provided, then "+
 			"it is assumed to be under the directory specified by 'appPath'.")
 	bindPortPtr := scriptCommand.String("bindPort", "", "[Optional] Port where the application will bind to. Default is 8080")
-	bindPort2Ptr := scriptCommand.String("bindPort2", "", "[Optional] Port where the application will bind to. Default is 8080")
+	bindPort2Ptr := scriptCommand.String("bindPort2", "", "[Optional] Port 2 where the application will bind to.")
 	userStartupCommandPtr := scriptCommand.String(
 		"userStartupCommand",
 		"",

--- a/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
@@ -22,6 +22,7 @@ type DotnetCoreStartupScriptGenerator struct {
 	UserStartupCommand string
 	DefaultAppFilePath string
 	BindPort           string
+	BindPort2          string
 	Manifest           common.BuildManifest
 	Configuration      Configuration
 }

--- a/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
 	"github.com/Masterminds/semver"
 )
 
@@ -70,6 +69,39 @@ func (gen *DotnetCoreStartupScriptGenerator) shouldApplicationInsightsBeConfigur
 	return false
 }
 
+// Checks if the .NET runtime version meets the version contraint
+func (gen *DotnetCoreStartupScriptGenerator) isDotnetRuntimeVersionMeetConstraint(versionConstraint string) bool {
+	dotNetRuntimeVersion := ""
+	
+	if gen.Manifest.DotNetCoreRuntimeVersion != "" {
+		dotNetRuntimeVersion = gen.Manifest.DotNetCoreRuntimeVersion
+	} else {
+		dotNetRuntimeVersion = os.Getenv("DOTNET_VERSION")
+	}
+	
+	fmt.Printf("\nDotNet Runtime %s", dotNetRuntimeVersion)
+	
+	if dotNetRuntimeVersion != "" {
+		dotNetRuntimeVersionConstraint, err := semver.NewConstraint(">= " + versionConstraint)
+		if err != nil {
+    		fmt.Printf("\nError in creating semver constraint %s", err)
+		}
+
+		dotNetCurrentVersion, err := semver.NewVersion(dotNetRuntimeVersion)
+		if err != nil {
+    		fmt.Printf("\nError in parsing current version to semver version %s", err)
+		}
+		// Check if the version meets the constraints. The a variable will be true.
+		constraintCheckResult := dotNetRuntimeVersionConstraint.Check(dotNetCurrentVersion)
+				
+	    if constraintCheckResult  {
+			   fmt.Printf("\nBefore returning true")
+			   return true
+		}
+	}
+	return false
+}
+
 func (gen *DotnetCoreStartupScriptGenerator) GenerateEntrypointScript(scriptBuilder *strings.Builder) string {
 	logger := common.GetLogger("dotnetcore.scriptgenerator.GenerateEntrypointScript")
 	defer logger.Shutdown()
@@ -81,6 +113,15 @@ func (gen *DotnetCoreStartupScriptGenerator) GenerateEntrypointScript(scriptBuil
 	// Expose the port so that a custom command can use it if needed
 	common.SetEnvironmentVariableInScript(scriptBuilder, "PORT", gen.BindPort, DefaultBindPort)
 	scriptBuilder.WriteString("export ASPNETCORE_URLS=http://*:$PORT\n\n")
+
+	logger.LogInformation("Setting up Kestrel Endpoints with BindPort and BindPort2 Env variables if .NET runtime version >= 7")
+	if gen.isDotnetRuntimeVersionMeetConstraint("7.0.0-0") {
+		scriptBuilder.WriteString("if [ -z \"$" + gen.BindPort2 + "\" ]; then" + "\n")
+		scriptBuilder.WriteString("		export Kestrel__Endpoints__Http2__Url=http://*:" + gen.BindPort2 + "\n")
+		scriptBuilder.WriteString("		export Kestrel__Endpoints__Http2__Protocols=Http2\n")
+		scriptBuilder.WriteString("		export Kestrel__Endpoints__Http1__Url=http://*:$PORT\n\n")
+		scriptBuilder.WriteString("fi")
+	}
 
 	appPath := gen.AppPath
 	if gen.RunFromPath != "" {

--- a/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
@@ -85,19 +85,18 @@ func (gen *DotnetCoreStartupScriptGenerator) isDotnetRuntimeVersionMeetConstrain
 		dotNetRuntimeVersionConstraint, err := semver.NewConstraint(">= " + versionConstraint)
 		if err != nil {
     		fmt.Printf("\nError in creating semver constraint %s", err)
+			return false
 		}
 
 		dotNetCurrentVersion, err := semver.NewVersion(dotNetRuntimeVersion)
 		if err != nil {
     		fmt.Printf("\nError in parsing current version to semver version %s", err)
+			return false
 		}
 		// Check if the version meets the constraints. The a variable will be true.
 		constraintCheckResult := dotNetRuntimeVersionConstraint.Check(dotNetCurrentVersion)
 				
-	    if constraintCheckResult  {
-			   fmt.Printf("\nBefore returning true")
-			   return true
-		}
+	    return constraintCheckResult
 	}
 	return false
 }

--- a/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
@@ -98,6 +98,7 @@ func (gen *DotnetCoreStartupScriptGenerator) isDotnetRuntimeVersionMeetConstrain
 				
 	    return constraintCheckResult
 	}
+
 	return false
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.


Oryx side change:
•        Surface a new optional -bindPort2 parameter.
•        When this parameter is set, pass the following env variables to the .NET 7 process:
o   Kestrel__Endpoints__Http2__Url=http://*:8585
(Port value here comes from the -bindPort2 parameter)
o   Kestrel__Endpoints__Http2__Protocols=Http2
o   Kestrel__Endpoints__Http__Url=http://*:8080
(Port value here comes from the -bindPort parameter)
o   Kestrel__Endpoints__Http__Protocols=Http1
•        We won’t change the existing behavior if -bindPort2 is not provided.
