### PR TITLE
Pauld/fix ruby gemfile lock version detection

### DIFF
--- a/src/Detector/Ruby/RubyDetector.cs
+++ b/src/Detector/Ruby/RubyDetector.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Oryx.Common.Extensions;
@@ -200,7 +201,12 @@ namespace Microsoft.Oryx.Detector.Ruby
                     // Make sure it's in valid format.
                     if (rubyVersionLine.Length == 2)
                     {
-                        return rubyVersionLine[1];
+                        var fullVersion = rubyVersionLine[1];
+                        var parsedVersionMatches = Regex.Match(fullVersion, @"^(.*?)(?:p[0-9]+)*$");
+                        if (parsedVersionMatches.Success)
+                        {
+                            return parsedVersionMatches.Groups[1].Value;
+                        }
                     }
                 }
             }

--- a/src/Detector/Ruby/RubyDetector.cs
+++ b/src/Detector/Ruby/RubyDetector.cs
@@ -202,6 +202,11 @@ namespace Microsoft.Oryx.Detector.Ruby
                     if (rubyVersionLine.Length == 2)
                     {
                         var fullVersion = rubyVersionLine[1];
+
+                        // Parse the ruby version to remove patch versioning from it.
+                        // At times, ruby will add a patch version such as p112 to the end of the semver version,
+                        // which causes Oryx to not find the correct version. This should take a version like
+                        // 2.3.1p112 and convert it to 2.3.1
                         var parsedVersionMatches = Regex.Match(fullVersion, @"^(.*?)(?:p[0-9]+)*$");
                         if (parsedVersionMatches.Success)
                         {

--- a/tests/Detector.Tests/Ruby/RubyDetectorTest.cs
+++ b/tests/Detector.Tests/Ruby/RubyDetectorTest.cs
@@ -26,11 +26,32 @@ namespace Microsoft.Oryx.Detector.Tests.Ruby
             ruby '2.7.1'
         ";
 
-        private const string GemFileLockWithVersion = @"
+        private const string GemFileLockWithPatchVersion = @"
             PLATFORMS
               ruby
             RUBY VERSION
               ruby 2.3.1p112
+        ";
+
+        private const string GemFileLockWithVersion = @"
+            PLATFORMS
+              ruby
+            RUBY VERSION
+              ruby 2.3.1
+        ";
+
+        private const string GemFileLockWithPreviewVersion = @"
+            PLATFORMS
+              ruby
+            RUBY VERSION
+              ruby 2.3.1-preview1
+        ";
+
+        private const string GemFileLockWithRcVersion = @"
+            PLATFORMS
+              ruby
+            RUBY VERSION
+              ruby 2.3.1.rc1
         ";
 
         private const string MalformedGemfile = @"
@@ -151,13 +172,17 @@ namespace Microsoft.Oryx.Detector.Tests.Ruby
             Assert.Equal(string.Empty, result.AppDirectory);
         }
 
-        [Fact]
-        public void Detect_ReturnsVersionFromGemfileLock()
+        [Theory]
+        [InlineData(GemFileLockWithVersion, "2.3.1")]
+        [InlineData(GemFileLockWithPatchVersion, "2.3.1")]
+        [InlineData(GemFileLockWithRcVersion, "2.3.1.rc1")]
+        [InlineData(GemFileLockWithPreviewVersion, "2.3.1-preview1")]
+        public void Detect_ReturnsVersionFromGemfileLock(string fileContents, string expectedVersion)
         {
             // Arrange
             var detector = CreateRubyPlatformDetector();
             var repo = new MemorySourceRepo();
-            repo.AddFile(GemFileLockWithVersion, RubyConstants.GemFileLockName);
+            repo.AddFile(fileContents, RubyConstants.GemFileLockName);
             var context = CreateContext(repo);
 
             // Act
@@ -166,7 +191,7 @@ namespace Microsoft.Oryx.Detector.Tests.Ruby
             // Assert
             Assert.NotNull(result);
             Assert.Equal(RubyConstants.PlatformName, result.Platform);
-            Assert.Equal("2.3.1p112", result.PlatformVersion);
+            Assert.Equal(expectedVersion, result.PlatformVersion);
             Assert.Equal(string.Empty, result.AppDirectory);
         }
 

--- a/tests/Oryx.BuildImage.Tests/CommandTests/OryxCommandTest.cs
+++ b/tests/Oryx.BuildImage.Tests/CommandTests/OryxCommandTest.cs
@@ -140,10 +140,10 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 () =>
                 {
                     Assert.Contains("#!" + expectedBashPath, result.StdOut);
-                    Assert.Contains($"{NodeConstants.PlatformName}={FinalStretchVersions.FinalStretchNode14Version}", result.StdOut);
+                    Assert.Contains($"{NodeConstants.PlatformName}={FinalStretchVersions.FinalStretchNode16Version}", result.StdOut);
                     Assert.True(result.IsSuccess);
                     // Actual output from `node --version` starts with a 'v'
-                    Assert.Contains($"v{FinalStretchVersions.FinalStretchNode14Version}", result.StdOut);
+                    Assert.Contains($"v{FinalStretchVersions.FinalStretchNode16Version}", result.StdOut);
                 },
                 result.GetDebugInfo());
         }

