### PR TITLE
Add back PHP 8.2 as runtime version in constants.yaml

### DIFF
--- a/build/constants.yaml
+++ b/build/constants.yaml
@@ -208,6 +208,7 @@
     - 7.4
     - 8.0
     - 8.1
+    - 8.2
   outputs:
   - type: csharp
     directory: src/BuildScriptGenerator


### PR DESCRIPTION
Just adding back PHP 8.2 to the runtime versions in constants.yaml, as it was removed by mistake recently.