### PR TITLE
Updating character enconding from POSIX to UTF-8

### DIFF
--- a/images/build/Dockerfiles/azureFunctions.JamStack.Dockerfile
+++ b/images/build/Dockerfiles/azureFunctions.JamStack.Dockerfile
@@ -9,7 +9,9 @@ ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR \
     DYNAMIC_INSTALL_ROOT_DIR="/opt" \
     PATH="/usr/local/go/bin:/opt/python/latest/bin:$PATH" \
     PYTHONIOENCODING="UTF-8" \
-    LANG="C.UTF-8"
+    LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"
 
 ARG IMAGES_DIR="/opt/tmp/images"
 RUN oryx prep --skip-detection --platforms-and-versions nodejs=14 --debug \

--- a/images/build/Dockerfiles/cli.Dockerfile
+++ b/images/build/Dockerfiles/cli.Dockerfile
@@ -15,6 +15,8 @@ ENV ORYX_SDK_STORAGE_BASE_URL=${SDK_STORAGE_BASE_URL_VALUE} \
     DYNAMIC_INSTALL_ROOT_DIR="/opt" \
     PYTHONIOENCODING="UTF-8" \
     LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8" \
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE="1"
 
 # Install an assortment of traditional tooling (unicode, SSL, HTTP, etc.)

--- a/images/build/Dockerfiles/gitHubActions.Dockerfile
+++ b/images/build/Dockerfiles/gitHubActions.Dockerfile
@@ -3,8 +3,7 @@ FROM oryxdevmcr.azurecr.io/private/oryx/githubrunners-buildpackdeps-${DEBIAN_FLA
 ARG DEBIAN_FLAVOR
 ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR
 # Install basic build tools
-RUN LANG="C.UTF-8" \
-    && apt-get update \
+RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         git \
@@ -160,6 +159,8 @@ RUN tmpDir="/opt/tmp" \
 ENV ORYX_PATHS="/opt/oryx:/opt/yarn/stable/bin:/opt/hugo/lts"
 
 ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8" \
     ORIGINAL_PATH="$PATH" \
     PATH="$ORYX_PATHS:$PATH" \
     NUGET_XMLDOC_MODE="skip" \

--- a/images/build/Dockerfiles/ltsVersions.buster.Dockerfile
+++ b/images/build/Dockerfiles/ltsVersions.buster.Dockerfile
@@ -3,8 +3,7 @@ FROM oryxdevmcr.azurecr.io/private/oryx/githubrunners-buildpackdeps-buster AS ma
 # Install basic build tools
 # Configure locale (required for Python)
 # NOTE: Do NOT move it from here as it could have global implications
-RUN LANG="C.UTF-8" \
-    && apt-get update \
+RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         git \
@@ -62,6 +61,8 @@ COPY --from=intermediate /opt /opt
 ENV ORYX_PATHS="/opt/oryx:/opt/nodejs/lts/bin:/opt/dotnet/lts:/opt/python/latest/bin:/opt/php/lts/bin:/opt/php-composer:/opt/yarn/stable/bin:/opt/hugo/lts"
 
 ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8" \
     ORIGINAL_PATH="$PATH" \
     PATH="$ORYX_PATHS:$PATH" \
     NUGET_XMLDOC_MODE="skip" \

--- a/images/build/Dockerfiles/vso.bullseye.Dockerfile
+++ b/images/build/Dockerfiles/vso.bullseye.Dockerfile
@@ -3,8 +3,7 @@ FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye AS main
 # Install basic build tools
 # Configure locale (required for Python)
 # NOTE: Do NOT move it from here as it could have global implications
-RUN LANG="C.UTF-8" \
-    && apt-get update \
+RUN apt-get update \
     && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git \
@@ -281,6 +280,9 @@ ENV NUGET_XMLDOC_MODE="skip" \
     ENABLE_DYNAMIC_INSTALL="true" \
     ORYX_PREFER_USER_INSTALLED_SDKS=true \
     ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY} \
-    PYTHONIOENCODING="UTF-8"
+    PYTHONIOENCODING="UTF-8" \
+    LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"
 
 ENTRYPOINT [ "benv" ]

--- a/images/build/Dockerfiles/vso.focal.Dockerfile
+++ b/images/build/Dockerfiles/vso.focal.Dockerfile
@@ -3,8 +3,7 @@ FROM oryxdevmcr.azurecr.io/private/oryx/githubrunners-buildpackdeps-focal AS mai
 # Install basic build tools
 # Configure locale (required for Python)
 # NOTE: Do NOT move it from here as it could have global implications
