### PR TITLE
yarn bug fix

### DIFF
--- a/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
@@ -110,6 +110,10 @@ then
 		cp -f "$SOURCE_DIR/.yarnrc.yml" .
 	fi
 
+	if [ YarnVersionSpec | IsNotBlank ] && [ -f "$SOURCE_DIR/.yarn/releases/yarn-${YarnVersionSpec}"* ]; then
+		cp -f "$SOURCE_DIR/.yarn/releases/yarn-${YarnVersionSpec}"* .
+	fi
+	
 	echo
 	echo "Installing production dependencies in '$SOURCE_DIR/$prodModulesDirName'..."
 	echo


### PR DESCRIPTION
`yarn install` command is failing for this new tag with error: Error: Cannot find module '/github/workspace/api/.oryx_prod_node_modules/.yarn/releases/yarn-1.22.19.cjs'.

 

Here’s a build succeeding (tag: 20221103.1): [https://github.com/vivekjilla/vanilla-api/actions/runs/3673036949/jobs/6209740649#step:4:95](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fvivekjilla%2Fvanilla-api%2Factions%2Fruns%2F3673036949%2Fjobs%2F6209740649%23step%3A4%3A95&data=05%7C01%7Cmbhuiyan%40microsoft.com%7C687c04d207864a7e541d08dadc531580%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638064546679701191%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=MgnqRe%2FHPY0HB1kGvmPlFEXVLSmejvWIVu7%2BFJFfgs8%3D&reserved=0)

Here’s a build failing (tag: 20221129.2): [https://github.com/vivekjilla/vanilla-api/actions/runs/3673043145/jobs/6209753543#step:4:105](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fvivekjilla%2Fvanilla-api%2Factions%2Fruns%2F3673043145%2Fjobs%2F6209753543%23step%3A4%3A105&data=05%7C01%7Cmbhuiyan%40microsoft.com%7C687c04d207864a7e541d08dadc531580%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638064546679701191%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=NZLNLYxUzFN2eJGeKOdAt4wKecAcVHJqN0qfFWhsTVE%3D&reserved=0)

Here’s the api folder being built: [https://github.com/vivekjilla/vanilla-api/tree/main/api](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fvivekjilla%2Fvanilla-api%2Ftree%2Fmain%2Fapi&data=05%7C01%7Cmbhuiyan%40microsoft.com%7C687c04d207864a7e541d08dadc531580%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638064546679701191%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=CswgT19wf05C0P0dwfjJnLA0kEYMnmkC6VWrhJWfWPA%3D&reserved=0)