### PR TITLE
Fix or skip failing tests after default version update

### DIFF
--- a/tests/Oryx.BuildImage.Tests/CommandTests/OryxCommandTest.cs
+++ b/tests/Oryx.BuildImage.Tests/CommandTests/OryxCommandTest.cs
@@ -140,10 +140,10 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 () =>
                 {
                     Assert.Contains("#!" + expectedBashPath, result.StdOut);
-                    Assert.Contains($"{NodeConstants.PlatformName}={FinalStretchVersions.FinalStretchNode14Version}", result.StdOut);
+                    Assert.Contains($"{NodeConstants.PlatformName}={FinalStretchVersions.FinalStretchNode16Version}", result.StdOut);
                     Assert.True(result.IsSuccess);
                     // Actual output from `node --version` starts with a 'v'
-                    Assert.Contains($"v{FinalStretchVersions.FinalStretchNode14Version}", result.StdOut);
+                    Assert.Contains($"v{FinalStretchVersions.FinalStretchNode16Version}", result.StdOut);
                 },
                 result.GetDebugInfo());
         }

--- a/tests/Oryx.BuildImage.Tests/Node/NodeAppOutputDirTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeAppOutputDirTest.cs
@@ -28,9 +28,10 @@ namespace Oryx.BuildImage.Tests.Node
         // Temporarily blocking next app as next build is failing accross npm
         // [InlineData("blog-starter-nextjs", ".next")]
         // [InlineData("hackernews-nuxtjs", ".nuxt")]
+        // Temporarily blocking gastbysample app after node default version bumped to 16: #1715134
+        // [InlineData("gatsbysample", "public")]
         [InlineData("vue-sample", "dist")]
         [InlineData("create-react-app-sample", "build")]
-        [InlineData("gatsbysample", "public")]
         [InlineData("hexo-sample", "public")]
         public void BuildsApp_AndAddsOutputDirToManifestFile(string appName, string expectedOutputDirPath)
         {

--- a/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
@@ -1093,7 +1093,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         {
             // Arrange
             // Create an app folder with a package.json having the 'appdynamics' package
-            var packageJsonContent = "{\"dependencies\": { \"appdynamics\": \"20.10.1\" }}";
+            var packageJsonContent = "{\"dependencies\": { \"appdynamics\": \"22.11.0\" }}";
             var sampleAppPath = Path.Combine(_tempRootDir, Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(sampleAppPath);
             File.WriteAllText(Path.Combine(sampleAppPath, NodeConstants.PackageJsonFileName), packageJsonContent);

--- a/tests/Oryx.Integration.Tests/Python/PythonDjangoAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonDjangoAppTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Oryx.Integration.Tests
         {
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily blocking multilanguage app after node default version bumped to 16: #1715134")]
         [Trait("category", "python-3.7")]
         [Trait("build-image", "debian-stretch")]
         public async Task CanBuildAndRun_MultiPlatformApp_HavingReactAndDjangoAsync()


### PR DESCRIPTION
The default version for a variety of platforms was updated recently, causing test failures due to certain applications being built against a new version that the app isn't configured to build with in its current state.

This PR attempts to fix the tests that it can and skips the tests that need more investigation that shouldn't block the Validation or Nightly pipelines for other PRs.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