--- a/tests/Oryx.BuildImage.Tests/Node/NodeAppOutputDirTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeAppOutputDirTest.cs
@@ -28,9 +28,10 @@ namespace Oryx.BuildImage.Tests.Node
         // Temporarily blocking next app as next build is failing accross npm
         // [InlineData("blog-starter-nextjs", ".next")]
         // [InlineData("hackernews-nuxtjs", ".nuxt")]
+        // Temporarily blocking gastbysample after node default version bumped to 16
+        // [InlineData("gatsbysample", "public")]
         [InlineData("vue-sample", "dist")]
         [InlineData("create-react-app-sample", "build")]
-        [InlineData("gatsbysample", "public")]
         [InlineData("hexo-sample", "public")]
         public void BuildsApp_AndAddsOutputDirToManifestFile(string appName, string expectedOutputDirPath)
         {

--- a/tests/Oryx.BuildImage.Tests/Node/NodeAppOutputDirTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeAppOutputDirTest.cs
@@ -28,7 +28,7 @@ namespace Oryx.BuildImage.Tests.Node
         // Temporarily blocking next app as next build is failing accross npm
         // [InlineData("blog-starter-nextjs", ".next")]
         // [InlineData("hackernews-nuxtjs", ".nuxt")]
-        // Temporarily blocking gastbysample after node default version bumped to 16
+        // Temporarily blocking gastbysample app after node default version bumped to 16: #1715134
         // [InlineData("gatsbysample", "public")]
         [InlineData("vue-sample", "dist")]
         [InlineData("create-react-app-sample", "build")]

--- a/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
@@ -1093,7 +1093,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         {
             // Arrange
             // Create an app folder with a package.json having the 'appdynamics' package
-            var packageJsonContent = "{\"dependencies\": { \"appdynamics\": \"20.10.1\" }}";
+            var packageJsonContent = "{\"dependencies\": { \"appdynamics\": \"22.11.0\" }}";
             var sampleAppPath = Path.Combine(_tempRootDir, Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(sampleAppPath);
             File.WriteAllText(Path.Combine(sampleAppPath, NodeConstants.PackageJsonFileName), packageJsonContent);

--- a/tests/Oryx.Integration.Tests/Python/PythonDjangoAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonDjangoAppTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Oryx.Integration.Tests
         {
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily blocking multilanguage app after node default version bumped to 16: #1715134")]
         [Trait("category", "python-3.7")]
         [Trait("build-image", "debian-stretch")]
         public async Task CanBuildAndRun_MultiPlatformApp_HavingReactAndDjangoAsync()


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.

See discussion at https://github.com/microsoft/Oryx/issues/1709. In short, ruby adds a patch version to the end of the gemfile.lock file version. Since `2.3.1p112` is equal to `2.3.1`, and Oryx only knows about version is `2.3.1`, we should resolve `2.3.1p112` as `2.3.1`. This also ensures that we can continue to detect rc and preview versions correctly.
- [x] Tests are included and/or updated for code changes.
- [ ] ~Proper license headers are included in each file.~