-RUN LANG="C.UTF-8" \
-    && apt-get update \
+RUN apt-get update \
     && apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git \
@@ -281,6 +280,9 @@ ENV NUGET_XMLDOC_MODE="skip" \
     ENABLE_DYNAMIC_INSTALL="true" \
     ORYX_PREFER_USER_INSTALLED_SDKS=true \
     ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY} \
-    PYTHONIOENCODING="UTF-8"
+    PYTHONIOENCODING="UTF-8" \
+    LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"
 
 ENTRYPOINT [ "benv" ]

--- a/images/runtime/dotnetcore/template.Dockerfile
+++ b/images/runtime/dotnetcore/template.Dockerfile
@@ -27,6 +27,10 @@ ENV ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS=true
 #Bake in client certificate path into image to avoid downloading it
 ENV PATH_CA_CERTIFICATE="/etc/ssl/certs/ca-certificate.crt"
 
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"
+
 # Oryx++ Builder variables
 ENV CNB_STACK_ID="oryx.stacks.skeleton"
 LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"

--- a/images/runtime/node/18/bullseye.Dockerfile
+++ b/images/runtime/node/18/bullseye.Dockerfile
@@ -13,7 +13,7 @@ ENV GIT_COMMIT=${GIT_COMMIT}
 ENV BUILD_NUMBER=${BUILD_NUMBER}
 RUN ./build.sh node /opt/startupcmdgen/startupcmdgen
 
