### PR TITLE
Ensure Microsoft ODBC Driver 17 and 18 are installed for PHP runtimes

### DIFF
--- a/images/runtime/php-fpm/7.4/7.4.Dockerfile
+++ b/images/runtime/php-fpm/7.4/7.4.Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux \
 	&& curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
 	&& curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
 	&& apt-get update \
-	&& ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev
+	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 msodbcsql18 unixodbc-dev
 
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.0/8.0.Dockerfile
+++ b/images/runtime/php-fpm/8.0/8.0.Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux \
 	&& curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
 	&& curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
 	&& apt-get update \
-	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc-dev
+	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 msodbcsql18 unixodbc-dev
 
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.1/8.1.Dockerfile
+++ b/images/runtime/php-fpm/8.1/8.1.Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux \
 	&& curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
 	&& curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
 	&& apt-get update \
-	&& ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev
+	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 msodbcsql18 unixodbc-dev
 
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -eux; \

--- a/images/runtime/php/7.4/7.4.Dockerfile
+++ b/images/runtime/php/7.4/7.4.Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux \
 	&& curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
 	&& curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
 	&& apt-get update \
-	&& ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev
+	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 msodbcsql18 unixodbc-dev
 
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -eux; \

--- a/images/runtime/php/8.0/8.0.Dockerfile
+++ b/images/runtime/php/8.0/8.0.Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux \
 	&& curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
 	&& curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
 	&& apt-get update \
-	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc-dev
+	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 msodbcsql18 unixodbc-dev
 
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -eux; \

--- a/images/runtime/php/8.1/8.1.Dockerfile
+++ b/images/runtime/php/8.1/8.1.Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux \
 	&& curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
 	&& curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
 	&& apt-get update \
-	&& ACCEPT_EULA=Y apt-get install -y msodbcsql18 unixodbc-dev
+	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17 msodbcsql18 unixodbc-dev
 
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -eux; \


### PR DESCRIPTION
From [this commit](https://github.com/microsoft/Oryx/commit/4298f80aa16716711aaa071a22b8ba30708a14ff), the Microsoft ODBC Driver 17 was swapped for 18 in some of the PHP runtimes -- this change ensures that both 17 and 18 are installed for all PHP (and PHP FPM) runtimes.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
