### PR TITLE
Handle unsupported runtime platforms in 'oryx dockerfile'

### DIFF
--- a/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
@@ -266,45 +266,44 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         {
             if (string.IsNullOrEmpty(dockerfileProperties.BuildImageName))
             {
-                var message = "Provided build image name parsed from the provided --build-image argument is empty. " +
-                    "Please provide a valid value for --build-image, or remove the argument and use the default " +
-                    "'cli:stable' build image from mcr.microsoft.com/oryx.";
-                var exc = new InvalidDockerfileImageException(message);
-                this.logger.LogError(exc, message);
-                throw exc;
+                this.LogInvalidDockerfileImageException(
+                    "Provided build image name parsed from the provided --build-image argument is empty. " +
+                    "Please provide a valid value for --build-image, or remove the argument to use the default " +
+                    "'cli:stable' build image from mcr.microsoft.com/oryx.");
             }
 
             if (string.IsNullOrEmpty(dockerfileProperties.BuildImageTag))
             {
-                var message = "Provided build image tag parsed from the provided --build-image argument is empty. " +
-                    "Please provide a valid value for --build-image, or remove the argument and use the default " +
-                    "'cli:stable' build image from mcr.microsoft.com/oryx.";
-                var exc = new InvalidDockerfileImageException(message);
-                this.logger.LogError(exc, message);
-                throw exc;
+                this.LogInvalidDockerfileImageException(
+                    "Provided build image tag parsed from the provided --build-image argument is empty. " +
+                    "Please provide a valid value for --build-image, or remove the argument to use the default " +
+                    "'cli:stable' build image from mcr.microsoft.com/oryx.");
             }
 
             if (string.IsNullOrEmpty(dockerfileProperties.RuntimeImageName))
             {
-                var message = "Either the value provided to the --runtime-platform argument is empty, or the platform " +
+                this.LogInvalidDockerfileImageException(
+                    "Either the value provided to the --runtime-platform argument is empty, or the platform " +
                     "discovered by Oryx does not have any available or supported runtime images. Please view the following " +
                     "document for more information on runtimes supported by Oryx: " +
-                    "https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md";
-                var exc = new InvalidDockerfileImageException(message);
-                this.logger.LogError(exc, message);
-                throw exc;
+                    "https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md");
             }
 
             if (string.IsNullOrEmpty(dockerfileProperties.RuntimeImageTag))
             {
-                var message = "Either the value provided to the --runtime-platform-version argument is empty, or the version " +
+                this.LogInvalidDockerfileImageException(
+                    "Either the value provided to the --runtime-platform-version argument is empty, or the version " +
                     "discovered by Oryx is not available or supported for the given platform. Please view the following " +
                     "document for more information on runtime versions supported by Oryx: " +
-                    "https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md";
-                var exc = new InvalidDockerfileImageException(message);
-                this.logger.LogError(exc, message);
-                throw exc;
+                    "https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md");
             }
+        }
+
+        private void LogInvalidDockerfileImageException(string message)
+        {
+            var exc = new InvalidDockerfileImageException(message);
+            this.logger.LogError(exc, message);
+            throw exc;
         }
     }
 }