-FROM mcr.microsoft.com/oryx/base:node-18-20220610.1
+FROM mcr.microsoft.com/oryx/base:node-18-20221027.2
 
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_KEY
@@ -33,3 +33,7 @@ RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
     && apt-get upgrade --assume-yes \
     && rm -rf /var/lib/apt/lists/*
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/node/template.Dockerfile
+++ b/images/runtime/node/template.Dockerfile
@@ -33,3 +33,7 @@ RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
     && apt-get upgrade --assume-yes \
     && rm -rf /var/lib/apt/lists/*
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php-fpm/7.4/base.bullseye.Dockerfile
+++ b/images/runtime/php-fpm/7.4/base.bullseye.Dockerfile
@@ -123,3 +123,7 @@ RUN set -x \
     && ./configure --with-unixODBC=shared,/usr \
     && docker-php-ext-install odbc \
     && rm -rf /var/lib/apt/lists/*
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php-fpm/8.1/base.bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.1/base.bullseye.Dockerfile
@@ -123,3 +123,7 @@ RUN set -x \
     && ./configure --with-unixODBC=shared,/usr \
     && docker-php-ext-install odbc \
     && rm -rf /var/lib/apt/lists/*
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php-fpm/template.Dockerfile
+++ b/images/runtime/php-fpm/template.Dockerfile
@@ -26,4 +26,6 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx
 
-
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php-fpm/template.base.Dockerfile
+++ b/images/runtime/php-fpm/template.base.Dockerfile
@@ -123,3 +123,7 @@ RUN set -x \
     && ./configure --with-unixODBC=shared,/usr \
     && docker-php-ext-install odbc \
     && rm -rf /var/lib/apt/lists/*
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php/7.4/base.bullseye.Dockerfile
+++ b/images/runtime/php/7.4/base.bullseye.Dockerfile
@@ -140,3 +140,7 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /tmp/oryx
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php/8.0/base.buster.Dockerfile
+++ b/images/runtime/php/8.0/base.buster.Dockerfile
@@ -140,3 +140,7 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /tmp/oryx
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php/8.1/base.bullseye.Dockerfile
+++ b/images/runtime/php/8.1/base.bullseye.Dockerfile
@@ -140,3 +140,7 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /tmp/oryx
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php/template.Dockerfile
+++ b/images/runtime/php/template.Dockerfile
@@ -31,3 +31,6 @@ RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     # Temporarily making sure apache2-foreground has permission
     && chmod +x /usr/local/bin/apache2-foreground
 
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/php/template.base.Dockerfile
+++ b/images/runtime/php/template.base.Dockerfile
@@ -140,3 +140,7 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf /tmp/oryx
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/python/3.10/bullseye.Dockerfile
+++ b/images/runtime/python/3.10/bullseye.Dockerfile
@@ -89,4 +89,8 @@ RUN pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/oryx
 
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen

--- a/images/runtime/python/3.11/bullseye.Dockerfile
+++ b/images/runtime/python/3.11/bullseye.Dockerfile
@@ -31,7 +31,7 @@ ADD build ${BUILD_DIR}
 RUN find ${IMAGES_DIR} -type f -iname "*.sh" -exec chmod +x {} \;
 RUN find ${BUILD_DIR} -type f -iname "*.sh" -exec chmod +x {} \;
 
-ENV PYTHON_VERSION 3.11.0b1
+ENV PYTHON_VERSION 3.11.0
 RUN true
 COPY build/__pythonVersions.sh ${BUILD_DIR}
 RUN true
@@ -51,7 +51,7 @@ RUN ${BUILD_DIR}/buildPythonSdkByVersion.sh $PYTHON_VERSION $DEBIAN_FLAVOR
 
 RUN set -ex \
  && cd /opt/python/ \
- && ln -s 3.11.0b1 3.11 \
+ && ln -s 3.11.0 3.11 \
  && ln -s 3.11 3 \
  && echo /opt/python/3/lib >> /etc/ld.so.conf.d/python.conf \
  && ldconfig \
@@ -88,5 +88,9 @@ RUN pip install --upgrade pip \
     && apt-get upgrade --assume-yes \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/oryx
+
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
 
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen

--- a/images/runtime/python/3.7/bullseye.Dockerfile
+++ b/images/runtime/python/3.7/bullseye.Dockerfile
@@ -89,4 +89,8 @@ RUN pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/oryx
 
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen

--- a/images/runtime/python/3.8/bullseye.Dockerfile
+++ b/images/runtime/python/3.8/bullseye.Dockerfile
@@ -89,4 +89,8 @@ RUN pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/oryx
 
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -89,4 +89,8 @@ RUN pip install --upgrade pip \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/oryx
 
+ENV LANG="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8"
+
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen

--- a/images/runtime/ruby/2.5/buster.Dockerfile
+++ b/images/runtime/ruby/2.5/buster.Dockerfile
@@ -28,6 +28,11 @@ ENV PATH="/opt/ruby/2/bin:${PATH}"
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
+
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 RUN ${IMAGES_DIR}/runtime/ruby/install-dependencies.sh
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
@@ -36,3 +41,7 @@ RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && rm -rf /tmp/oryx
     
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/ruby/2.6/buster.Dockerfile
+++ b/images/runtime/ruby/2.6/buster.Dockerfile
@@ -28,6 +28,11 @@ ENV PATH="/opt/ruby/2/bin:${PATH}"
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
+
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 RUN ${IMAGES_DIR}/runtime/ruby/install-dependencies.sh
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
@@ -36,3 +41,7 @@ RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && rm -rf /tmp/oryx
     
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/ruby/2.7/buster.Dockerfile
+++ b/images/runtime/ruby/2.7/buster.Dockerfile
@@ -28,6 +28,11 @@ ENV PATH="/opt/ruby/2/bin:${PATH}"
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_KEY
 ENV ORYX_AI_INSTRUMENTATION_KEY=${AI_KEY}
+
+# Oryx++ Builder variables
+ENV CNB_STACK_ID="oryx.stacks.skeleton"
+LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
+
 RUN ${IMAGES_DIR}/runtime/ruby/install-dependencies.sh
 RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && apt-get update \
@@ -36,3 +41,7 @@ RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && rm -rf /tmp/oryx
     
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"

--- a/images/runtime/ruby/template.Dockerfile
+++ b/images/runtime/ruby/template.Dockerfile
@@ -41,3 +41,7 @@ RUN ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
     && rm -rf /tmp/oryx
     
 COPY --from=startupCmdGen /opt/startupcmdgen/startupcmdgen /opt/startupcmdgen/startupcmdgen
+
+ENV LANG="C.UTF-8" \
+    LANGUAGE="C.UTF-8" \
+    LC_ALL="C.UTF-8"


### PR DESCRIPTION
Updated language setting env from POSIX to C.UTF-8 or en_US.UTF-8.
Most images don't have locale installed. Therefore can only use C.UTF-8 without installing it. The supported characters of C.UTF-8 and en_US are same. The only difference is the orders of a-z, A-Z, numbers, etc. en_US is more user friendly, while C.UTF-8 is more compatible to machine. 
Therefore, this PR hasn't installed locale to every img but to choose whichever character encoding the image supported.
Only python runtime img is using en_US.UTF-8. All the others are using C.UTF-8