### PR TITLE
Update to run generateConstants after new sdks are added

### DIFF
--- a/.github/workflows/automationTemplate.yaml
+++ b/.github/workflows/automationTemplate.yaml
@@ -51,7 +51,9 @@ jobs:
           echo "PLATFORM_NAME_CAMEL_CASE=${platformNamesAsInBasePipeline[${{ inputs.platformName }}]}" >> $GITHUB_ENV
 
       - name: Run SDK Automation
-        run: dotnet run --project build/tools/Automation/Automation.csproj ${RELEASE_DATE} ${{ github.workspace }}
+        run: |
+          dotnet run --project build/tools/Automation/Automation.csproj ${RELEASE_DATE} ${{ github.workspace }}
+          ./build/generateConstants.sh
 
       - name: Commit new ${{ env.PLATFORM_NAME_CAMEL_CASE }} SDK versions
         run: |


### PR DESCRIPTION
- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as
  - Re-add ./build/generateConstants.sh after getting new SDKs. This needs to be run twice. Once for the SDKs and another for updating Oryx with the runtime base tag. This PR adds the former.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