--- a/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
+++ b/src/BuildScriptGenerator/DefaultDockerfileGenerator.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         {
             if (string.IsNullOrEmpty(dockerfileProperties.BuildImageName))
             {
-                this.LogInvalidDockerfileImageException(
+                this.LogAndThrowInvalidDockerfileImageException(
                     "Provided build image name parsed from the provided --build-image argument is empty. " +
                     "Please provide a valid value for --build-image, or remove the argument to use the default " +
                     "'cli:stable' build image from mcr.microsoft.com/oryx.");
@@ -274,7 +274,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
             if (string.IsNullOrEmpty(dockerfileProperties.BuildImageTag))
             {
-                this.LogInvalidDockerfileImageException(
+                this.LogAndThrowInvalidDockerfileImageException(
                     "Provided build image tag parsed from the provided --build-image argument is empty. " +
                     "Please provide a valid value for --build-image, or remove the argument to use the default " +
                     "'cli:stable' build image from mcr.microsoft.com/oryx.");
@@ -282,24 +282,22 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
             if (string.IsNullOrEmpty(dockerfileProperties.RuntimeImageName))
             {
-                this.LogInvalidDockerfileImageException(
+                this.LogAndThrowInvalidDockerfileImageException(
                     "Either the value provided to the --runtime-platform argument is empty, or the platform " +
                     "discovered by Oryx does not have any available or supported runtime images. Please view the following " +
-                    "document for more information on runtimes supported by Oryx: " +
-                    "https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md");
+                    "document for more information on runtimes supported by Oryx: https://aka.ms/oryx-runtime-images");
             }
 
             if (string.IsNullOrEmpty(dockerfileProperties.RuntimeImageTag))
             {
-                this.LogInvalidDockerfileImageException(
+                this.LogAndThrowInvalidDockerfileImageException(
                     "Either the value provided to the --runtime-platform-version argument is empty, or the version " +
                     "discovered by Oryx is not available or supported for the given platform. Please view the following " +
-                    "document for more information on runtime versions supported by Oryx: " +
-                    "https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md");
+                    "document for more information on runtime versions supported by Oryx: https://aka.ms/oryx-runtime-images");
             }
         }
 
-        private void LogInvalidDockerfileImageException(string message)
+        private void LogAndThrowInvalidDockerfileImageException(string message)
         {
             var exc = new InvalidDockerfileImageException(message);
             this.logger.LogError(exc, message);

--- a/src/BuildScriptGenerator/Exceptions/InvalidDockerfileImageException.cs
+++ b/src/BuildScriptGenerator/Exceptions/InvalidDockerfileImageException.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+
+namespace Microsoft.Oryx.BuildScriptGenerator.Exceptions
+{
+    /// <summary>
+    /// Thrown when an image used for the 'oryx dockerfile' command is invalid.
+    /// </summary>
+    public class InvalidDockerfileImageException : InvalidUsageException
+    {
+        public InvalidDockerfileImageException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/tests/BuildScriptGenerator.Tests/DefaultDockerfileGeneratorTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DefaultDockerfileGeneratorTest.cs
@@ -374,6 +374,57 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests
             Assert.True(detector.DetectInvoked);
         }
 
+        [Theory]
+        [InlineData("golang", "1.17")]
+        [InlineData("java", "11.0.14")]
+        public void GenerateDockerfile_FailsForUnsupportedPlatform(
+            string platformName,
+            string detectedPlatformVersion)
+        {
+            // Arrange
+            var detector = new TestPlatformDetectorUsingPlatformName(
+                detectedPlatformName: platformName,
+                detectedPlatformVersion: detectedPlatformVersion);
+            var platform = new TestProgrammingPlatform(
+                platformName,
+                new string[] { },
+                detector: detector);
+            var commonOptions = new BuildScriptGeneratorOptions();
+            var generator = CreateDefaultDockerfileGenerator(platform, commonOptions);
+            var ctx = CreateDockerfileContext();
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidDockerfileImageException>(() => generator.GenerateDockerfile(ctx));
+            Assert.Contains("--runtime-platform argument is empty", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("golang", "1.17")]
+        [InlineData("java", "11.0.14")]
+        public void GenerateDockerfile_FailsForUnsupportedPlatformVersion(
+            string platformName,
+            string detectedPlatformVersion)
+        {
+            // Arrange
+            var detector = new TestPlatformDetectorUsingPlatformName(
+                detectedPlatformName: platformName,
+                detectedPlatformVersion: detectedPlatformVersion);
+            var platform = new TestProgrammingPlatform(
+                platformName,
+                new string[] { },
+                detector: detector);
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                RuntimePlatformName = platformName,
+            };
+            var generator = CreateDefaultDockerfileGenerator(platform, commonOptions);
+            var ctx = CreateDockerfileContext();
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidDockerfileImageException>(() => generator.GenerateDockerfile(ctx));
+            Assert.Contains("--runtime-platform-version argument is empty", exception.Message);
+        }
+
         private DockerfileContext CreateDockerfileContext()
         {
             return new DockerfileContext();


### PR DESCRIPTION
Currently when running the `oryx dockerfile` command against an application that targets a platform without a supporting set of runtime images, the Dockerfile generated has empty values for the runtime, which is causing some users issues when using `azure/container-app-deploy-action` or the `AzureContainerAppsRC` task.

Relevant issue filed: https://github.com/Azure/container-apps-deploy-pipelines-task/issues/9

This PR now checks for the build and runtime images provided/discovered by the `oryx dockerfile` command and ensures that they are valid before trying to populate the Dockerfile template with them, and if not valid, throws meaningful exceptions to let the user know why the command failed (and in the case of runtimes, point them to [our doc](https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md) with the supported runtimes).

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
