### PR TITLE
Add command option to docs

### DIFF
--- a/doc/runtimes/dotnetcore.md
+++ b/doc/runtimes/dotnetcore.md
@@ -34,10 +34,10 @@ We currently support detecting both `.csproj` ("C# Project") and `.fsproj` ("F# 
 
 The following process is applied for each build.
 
-1. Run custom script if specified by `PRE_BUILD_SCRIPT_PATH`.
+1. Run custom command or script if specified by `PRE_BUILD_COMMAND` or `PRE_BUILD_SCRIPT_PATH`.
 1. Run `dotnet restore` to restore Nuget dependencies.
 1. Run `dotnet publish` to build a binary for production.
-1. Run custom script if specified by `POST_BUILD_SCRIPT_PATH`.
+1. Run custom command or script if specified by `POST_BUILD_COMMAND` or `POST_BUILD_SCRIPT_PATH`.
 
 # Run
 

--- a/doc/runtimes/hugo.md
+++ b/doc/runtimes/hugo.md
@@ -20,8 +20,8 @@ The Hugo toolset is run when one of following conditions met:
 
 The following process is applied for each build:
 
-1. Run custom script if specified by `PRE_BUILD_SCRIPT_PATH`.
-2. Run custom script if specified by `POST_BUILD_SCRIPT_PATH`.
+1. Run custom command or script if specified by `PRE_BUILD_COMMAND` or `PRE_BUILD_SCRIPT_PATH`.
+2. Run custom command or script if specified by `POST_BUILD_COMMAND` or `POST_BUILD_SCRIPT_PATH`.
 
 # Version support
 

--- a/doc/runtimes/php.md
+++ b/doc/runtimes/php.md
@@ -68,9 +68,9 @@ The PHP toolset will run when the following conditions are met:
 
 The following process is applied for each build:
 
-1. Run custom script if specified by `PRE_BUILD_SCRIPT_PATH`.
+1. Run custom command or script if specified by `PRE_BUILD_COMMAND` or `PRE_BUILD_SCRIPT_PATH`.
 1. Run `php composer.phar install --ignore-platform-reqs --no-interaction` if composer file found.
-1. Run custom script if specified by `POST_BUILD_SCRIPT_PATH`.
+1. Run custom command or script if specified by `POST_BUILD_COMMAND` or `POST_BUILD_SCRIPT_PATH`.
 
 ## Package manager
 

--- a/doc/runtimes/python.md
+++ b/doc/runtimes/python.md
@@ -59,7 +59,7 @@ The Python conda is run when the following conditions are met:
 
 The following process is applied for each build.
 
-1. Run custom script if specified by `PRE_BUILD_SCRIPT_PATH`.
+1. Run custom command or script if specified by `PRE_BUILD_COMMAND` or `PRE_BUILD_SCRIPT_PATH`.
 2. Create python virtual environment if specified by `VIRTUALENV_NAME`.
 3. Run `python -m pip install --cache-dir /usr/local/share/pip-cache --prefer-binary -r requirements.txt` 
    if `requirements.txt` exists in the root of repo or specified by `CUSTOM_REQUIREMENTSTXT_PATH`.
@@ -68,16 +68,17 @@ The following process is applied for each build.
 6. If `manage.py` is found in the root of the repo `manage.py collectstatic` is run. However,
    if `DISABLE_COLLECTSTATIC` is set to `true` this step is skipped.
 7. Compress virtual environment folder if specified by `compress_virtualenv` property key.
-8. Run custom script if specified by `POST_BUILD_SCRIPT_PATH`.
+8. Run custom command or script if specified by `POST_BUILD_COMMAND` or `POST_BUILD_SCRIPT_PATH`.
 
 ## Build Conda environment and Python JupyterNotebook
 
 The following process is applied for each build.
-1. Run custom script if specified by `PRE_BUILD_SCRIPT_PATH`.
+
+1. Run custom command or script if specified by `PRE_BUILD_COMMAND` or `PRE_BUILD_SCRIPT_PATH`.
 2. Set up Conda virtual environemnt `conda env create --file $envFile`.
 3. If `requirment.txt` exists in the root of repo or specified by `CUSTOM_REQUIREMENTSTXT_PATH`, activate environemnt 
   `conda activate $environmentPrefix` and run `pip install --no-cache-dir -r requirements.txt`.
-4. Run custom script if specified by `POST_BUILD_SCRIPT_PATH`.
+4. Run custom command or script if specified by `POST_BUILD_COMMAND` or `POST_BUILD_SCRIPT_PATH`.
 
 
 ## Package manager

--- a/doc/runtimes/ruby.md
+++ b/doc/runtimes/ruby.md
@@ -20,10 +20,10 @@ The Ruby toolset is run when one of following conditions met:
 
 The following process is applied for each build:
 
-1. Run custom script if specified by `PRE_BUILD_SCRIPT_PATH`.
+1. Run custom command or script if specified by `PRE_BUILD_COMMAND` or `PRE_BUILD_SCRIPT_PATH`.
 2. Run `gem install bundler` comamnd to install bundler tool.
 3. Run `bundle install` command.
-4. Run custom script if specified by `POST_BUILD_SCRIPT_PATH`.
+4. Run custom command or script if specified by `POST_BUILD_COMMAND` or `POST_BUILD_SCRIPT_PATH`.
 
 ## Package manager
 


### PR DESCRIPTION
- [X] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [X] Tests are included and/or updated for code changes.
- [X] Proper license headers are included in each file.

Currently, only the NodeJS docs and Java docs mention `PRE_BUILD_COMMAND` and `POST_BUILD_COMMAND`. The other docs only mention the `SCRIPT_PATH` options. This PR makes the wording consistent and up to date across all the runtimes.