### PR TITLE
Allow for default versions to upload from dev to prod storage account

### DIFF
--- a/platforms/__common.sh
+++ b/platforms/__common.sh
@@ -122,6 +122,15 @@ shouldOverwritePlatformSdk() {
 	esac
 }
 
+isDefaultVersionFile() {
+	$blobName="$1"
+	if [[ "$blobName" == "defaultVersion"* ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
 getSdkFromImage() {
 	local imageName="$1"
 	local hostVolumeDir="$2"

--- a/vsts/scripts/publishSdksFromDevToProdStorageAccount.sh
+++ b/vsts/scripts/publishSdksFromDevToProdStorageAccount.sh
@@ -36,8 +36,9 @@ function blobExistsInProd() {
 function copyBlob() {
     local platformName="$1"
     local blobName="$2"
+    local isDefaultVersionFile="$3"
 
-    if shouldOverwriteSdk || shouldOverwritePlatformSdk $platformName; then
+    if shouldOverwriteSdk || shouldOverwritePlatformSdk $platformName || isDefaultVersionFile $blobName; then
         echo
         echo "Blob '$blobName' exists in Prod storage container '$platformName'. Overwriting it..."
         if [ $dryRun == "False" ]; then
@@ -90,11 +91,13 @@ function copyPlatformBlobsToProdForDebianFlavor() {
 
     if [ "$debianFlavor" == "stretch" ]; then
         defaultFile="defaultVersion.txt"
+        copyBlob "$platformName" "$defaultFile"
         binaryPrefix="$platformName"
     else
-        defaultFile="defaultVersion.$debianFlavor.txt"
         binaryPrefix="$platformName-$debianFlavor"
     fi
+    defaultFile="defaultVersion.$debianFlavor.txt"
+    copyBlob "$platformName" "$defaultFile"
 
     # Here '3' is a file descriptor which is specifically used to read the versions file.
     # This is used since 'azcopy' command seems to also be using the standard file descriptor for stdin '0'
@@ -111,7 +114,6 @@ function copyPlatformBlobsToProdForDebianFlavor() {
         copyBlob "$platformName" "$binaryPrefix-$version.tar.gz"
 	done 3< "$versionsFile"
 
-    copyBlob "$platformName" "$defaultFile"
 }
 
 if [ ! -f "$azCopyDir/azcopy" ]; then


### PR DESCRIPTION
Judging by [this job](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7169109&view=logs&j=0a5797b8-cfdf-55f5-5b6b-be23ea765961&t=1e82c795-0f4f-504e-24ac-61f2dff7c43d&l=258), default versions were not being updated during the job that copies files to the prod storage account. This should let the files be overwritten.

![image](https://user-images.githubusercontent.com/107068277/211631315-6a5d85b2-43b1-48af-8696-f0be48553e9b.png)

