### PR TITLE
Lock version of viper to 1.13.0

### DIFF
--- a/src/startupscriptgenerator/src/common/Gopkg.toml
+++ b/src/startupscriptgenerator/src/common/Gopkg.toml
@@ -43,7 +43,7 @@
 
 [[override]]
   name = "github.com/spf13/viper"
-  version = "=1.13.0"
+  version = "=1.10.0"
 
 [[override]]
   name = "golang.org/x/sys"

--- a/src/startupscriptgenerator/src/common/Gopkg.toml
+++ b/src/startupscriptgenerator/src/common/Gopkg.toml
@@ -42,6 +42,10 @@
   version = "=1.8.2"
 
 [[override]]
+  name = "github.com/spf13/viper"
+  version = "=1.13.0"
+
+[[override]]
   name = "golang.org/x/sys"
   version = "=v0.0.0-20220908164124-27713097b956"
 

--- a/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
+++ b/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
@@ -34,6 +34,10 @@
   version = "1.3.0"
 
 [[override]]
+  name = "github.com/spf13/viper"
+  version = "=1.13.0"
+
+[[override]]
   name = "github.com/spf13/afero"
   version = "=1.8.2"
   

--- a/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
+++ b/src/startupscriptgenerator/src/dotnetcore/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[override]]
   name = "github.com/spf13/viper"
-  version = "=1.13.0"
+  version = "=1.10.0"
 
 [[override]]
   name = "github.com/spf13/afero"

--- a/src/startupscriptgenerator/src/node/Gopkg.toml
+++ b/src/startupscriptgenerator/src/node/Gopkg.toml
@@ -30,6 +30,10 @@
   version = "1.3.0"
 
 [[override]]
+  name = "github.com/spf13/viper"
+  version = "=1.13.0"
+
+[[override]]
   name = "github.com/spf13/afero"
   version = "=1.8.2"
 

--- a/src/startupscriptgenerator/src/node/Gopkg.toml
+++ b/src/startupscriptgenerator/src/node/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[override]]
   name = "github.com/spf13/viper"
-  version = "=1.13.0"
+  version = "=1.10.0"
 
 [[override]]
   name = "github.com/spf13/afero"

--- a/src/startupscriptgenerator/src/python/Gopkg.toml
+++ b/src/startupscriptgenerator/src/python/Gopkg.toml
@@ -30,6 +30,10 @@
   version = "1.3.0"
 
 [[override]]
+  name = "github.com/spf13/viper"
+  version = "=1.13.0"
+
+[[override]]
   name = "github.com/spf13/afero"
   version = "=1.8.2"
 

--- a/src/startupscriptgenerator/src/python/Gopkg.toml
+++ b/src/startupscriptgenerator/src/python/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[override]]
   name = "github.com/spf13/viper"
-  version = "=1.13.0"
+  version = "=1.10.0"
 
 [[override]]
   name = "github.com/spf13/afero"


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [X ] The purpose of this PR is explained in this message or in an issue. 
- [<del> ] Tests are included and/or updated for code changes.
- [<del> ] Proper license headers are included in each file.


The purpose of this PR is to lock in spf13/viper version to 1.13.0 as the version upgrade to 1.14.0 does not respect the locked in afero version 1.8.2 and uses 1.9.2 instead. This change is breaking our validation pipeline https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6927853&view=logs&j=d730335a-3d63-589c-410a-f89ac50fbae9&t=9cf7daf0-a09d-559f-a9aa-775d93f3b74f
