### PR TITLE
Run npm install as current user

### DIFF
--- a/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
@@ -129,6 +129,10 @@ then
 	fi
 fi
 
+# ensure that the current user owns the application source directory,
+# so we execute npm install with the correct permissions.
+chown -R "$(whoami)" $SOURCE_DIR
+
 cd "$SOURCE_DIR"
 
 {{ if CustomBuildCommand | IsNotBlank }}

--- a/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
@@ -129,9 +129,13 @@ then
 	fi
 fi
 
-# ensure that the current user owns the application source directory,
-# so we execute npm install with the correct permissions.
-chown -R "$(whoami)" $SOURCE_DIR
+# ensure that if the current user is root, that the root user also owns
+# the application directory. This ensures that when npm install runs, it 
+# does so as the root user, and therefore can access the npm cache located at
+# ~/.npm by default
+if [[ "$(whoami)" == "root" ]]; then
+	chown -R root:root $SOURCE_DIR
+fi
 
 cd "$SOURCE_DIR"
 

--- a/src/BuildScriptGenerator/Node/NodeConstants.cs
+++ b/src/BuildScriptGenerator/Node/NodeConstants.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
         public const string LernaInitCommand = "lerna init";
         public const string LernaBootstrapCommand = "lerna bootstrap";
         public const string InstallLernaCommandNpm = "npm install --global lerna";
-        public const string NpmPackageInstallCommand = "npm install --unsafe-perm";
+        public const string NpmPackageInstallCommand = "npm install";
         public const string InstallLernaCommandYarn = "npm install --global lerna --no-package-lock";
         public const string InstallLageCommand = "npm install --global lage";
         public const string NpmRunLageBuildCommand = "npm run lage build";


### PR DESCRIPTION
See https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1688940 for full details.

Summarizing the ticket, we were seeing permission errors when we ran npm install once we upgraded to node 16. The new version of npm used for node 16 (vs 14) has behavior that causes it to execute npm install commands as whoever owns the directory where it is executing. In ADO pipelines this causes an issue because a non-root user owns the application directory, but the npm cache is located in `/root/.npm/`. So the non-root user that npm install is running as does not have permissions to write to the cache.

This solution should make the application directory be owned by whoever is executing the Oryx script. So in cases where that is root, the root user will then execute npm install. But if a customer is running as a non-root user, we won't be changing the owner to root.
Tested with github actions and ADO pipeline in https://github.com/pauld-msft/create-react-app-sample-testing-root
