### PR TITLE
Update service connection used to authorize calls to oryx-automation resource group

### DIFF
--- a/vsts/pipelines/baseImages/dotnetcore.yml
+++ b/vsts/pipelines/baseImages/dotnetcore.yml
@@ -1,5 +1,5 @@
 variables:
-    ascName: oryxSP
+    ascName: oryx-automation-service-principal
     acrName: oryxdevmcr.azurecr.io
     skipComponentGovernanceDetection: true
     Packaging.EnableSBOMSigning: true

--- a/vsts/pipelines/baseImages/node.yml
+++ b/vsts/pipelines/baseImages/node.yml
@@ -1,5 +1,5 @@
 variables:
-    ascName: oryxSP
+    ascName: oryx-automation-service-principal
     acrName: oryxdevmcr.azurecr.io
     skipComponentGovernanceDetection: true
     Packaging.EnableSBOMSigning: true

--- a/vsts/pipelines/baseImages/php-fpm.yml
+++ b/vsts/pipelines/baseImages/php-fpm.yml
@@ -1,5 +1,5 @@
 variables:
-    ascName: oryxSP
+    ascName: oryx-automation-service-principal
     acrName: oryxdevmcr.azurecr.io
     skipComponentGovernanceDetection: true
     Packaging.EnableSBOMSigning: true

--- a/vsts/pipelines/baseImages/php.yml
+++ b/vsts/pipelines/baseImages/php.yml
@@ -1,5 +1,5 @@
 variables:
-    ascName: oryxSP
+    ascName: oryx-automation-service-principal
     acrName: oryxdevmcr.azurecr.io
     skipComponentGovernanceDetection: true
     Packaging.EnableSBOMSigning: true

--- a/vsts/pipelines/baseImages/python.yml
+++ b/vsts/pipelines/baseImages/python.yml
@@ -1,5 +1,5 @@
 variables:
-    ascName: oryxSP
+    ascName: oryx-automation-service-principal
     acrName: oryxdevmcr.azurecr.io
     skipComponentGovernanceDetection: true
     Packaging.EnableSBOMSigning: true

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -1,5 +1,5 @@
 parameters:
-  ascName: oryxSP
+  ascName: oryx-automation-service-principal
   acrName: oryxdevmcr.azurecr.io
   imageName: oryxdevmcr.azurecr.io/public/oryx
   imageType: null

--- a/vsts/pipelines/templates/_releaseBaseImagesStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseBaseImagesStepTemplate.yml
@@ -1,5 +1,5 @@
 parameters:
-  ascName: oryxSP
+  ascName: oryx-automation-service-principal
   acrDevName: oryxdevmcr
   acrProdName: oryxmcr
   acrPmeProdName: oryxprodmcr

--- a/vsts/pipelines/templates/_releaseStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseStepTemplate.yml
@@ -1,5 +1,5 @@
 parameters:
-  ascName: oryxSP
+  ascName: oryx-automation-service-principal
   acrDevName: oryxdevmcr.azurecr.io
   acrProdName: oryxmcr
   acrPmeProdName: oryxprodmcr


### PR DESCRIPTION
The `oryxSP` service connection we used to authorize calls to the `oryx-automation` resource group has a service principal linked to it, and the secret we were using for that SP recently expired. A new service connection, `oryx-automation-service-principal`, was created with a new SP linked to it, so this PR updates the reference to the service connection that we're using across our Azure Pipelines.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
