### PR TITLE
Remove debian flavor specific repo for cli 

### DIFF
--- a/acr-tasks/purge-dev-acr-tasks.sh
+++ b/acr-tasks/purge-dev-acr-tasks.sh
@@ -14,9 +14,6 @@ az acr task create --name weeklyBuildImagePurgeTask -r oryxdevmcr --cmd "$PURGE_
 PURGE_CMD="acr purge  --filter 'public/oryx/cli:.*'  --ago 30d --untagged"
 az acr task create --name weeklyCliImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
 
-PURGE_CMD="acr purge  --filter 'public/oryx/cli-buster:.*'  --ago 30d --untagged"
-az acr task create --name weeklyCliBusterImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
-
 PURGE_CMD="acr purge  --filter 'public/oryx/base:.*'  --ago 30d --untagged"
 az acr task create --name weeklyBaseImagePurgeTask -r oryxdevmcr --cmd "$PURGE_CMD" --schedule "0 22 * * WED" --timeout 9000 -c /dev/null
 

--- a/build/buildBuildImages.sh
+++ b/build/buildBuildImages.sh
@@ -412,7 +412,7 @@ function buildCliImage() {
 		debianFlavor="stretch"
 		builtImageName="$builtImageName:debian-$debianFlavor"
 	else
-		builtImageName="$builtImageName-$debianFlavor:debian-$debianFlavor"
+		builtImageName="$builtImageName:debian-$debianFlavor"
 		devImageRepo="$DEVBOX_CLI_BUILD_IMAGE_REPO-$debianFlavor"
 	fi
 	echo "dev image tag: "$devImageTag
@@ -495,6 +495,7 @@ if [ -z "$imageTypeToBuild" ]; then
 	buildVsoImage "focal"
 	buildVsoImage "bullseye"
 	buildCliImage "buster"
+	buildCliImage "bullseye"
 	buildCliImage
 	buildBuildPackImage
 	buildFullImage "buster"
@@ -536,8 +537,13 @@ elif [ "$imageTypeToBuild" == "vso-bullseye" ]; then
 elif [ "$imageTypeToBuild" == "cli" ]; then
 	buildCliImage
 	buildCliImage "buster"
+	buildCliImage "bullseye"
+elif [ "$imageTypeToBuild" == "cli-stretch" ]; then
+    buildCliImage
 elif [ "$imageTypeToBuild" == "cli-buster" ]; then
 	buildCliImage "buster"
+elif ["$imageTypeToBuild" == "cli-bullseye"]; then
+    buildCliImage "bullseye"
 elif [ "$imageTypeToBuild" == "buildpack" ]; then
 	buildBuildPackImage
 else

--- a/build/buildBuildImages.sh
+++ b/build/buildBuildImages.sh
@@ -542,7 +542,7 @@ elif [ "$imageTypeToBuild" == "cli-stretch" ]; then
     buildCliImage
 elif [ "$imageTypeToBuild" == "cli-buster" ]; then
 	buildCliImage "buster"
-elif ["$imageTypeToBuild" == "cli-bullseye"]; then
+elif ["$imageTypeToBuild" == "cli-bullseye" ]; then
     buildCliImage "bullseye"
 elif [ "$imageTypeToBuild" == "buildpack" ]; then
 	buildBuildPackImage

--- a/build/buildBuildImages.sh
+++ b/build/buildBuildImages.sh
@@ -542,7 +542,7 @@ elif [ "$imageTypeToBuild" == "cli-stretch" ]; then
     buildCliImage
 elif [ "$imageTypeToBuild" == "cli-buster" ]; then
 	buildCliImage "buster"
-elif ["$imageTypeToBuild" == "cli-bullseye" ]; then
+elif [ "$imageTypeToBuild" == "cli-bullseye" ]; then
     buildCliImage "bullseye"
 elif [ "$imageTypeToBuild" == "buildpack" ]; then
 	buildBuildPackImage

--- a/images/build/Dockerfiles/cli.Dockerfile
+++ b/images/build/Dockerfiles/cli.Dockerfile
@@ -47,7 +47,6 @@ RUN if [ "${DEBIAN_FLAVOR}" = "buster" ]; then \
         && rm -rf /var/lib/apt/lists/* ; \
     fi
 
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
 # .NET Core dependencies for running Oryx

--- a/images/build/Dockerfiles/cli.Dockerfile
+++ b/images/build/Dockerfiles/cli.Dockerfile
@@ -31,7 +31,6 @@ RUN if [ "${DEBIAN_FLAVOR}" = "buster" ]; then \
     elif [ "${DEBIAN_FLAVOR}" = "bullseye" ]; then \ 
         apt-get update \
         && apt-get install -y --no-install-recommends \
-            libssl1.0.2 \
             libicu67 \
             libcurl4 \
             libssl1.1 \
@@ -47,6 +46,7 @@ RUN if [ "${DEBIAN_FLAVOR}" = "buster" ]; then \
             libssl1.0.2 \
         && rm -rf /var/lib/apt/lists/* ; \
     fi
+
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/images/build/Dockerfiles/cli.Dockerfile
+++ b/images/build/Dockerfiles/cli.Dockerfile
@@ -28,6 +28,15 @@ RUN if [ "${DEBIAN_FLAVOR}" = "buster" ]; then \
             libcurl4 \
             libssl1.1 \
         && rm -rf /var/lib/apt/lists/* ; \
+    elif [ "${DEBIAN_FLAVOR}" = "bullseye" ]; then \ 
+        apt-get update \
+        && apt-get install -y --no-install-recommends \
+            libicu67 \
+            libcurl4 \
+            libssl1.1 \
+            libyaml-dev \
+            libxml2 \
+        && rm -rf /var/lib/apt/lists/* ; \
     else \
         apt-get update \
         && apt-get install -y --no-install-recommends \
@@ -48,6 +57,8 @@ RUN apt-get update \
         zlib1g \
         rsync \
         libgdiplus \
+        # Required for mysqlclient
+        default-libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/* \
     && chmod a+x /opt/buildscriptgen/GenerateBuildScript \
     && mkdir -p /opt/oryx \

--- a/images/build/Dockerfiles/cli.Dockerfile
+++ b/images/build/Dockerfiles/cli.Dockerfile
@@ -31,6 +31,7 @@ RUN if [ "${DEBIAN_FLAVOR}" = "buster" ]; then \
     elif [ "${DEBIAN_FLAVOR}" = "bullseye" ]; then \ 
         apt-get update \
         && apt-get install -y --no-install-recommends \
+            libssl1.0.2 \
             libicu67 \
             libcurl4 \
             libssl1.1 \

--- a/src/BuildScriptGenerator/Php/PhpComposerInstaller.cs
+++ b/src/BuildScriptGenerator/Php/PhpComposerInstaller.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
             stringBuilder.AppendLine($"echo 'Installing php-composer specific dependencies...'");
 
             // Install an assortment of traditional tooling (unicode, SSL, HTTP, etc.)
-            stringBuilder.AppendLine("if [ \"${DEBIAN_FLAVOR}\" = \"buster\" ]; then");
+            stringBuilder.AppendLine("if [[ \"${DEBIAN_FLAVOR}\" = \"buster\" || \"${DEBIAN_FLAVOR}\" = \"bullseye\" ]]; then");
             stringBuilder.AppendAptGetInstallPackages(
                 "ca-certificates",
                 "libargon2-0",

--- a/src/BuildScriptGenerator/Php/PhpPlatformInstaller.cs
+++ b/src/BuildScriptGenerator/Php/PhpPlatformInstaller.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
             stringBuilder.AppendLine($"echo 'Installing {PhpConstants.PlatformName} specific dependencies...'");
 
             // Install an assortment of traditional tooling (unicode, SSL, HTTP, etc.)
-            stringBuilder.AppendLine("if [ \"${DEBIAN_FLAVOR}\" = \"buster\" ]; then");
+            stringBuilder.AppendLine("if [[ \"${DEBIAN_FLAVOR}\" = \"buster\" || \"${DEBIAN_FLAVOR}\" = \"bullseye\" ]]; then");
             stringBuilder.AppendAptGetInstallPackages(
                 "ca-certificates",
                 "libargon2-0",

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
             string runtimeVersion)
         {
             BuildsApplication_ByDynamicallyInstallingSDKs(
-                appName, runtimeVersion, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+                appName, runtimeVersion, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
         private void BuildsApplication_ByDynamicallyInstallingSDKs(
@@ -753,7 +753,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
             
             var imageHelper = new ImageTestHelper();
             TestImageTypeResolution(
-                imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository),
+                imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag),
                 removeImageTypeFile,
                 "cli");
         }

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
@@ -82,6 +82,16 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 appName, runtimeVersion, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
+        [Theory, Trait("category", "cli-bullseye")]
+        [InlineData(NetCore7PreviewMvcApp, "7.0")]
+        public void BuildsApplication_ByDynamicallyInstallingSDKs_CliBullseye(
+           string appName,
+           string runtimeVersion)
+        {
+            BuildsApplication_ByDynamicallyInstallingSDKs(
+                appName, runtimeVersion, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+        }
+
         private void BuildsApplication_ByDynamicallyInstallingSDKs(
             string appName,
             string runtimeVersion,

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
@@ -763,7 +763,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
             
             var imageHelper = new ImageTestHelper();
             TestImageTypeResolution(
-                imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag),
+                imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository),
                 removeImageTypeFile,
                 "cli");
         }

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Fact, Trait("category", "cli")]
         public void PipelineTestInvocationCli()
         {
-            GDIPlusLibrary_IsPresentInTheImage(ImageTestHelperConstants.CliStretchTag);
+            GDIPlusLibrary_IsPresentInTheImage(ImageTestHelperConstants.CliRepository);
             Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage());
         }
 

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
@@ -58,15 +58,15 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Fact, Trait("category", "cli")]
         public void PipelineTestInvocationCli()
         {
-            GDIPlusLibrary_IsPresentInTheImage(ImageTestHelperConstants.CliRepository);
+            GDIPlusLibrary_IsPresentInTheImage(ImageTestHelperConstants.CliStretchTag);
             Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage());
         }
 
         [Fact, Trait("category", "cli-buster")]
         public void PipelineTestInvocationCliBuster()
         {
-            GDIPlusLibrary_IsPresentInTheImage(ImageTestHelperConstants.CliBusterRepository);
-            Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+            GDIPlusLibrary_IsPresentInTheImage(ImageTestHelperConstants.CliBusterTag);
+            Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
         private readonly string SdkVersionMessageFormat = "Using .NET Core SDK Version: {0}";

--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreSampleAppsTest.cs
@@ -69,6 +69,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
+        [Fact, Trait("category", "cli-bullseye")]
+        public void PipelineTestInvocationCliBullseye()
+        {
+            GDIPlusLibrary_IsPresentInTheImage(ImageTestHelperConstants.CliBullseyeTag);
+            Builds_NetCore31App_UsingNetCore31_DotNetSdkVersion(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+        }
+
         private readonly string SdkVersionMessageFormat = "Using .NET Core SDK Version: {0}";
 
         [Fact (Skip="NetCore11 is no longer officially supported"), Trait("category", "latest")]

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCli()
         {
             var imageTestHelper = new ImageTestHelper();
-            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag));
+            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliRepository));
         }
 
         [Fact, Trait("category", "cli-buster")]

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
@@ -50,6 +50,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
+        [Fact, Trait("category", "cli-bullseye")]
+        public void PipelineTestInvocationCliBullseye()
+        {
+            var imageTestHelper = new ImageTestHelper();
+            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+        }
+
         private void InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(string imageName)
         {
             // Please note:

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoDynamicInstallationTest.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCli()
         {
             var imageTestHelper = new ImageTestHelper();
-            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliRepository));
+            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag));
         }
 
         [Fact, Trait("category", "cli-buster")]
         public void PipelineTestInvocationCliBuster()
         {
             var imageTestHelper = new ImageTestHelper();
-            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+            InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
         private void InstallsHugoVersionDynamically_UsingEnvironmentVariable_AndBuildsApp(string imageName)

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCli()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag));
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliRepository));
         }
 
         [Fact, Trait("category", "cli-buster")]

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
@@ -47,14 +47,14 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCli()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliRepository));
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag));
         }
 
         [Fact, Trait("category", "cli-buster")]
         public void PipelineTestInvocationCliBuster()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
         private void GeneratesScript_AndBuilds(string buildImageName)

--- a/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Hugo/HugoSampleAppsTest.cs
@@ -57,6 +57,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
+        [Fact, Trait("category", "cli-bullseye")]
+        public void PipelineTestInvocationCliBullseye()
+        {
+            var imageTestHelper = new ImageTestHelper();
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+        }
+
         private void GeneratesScript_AndBuilds(string buildImageName)
         {
             // Please note:

--- a/tests/Oryx.BuildImage.Tests/Java/JavaDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Java/JavaDynamicInstallationTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [MemberData(nameof(VersionsData))]
         public void BuildsMavenArcheTypeSampleWithDynamicInstallationCliBuster(string version)
         {
-            BuildsMavenArcheTypeSampleWithDynamicInstallation(version, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+            BuildsMavenArcheTypeSampleWithDynamicInstallation(version, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
         private void BuildsMavenArcheTypeSampleWithDynamicInstallation(string version, string imageName)

--- a/tests/Oryx.BuildImage.Tests/Java/JavaDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Java/JavaDynamicInstallationTest.cs
@@ -57,6 +57,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             BuildsMavenArcheTypeSampleWithDynamicInstallation(version, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
+        [Theory, Trait("category", "cli-bullseye")]
+        [MemberData(nameof(VersionsData))]
+        public void BuildsMavenArcheTypeSampleWithDynamicInstallationCliBullseye(string version)
+        {
+            BuildsMavenArcheTypeSampleWithDynamicInstallation(version, _imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+        }
+
         private void BuildsMavenArcheTypeSampleWithDynamicInstallation(string version, string imageName)
         {
             // Arrange

--- a/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
@@ -53,6 +53,16 @@ namespace Microsoft.Oryx.BuildImage.Tests
             BuildsSpringBootSampleApp(imageTag);
         }
 
+        [Theory, Trait("category", "cli-bullseye")]
+        [InlineData(ImageTestHelperConstants.CliBullseyeTag)]
+        public void JavaSampleAppsTestsCliBullseye(string imageTag)
+        {
+            BuildsMavenArcheTypeSample(imageTag);
+            BuildsMavenJ2EESample(imageTag);
+            BuildsMavenSimpleJavaApp(imageTag);
+            BuildsSpringBootSampleApp(imageTag);
+        }
+
         private void BuildsMavenArcheTypeSample(string imageTag)
         {
             // Arrange

--- a/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
 
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliRepository)]
+        [InlineData(ImageTestHelperConstants.CliStretchTag)]
         public void JavaSampleAppsTestsCli(string imageTag)
         {
             BuildsMavenArcheTypeSample(imageTag);
@@ -44,7 +44,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli-buster")]
-        [InlineData(ImageTestHelperConstants.CliBusterRepository)]
+        [InlineData(ImageTestHelperConstants.CliBusterTag)]
         public void JavaSampleAppsTestsCliBuster(string imageTag)
         {
             BuildsMavenArcheTypeSample(imageTag);

--- a/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Java/JavaSampleAppsTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
 
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliStretchTag)]
+        [InlineData(ImageTestHelperConstants.CliRepository)]
         public void JavaSampleAppsTestsCli(string imageTag)
         {
             BuildsMavenArcheTypeSample(imageTag);

--- a/tests/Oryx.BuildImage.Tests/Node/NodeDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeDynamicInstallationTest.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Oryx.BuildImage.Tests
             {
                 var data = new TheoryData<string, string>();
                 var imageTestHelper = new ImageTestHelper();
-                data.Add("12.22.11", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
-                data.Add("14.19.1", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
-                data.Add("16.14.2", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+                data.Add("12.22.11", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
+                data.Add("14.19.1", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
+                data.Add("16.14.2", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
                 return data;
             }
         }

--- a/tests/Oryx.BuildImage.Tests/Node/NodeDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeDynamicInstallationTest.cs
@@ -61,6 +61,19 @@ namespace Microsoft.Oryx.BuildImage.Tests
             }
         }
 
+        public static TheoryData<string, string> ImageNameDataCliBullseye
+        {
+            get
+            {
+                var data = new TheoryData<string, string>();
+                var imageTestHelper = new ImageTestHelper();
+                data.Add("12.22.11", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+                data.Add("14.19.1", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+                data.Add("16.14.2", imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+                return data;
+            }
+        }
+
         [Theory, Trait("category", "githubactions")]
         [Trait("build-image", "github-actions-debian-stretch")]
         [MemberData(nameof(ImageNameData))]
@@ -81,6 +94,14 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Trait("build-image", "cli-debian-buster")]
         [MemberData(nameof(ImageNameDataCliBuster))]
         public void GeneratesScript_AndBuildNodeAppsWithDynamicInstallationCliBuster(string version, string buildImageName)
+        {
+            GeneratesScript_AndBuildNodeAppsWithDynamicInstallation(version, buildImageName);
+        }
+
+        [Theory, Trait("category", "cli-bullseye")]
+        [Trait("build-image", "cli-debian-bullseye")]
+        [MemberData(nameof(ImageNameDataCliBullseye))]
+        public void GeneratesScript_AndBuildNodeAppsWithDynamicInstallationCliBullseye(string version, string buildImageName)
         {
             GeneratesScript_AndBuildNodeAppsWithDynamicInstallation(version, buildImageName);
         }

--- a/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
@@ -63,6 +63,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
+        [Fact, Trait("category", "cli-bullseye")]
+        public void PipelineTestInvocationCliBullseye()
+        {
+            var imageTestHelper = new ImageTestHelper();
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+        }
+
         private void GeneratesScript_AndBuilds(string buildImageName)
         {
             // Please note:

--- a/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
+++ b/tests/Oryx.BuildImage.Tests/Node/NodeJsSampleAppsOtherTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCliBuster()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+            GeneratesScript_AndBuilds(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
         private void GeneratesScript_AndBuilds(string buildImageName)

--- a/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
@@ -89,6 +89,26 @@ namespace Microsoft.Oryx.BuildImage.Tests
             }
         }
 
+        public static TheoryData<string, string, string> VersionAndImageNameDataCliBullseye
+        {
+            get
+            {
+                var data = new TheoryData<string, string, string>();
+                var imageHelper = new ImageTestHelper();
+                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php82Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.ComposerVersion);
+
+                // test latest php-composer version
+                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php82Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), PhpVersions.Composer23Version);
+                return data;
+            }
+        }
+
         [Theory, Trait("category", "githubactions")]
         [MemberData(nameof(VersionAndImageNameData))]
         public void BuildsAppByInstallingSdkDynamicallyGithubActions(string phpVersion, string imageName, string phpComposerVersion)
@@ -106,6 +126,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Theory, Trait("category", "cli-buster")]
         [MemberData(nameof(VersionAndImageNameDataCliBuster))]
         public void BuildsAppByInstallingSdkDynamicallyCliBuster(string phpVersion, string imageName, string phpComposerVersion)
+        {
+            BuildsAppByInstallingSdkDynamically(phpVersion, imageName, phpComposerVersion, "/opt/php");
+        }
+
+        [Theory, Trait("category", "cli-bullseye")]
+        [MemberData(nameof(VersionAndImageNameDataCliBullseye))]
+        public void BuildsAppByInstallingSdkDynamicallyCliBullseye(string phpVersion, string imageName, string phpComposerVersion)
         {
             BuildsAppByInstallingSdkDynamically(phpVersion, imageName, phpComposerVersion, "/opt/php");
         }

--- a/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpDynamicInstallationTest.cs
@@ -75,16 +75,16 @@ namespace Microsoft.Oryx.BuildImage.Tests
             {
                 var data = new TheoryData<string, string, string>();
                 var imageHelper = new ImageTestHelper();
-                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.ComposerVersion);
-                data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.ComposerVersion);
-                data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.ComposerVersion);
-                data.Add(PhpVersions.Php82Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.ComposerVersion);
+                data.Add(PhpVersions.Php82Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.ComposerVersion);
 
                 // test latest php-composer version
-                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.Composer23Version);
-                data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.Composer23Version);
-                data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.Composer23Version);
-                data.Add(PhpVersions.Php82Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php74Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php80Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php81Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.Composer23Version);
+                data.Add(PhpVersions.Php82Version, imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), PhpVersions.Composer23Version);
                 return data;
             }
         }

--- a/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(PhpVersions.Php74Version, ImageTestHelperConstants.CliStretchTag)]
-        [InlineData(PhpVersions.Php73Version, ImageTestHelperConstants.CliStretchTag)]
+        [InlineData(PhpVersions.Php74Version, ImageTestHelperConstants.CliRepository)]
+        [InlineData(PhpVersions.Php73Version, ImageTestHelperConstants.CliRepository)]
         public void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation_Cli(string phpVersion, string imageTag) {
             GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(phpVersion, imageTag);
         }

--- a/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
@@ -97,14 +97,14 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(PhpVersions.Php74Version, ImageTestHelperConstants.CliRepository)]
-        [InlineData(PhpVersions.Php73Version, ImageTestHelperConstants.CliRepository)]
+        [InlineData(PhpVersions.Php74Version, ImageTestHelperConstants.CliStretchTag)]
+        [InlineData(PhpVersions.Php73Version, ImageTestHelperConstants.CliStretchTag)]
         public void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation_Cli(string phpVersion, string imageTag) {
             GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(phpVersion, imageTag);
         }
 
         [Theory, Trait("category", "cli-buster")]
-        [InlineData(PhpVersions.Php80Version, ImageTestHelperConstants.CliBusterRepository)]
+        [InlineData(PhpVersions.Php80Version, ImageTestHelperConstants.CliBusterTag)]
         public void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation_CliBuster(string phpVersion, string imageTag) {
             GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(phpVersion, imageTag);
         }

--- a/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Php/PhpSampleAppsTest.cs
@@ -109,6 +109,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(phpVersion, imageTag);
         }
 
+        [Theory, Trait("category", "cli-bullseye")]
+        [InlineData(PhpVersions.Php80Version, ImageTestHelperConstants.CliBullseyeTag)]
+        public void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation_CliBullseye(string phpVersion, string imageTag)
+        {
+            GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(phpVersion, imageTag);
+        }
+
         private void GeneratesScript_AndBuilds_TwigExample_WithDynamicInstallation(string phpVersion, string imageTag)
         {
             // Arrange

--- a/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Trait("category", "cli")]
         public void PulledCliStretchBuildImages_Contains_BUILDIMAGE_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag), "cli");
+            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository), "cli");
         }
 
         [Fact]

--- a/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
@@ -61,14 +61,14 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Trait("category", "cli")]
         public void PulledCliStretchBuildImages_Contains_BUILDIMAGE_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository), "cli");
+            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag), "cli");
         }
 
         [Fact]
         [Trait("category", "cli-buster")]
         public void PulledCliBusterBuildImages_Contains_BUILDIMAGE_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), "cli");
+            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), "cli");
         }
 
         [Fact]

--- a/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
@@ -72,6 +72,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Fact]
+        [Trait("category", "cli-bullseye")]
+        public void PulledCliBullseyeBuildImages_Contains_BUILDIMAGE_TYPE_Info()
+        {
+            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeRepository), "cli");
+        }
+
+        [Fact]
         [Trait("category", "jamstack")]
         public void PulledJamstackStretchBuildImages_Contains_BUILDIMAGE_TYPE_Info()
         {

--- a/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildImageTypeTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Trait("category", "cli-bullseye")]
         public void PulledCliBullseyeBuildImages_Contains_BUILDIMAGE_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeRepository), "cli");
+            PulledBuildImages_Contains_BUILDIMAGE_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), "cli");
         }
 
         [Fact]

--- a/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Trait("category", "cli")]
         public void PulledCliStretchBuildImages_Contains_BUILDOS_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag), "DEBIAN|STRETCH");
+            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository), "DEBIAN|STRETCH");
         }
 
         [Fact]

--- a/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
@@ -93,6 +93,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Fact]
+        [Trait("category", "cli-bullseye")]
+        public void PulledCliBullseyeBuildImages_Contains_BUILDOS_TYPE_Info()
+        {
+            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeRepository), "DEBIAN|BULLSEYE");
+        }
+
+        [Fact]
         [Trait("category", "jamstack")]
         public void PulledJamstackStretchBuildImages_Contains_BUILDOS_TYPE_Info()
         {

--- a/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
@@ -82,14 +82,14 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Trait("category", "cli")]
         public void PulledCliStretchBuildImages_Contains_BUILDOS_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository), "DEBIAN|STRETCH");
+            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag), "DEBIAN|STRETCH");
         }
 
         [Fact]
         [Trait("category", "cli-buster")]
         public void PulledCliBusterBuildImages_Contains_BUILDOS_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), "DEBIAN|BUSTER");
+            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), "DEBIAN|BUSTER");
         }
 
         [Fact]

--- a/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
+++ b/tests/Oryx.BuildImage.Tests/PulledBuildOsTypeTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Trait("category", "cli-bullseye")]
         public void PulledCliBullseyeBuildImages_Contains_BUILDOS_TYPE_Info()
         {
-            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeRepository), "DEBIAN|BULLSEYE");
+            PulledBuildImages_Contains_BUILDOS_TYPE_Info(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), "DEBIAN|BULLSEYE");
         }
 
         [Fact]

--- a/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
@@ -67,6 +67,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), "3.9.0", "/opt");
         }
 
+        [Fact, Trait("category", "cli-bullseye")]
+        public void PipelineTestInvocationCliBullseye()
+        {
+            var imageTestHelper = new ImageTestHelper();
+            GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeRepository), "3.9.0", "/opt");
+        }
+
         private void GeneratesScript_AndBuildsPython_FlaskApp(
             string imageName, 
             string version, 

--- a/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCliBuster()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository), "3.9.0", "/opt");
+            GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag), "3.9.0", "/opt");
         }
 
         private void GeneratesScript_AndBuildsPython_FlaskApp(

--- a/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonDynamicInstallationTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         public void PipelineTestInvocationCliBullseye()
         {
             var imageTestHelper = new ImageTestHelper();
-            GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeRepository), "3.9.0", "/opt");
+            GeneratesScript_AndBuildsPython_FlaskApp(imageTestHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag), "3.9.0", "/opt");
         }
 
         private void GeneratesScript_AndBuildsPython_FlaskApp(

--- a/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliRepository)]
+        [InlineData(ImageTestHelperConstants.CliStretchTag)]
         public void PipelineTestInvocationCli(string imageTag)
         {
             GeneratesScript_AndBuilds(_imageHelper.GetCliImage(imageTag));
@@ -66,7 +66,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli-buster")]
-        [InlineData(ImageTestHelperConstants.CliBusterRepository)]
+        [InlineData(ImageTestHelperConstants.CliBusterTag)]
         public void PipelineTestInvocationCliBuster(string imageTag)
         {
             GeneratesScript_AndBuilds(_imageHelper.GetCliImage(imageTag));

--- a/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
@@ -74,6 +74,15 @@ namespace Microsoft.Oryx.BuildImage.Tests
             DoesNotGenerateCondaBuildScript_IfImageDoesNotHaveCondaInstalledInIt(imageTag);
         }
 
+        [Theory, Trait("category", "cli-bullseye")]
+        [InlineData(ImageTestHelperConstants.CliBullseyeTag)]
+        public void PipelineTestInvocationCliBullseye(string imageTag)
+        {
+            GeneratesScript_AndBuilds(_imageHelper.GetCliImage(imageTag));
+            JamSpell_CanBe_Installed_In_The_BuildImage(imageTag);
+            DoesNotGenerateCondaBuildScript_IfImageDoesNotHaveCondaInstalledInIt(imageTag);
+        }
+
         [Theory]
         [InlineData(Settings.BuildImageName)]
         [InlineData(Settings.LtsVersionsBuildImageName)]

--- a/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Python/PythonSampleAppsTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliStretchTag)]
+        [InlineData(ImageTestHelperConstants.CliRepository)]
         public void PipelineTestInvocationCli(string imageTag)
         {
             GeneratesScript_AndBuilds(_imageHelper.GetCliImage(imageTag));

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliRepository)]
+        [InlineData(ImageTestHelperConstants.CliStretchTag)]
         public void PipelineTestInvocationCli(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();
@@ -53,7 +53,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli-buster")]
-        [InlineData(ImageTestHelperConstants.CliBusterRepository)]
+        [InlineData(ImageTestHelperConstants.CliBusterTag)]
         public void PipelineTestInvocationCliBuster(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliStretchTag)]
+        [InlineData(ImageTestHelperConstants.CliRepository)]
         public void PipelineTestInvocationCli(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubyDynamicInstallationTest.cs
@@ -63,6 +63,17 @@ namespace Microsoft.Oryx.BuildImage.Tests
                 RubyVersions.Ruby31Version, imageTestHelper.GetCliImage(imageTag));
         }
 
+        [Theory, Trait("category", "cli-bullseye")]
+        [InlineData(ImageTestHelperConstants.CliBullseyeTag)]
+        public void PipelineTestInvocationCliBullseye(string imageTag)
+        {
+            var imageTestHelper = new ImageTestHelper();
+            GeneratesScript_AndBuildSinatraAppWithDynamicInstall(
+                RubyVersions.Ruby30Version, imageTestHelper.GetCliImage(imageTag));
+            GeneratesScript_AndBuildSinatraAppWithDynamicInstall(
+                RubyVersions.Ruby31Version, imageTestHelper.GetCliImage(imageTag));
+        }
+
         private void GeneratesScript_AndBuildSinatraAppWithDynamicInstall(string version, string buildImageName)
         {
             // Please note:

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliRepository)]
+        [InlineData(ImageTestHelperConstants.CliStretchTag)]
         public void PipelineTestInvocationCli(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();
@@ -51,7 +51,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli-buster")]
-        [InlineData(ImageTestHelperConstants.CliBusterRepository)]
+        [InlineData(ImageTestHelperConstants.CliBusterTag)]
         public void PipelineTestInvocationCliBuster(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
@@ -60,6 +60,16 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuildRailsApp(imageTestHelper.GetCliImage(imageTag));
         }
 
+        [Theory, Trait("category", "cli-bullseye")]
+        [InlineData(ImageTestHelperConstants.CliBullseyeTag)]
+        public void PipelineTestInvocationCliBullseye(string imageTag)
+        {
+            var imageTestHelper = new ImageTestHelper();
+            Builds_JekyllStaticWebApp_UsingCustomBuildCommand(
+                imageTestHelper.GetCliImage(imageTag));
+            GeneratesScript_AndBuildRailsApp(imageTestHelper.GetCliImage(imageTag));
+        }
+
         [Fact, Trait("category", "vso-focal")]
         public void GeneratesScript_AndBuildSinatraApp()
         {

--- a/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
+++ b/tests/Oryx.BuildImage.Tests/Ruby/RubySampleAppsTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         }
 
         [Theory, Trait("category", "cli")]
-        [InlineData(ImageTestHelperConstants.CliStretchTag)]
+        [InlineData(ImageTestHelperConstants.CliRepository)]
         public void PipelineTestInvocationCli(string imageTag)
         {
             var imageTestHelper = new ImageTestHelper();

--- a/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
@@ -54,6 +54,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
             GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
+        [Fact, Trait("category", "cli-bullseye")]
+        public void GeneratesScript_AndBuildGolangAppWithDynamicInstall_CliBullseye()
+        {
+            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBullseyeTag));
+        }
+
+
         private void GeneratesScript_AndBuildGolangAppWithDynamicInstall(string imageName)
         {
             var imageTestHelper = new ImageTestHelper();

--- a/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
@@ -45,13 +45,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Fact, Trait("category", "cli")]
         public void GeneratesScript_AndBuildGolangAppWithDynamicInstall_Cli()
         {
-            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository));
+            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag));
         }
 
         [Fact, Trait("category", "cli-buster")]
         public void GeneratesScript_AndBuildGolangAppWithDynamicInstall_CliBuster()
         {
-            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterRepository));
+            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliBusterTag));
         }
 
         private void GeneratesScript_AndBuildGolangAppWithDynamicInstall(string imageName)

--- a/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
+++ b/tests/Oryx.BuildImage.Tests/golang/GolangDynamicInstallationTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Oryx.BuildImage.Tests
         [Fact, Trait("category", "cli")]
         public void GeneratesScript_AndBuildGolangAppWithDynamicInstall_Cli()
         {
-            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliStretchTag));
+            GeneratesScript_AndBuildGolangAppWithDynamicInstall(_imageHelper.GetCliImage(ImageTestHelperConstants.CliRepository));
         }
 
         [Fact, Trait("category", "cli-buster")]

--- a/tests/Oryx.Tests.Common/ImageTestHelper.cs
+++ b/tests/Oryx.Tests.Common/ImageTestHelper.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Oryx.Tests.Common
                 return $"{_repoPrefix}/{_cliRepository}:{_cliBullseyeTag}{_tagSuffix}";
             }
 
-            return $"{_repoPrefix}/{_cliStretchTag}:{_cliStretchTag}{_tagSuffix}";
+            return $"{_repoPrefix}/{_cliRepository}:{_cliStretchTag}{_tagSuffix}";
         }
 
         private string GetTestTag()

--- a/tests/Oryx.Tests.Common/ImageTestHelper.cs
+++ b/tests/Oryx.Tests.Common/ImageTestHelper.cs
@@ -241,9 +241,9 @@ namespace Microsoft.Oryx.Tests.Common
             {
                 return GetAzureFunctionsJamStackBuildImage(_azureFunctionsJamStackBullseye);
             }
-            else if (string.Equals(tag, _cliStretchTag))
+            else if (string.Equals(tag, _cliRepository))
             {
-                return GetCliImage(_cliStretchTag);
+                return GetCliImage(_cliRepository);
             }
             else if (string.Equals(tag, _cliBusterTag))
             {

--- a/tests/Oryx.Tests.Common/ImageTestHelper.cs
+++ b/tests/Oryx.Tests.Common/ImageTestHelper.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Oryx.Tests.Common
         private const string _vsoBullseye = ImageTestHelperConstants.VsoBullseye;
         private const string _buildRepository = ImageTestHelperConstants.BuildRepository;
         private const string _packRepository = ImageTestHelperConstants.PackRepository;
+        private const string _cliRepository = ImageTestHelperConstants.CliRepository;
         private const string _cliStretchTag = ImageTestHelperConstants.CliStretchTag;
         private const string _cliBusterTag = ImageTestHelperConstants.CliBusterTag;
         private const string _cliBullseyeTag = ImageTestHelperConstants.CliBullseyeTag;
@@ -248,6 +249,10 @@ namespace Microsoft.Oryx.Tests.Common
             {
                 return GetCliImage(_cliBusterTag);
             }
+            else if(string.Equals(tag, _cliBullseyeTag))
+            {
+                return GetCliImage(_cliBullseyeTag);
+            }
             else if (string.Equals(tag, _fullStretch))
             {
                 return GetFullBuildImage(_fullStretch);
@@ -389,7 +394,11 @@ namespace Microsoft.Oryx.Tests.Common
             if (!string.IsNullOrEmpty(debianFlavor)
                 && string.Equals(debianFlavor.ToLower(), _cliBusterTag))
             {
-                return $"{_repoPrefix}/{_cliBusterTag}:{_cliBusterTag}{_tagSuffix}";
+                return $"{_repoPrefix}/{_cliRepository}:{_cliBusterTag}{_tagSuffix}";
+            }
+            else if (!string.IsNullOrEmpty(debianFlavor) && string.Equals(debianFlavor.ToLower(), _cliBullseyeTag))
+            {
+                return $"{_repoPrefix}/{_cliRepository}:{_cliBullseyeTag}{_tagSuffix}";
             }
 
             return $"{_repoPrefix}/{_cliStretchTag}:{_cliStretchTag}{_tagSuffix}";
@@ -514,6 +523,7 @@ namespace Microsoft.Oryx.Tests.Common
         public const string VsoBullseye = "vso-debian-bullseye";
         public const string BuildRepository = "build";
         public const string PackRepository = "pack";
+        public const string CliRepository = "cli";
         public const string CliStretchTag = "debian-stretch";
         public const string CliBusterTag = "debian-buster";
         public const string CliBullseyeTag = "debian-bullseye";

--- a/tests/Oryx.Tests.Common/ImageTestHelper.cs
+++ b/tests/Oryx.Tests.Common/ImageTestHelper.cs
@@ -45,10 +45,9 @@ namespace Microsoft.Oryx.Tests.Common
         private const string _vsoBullseye = ImageTestHelperConstants.VsoBullseye;
         private const string _buildRepository = ImageTestHelperConstants.BuildRepository;
         private const string _packRepository = ImageTestHelperConstants.PackRepository;
-        private const string _cliRepository = ImageTestHelperConstants.CliRepository;
-        private const string _cliBusterRepository = ImageTestHelperConstants.CliBusterRepository;
         private const string _cliStretchTag = ImageTestHelperConstants.CliStretchTag;
         private const string _cliBusterTag = ImageTestHelperConstants.CliBusterTag;
+        private const string _cliBullseyeTag = ImageTestHelperConstants.CliBullseyeTag;
         private const string _latestTag = ImageTestHelperConstants.LatestStretchTag;
         private const string _ltsVersionsStretch = ImageTestHelperConstants.LtsVersionsStretch;
         private const string _ltsVersionsBuster = ImageTestHelperConstants.LtsVersionsBuster;
@@ -241,13 +240,13 @@ namespace Microsoft.Oryx.Tests.Common
             {
                 return GetAzureFunctionsJamStackBuildImage(_azureFunctionsJamStackBullseye);
             }
-            else if (string.Equals(tag, _cliRepository))
+            else if (string.Equals(tag, _cliStretchTag))
             {
-                return GetCliImage(_cliRepository);
+                return GetCliImage(_cliStretchTag);
             }
-            else if (string.Equals(tag, _cliBusterRepository))
+            else if (string.Equals(tag, _cliBusterTag))
             {
-                return GetCliImage(_cliBusterRepository);
+                return GetCliImage(_cliBusterTag);
             }
             else if (string.Equals(tag, _fullStretch))
             {
@@ -388,12 +387,12 @@ namespace Microsoft.Oryx.Tests.Common
         public string GetCliImage(string debianFlavor = null)
         {
             if (!string.IsNullOrEmpty(debianFlavor)
-                && string.Equals(debianFlavor.ToLower(), _cliBusterRepository))
+                && string.Equals(debianFlavor.ToLower(), _cliBusterTag))
             {
-                return $"{_repoPrefix}/{_cliBusterRepository}:{_cliBusterTag}{_tagSuffix}";
+                return $"{_repoPrefix}/{_cliBusterTag}:{_cliBusterTag}{_tagSuffix}";
             }
 
-            return $"{_repoPrefix}/{_cliRepository}:{_cliStretchTag}{_tagSuffix}";
+            return $"{_repoPrefix}/{_cliStretchTag}:{_cliStretchTag}{_tagSuffix}";
         }
 
         private string GetTestTag()
@@ -515,10 +514,9 @@ namespace Microsoft.Oryx.Tests.Common
         public const string VsoBullseye = "vso-debian-bullseye";
         public const string BuildRepository = "build";
         public const string PackRepository = "pack";
-        public const string CliRepository = "cli";
-        public const string CliBusterRepository = "cli-buster";
         public const string CliStretchTag = "debian-stretch";
         public const string CliBusterTag = "debian-buster";
+        public const string CliBullseyeTag = "debian-bullseye";
         public const string LatestStretchTag = "debian-stretch";
         public const string LtsVersionsStretch = "lts-versions-debian-stretch";
         public const string LtsVersionsBuster = "lts-versions-debian-buster";

--- a/tests/Oryx.Tests.Common/Settings.cs
+++ b/tests/Oryx.Tests.Common/Settings.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Oryx.Tests.Common
         public const string JamStackBusterBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/build:azfunc-jamstack-debian-buster";
         public const string JamStackBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/build:azfunc-jamstack-debian-stretch";
         public const string CliBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/cli:debian-stretch";
-        public const string CliBusterBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/cli-buster:debian-buster";
+        public const string CliBusterBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/cli:debian-buster";
+        public const string CliBullseyeBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/cli:debian-bullseye";
         public const string LtsVerionsBusterBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/build:lts-versions-debian-buster";
         public const string VsoUbuntuBuildImageName = "oryxdevmcr.azurecr.io/public/oryx/build:vso-ubuntu-focal";
 

--- a/vsts/pipelines/ci.yml
+++ b/vsts/pipelines/ci.yml
@@ -36,6 +36,9 @@ parameters:
         key: CliBuster
         value: cli-buster
       - 
+        key: CliBullseye
+        value: cli-bullseye
+      - 
         key: Buildpack
         value: buildpack
 

--- a/vsts/pipelines/nightly.yml
+++ b/vsts/pipelines/nightly.yml
@@ -34,6 +34,9 @@ parameters:
         key: CliBuster
         value: cli-buster
       - 
+        key: CliBullseye
+        value: cli-bullseye
+      - 
         key: Buildpack
         value: buildpack
 

--- a/vsts/pipelines/validation.yml
+++ b/vsts/pipelines/validation.yml
@@ -34,6 +34,9 @@ parameters:
         key: CliBuster
         value: cli-buster
       - 
+        key: CliBullseye
+        value: cli-bullseye
+      - 
         key: Buildpack
         value: buildpack
 

--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -103,7 +103,8 @@ tagBuildImageForIntegrationTest "$imagefilter/build" "vso-debian-bullseye" "$bui
 tagBuildImageForIntegrationTest "$imagefilter/build" "full-debian-buster" "$buildImageFilter" "$buildImageTagFilter"
 tagBuildImageForIntegrationTest "$imagefilter/build" "full-debian-bullseye" "$buildImageFilter" "$buildImageTagFilter"
 tagBuildImageForIntegrationTest "$imagefilter/cli" "debian-stretch" "$buildImageFilter" "$buildImageTagFilter"
-tagBuildImageForIntegrationTest "$imagefilter/cli-buster" "debian-buster" "$buildImageFilter" "$buildImageTagFilter"
+tagBuildImageForIntegrationTest "$imagefilter/cli" "debian-buster" "$buildImageFilter" "$buildImageTagFilter"
+tagBuildImageForIntegrationTest "$imagefilter/cli" "debian-bullseye" "$buildImageFilter" "$buildImageTagFilter"
 tagBuildImageForIntegrationTest "$imagefilter/pack" "" "$buildImageFilter" "$buildImageTagFilter"
 
 

--- a/vsts/scripts/tagCliImagesForRelease.sh
+++ b/vsts/scripts/tagCliImagesForRelease.sh
@@ -20,7 +20,8 @@ if [ -f "$outPmeFile" ]; then
 fi
 
 cliImage="$sourceImageRepo/cli:debian-stretch-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
-cliBusterImage="$sourceImageRepo/cli-buster:debian-buster-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
+cliBusterImage="$sourceImageRepo/cli:debian-buster-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
+cliBullseyeImage="$sourceImageRepo/cli:debian-bullseye-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
 echo "Pulling CLI image '$cliImage'..."
 docker pull "$cliImage"
 
@@ -32,8 +33,15 @@ echo "Pulling CLI buster image '$cliBusterImage'..."
 docker pull "$cliBusterImage"
 
 echo "Retagging CLI buster image for $prodPmeImageRepo with 'debian-buster-$RELEASE_TAG_NAME'..."
-echo "$prodPmeImageRepo/cli-buster:debian-buster-$RELEASE_TAG_NAME">>"$outPmeFile"
-docker tag "$cliBusterImage" "$prodPmeImageRepo/cli-buster:debian-buster-$RELEASE_TAG_NAME"
+echo "$prodPmeImageRepo/cli:debian-buster-$RELEASE_TAG_NAME">>"$outPmeFile"
+docker tag "$cliBusterImage" "$prodPmeImageRepo/cli:debian-buster-$RELEASE_TAG_NAME"
+
+echo "Pulling CLI bullseye image '$cliBullseyeImage'"
+docker pull "$cliBullseyeImage"
+
+echo "Retagging CLI bullseye image for $prodPmeImageRepo with 'debian-bullseye-$RELEASE_TAG_NAME'..."
+echo "$prodPmeImageRepo/cli:debian-bullseye-$RELEASE_TAG_NAME">>"$outPmeFile"
+docker tag "$cliBullseyeImage" "$prodPmeImageRepo/cli:debian-bullseye-$RELEASE_TAG_NAME"
 
 if [ "$sourceBranchName" == "main" ]; then
     echo "Retagging CLI image with '{os type}-stable'..."
@@ -41,8 +49,11 @@ if [ "$sourceBranchName" == "main" ]; then
     docker tag "$cliImage" "$prodPmeImageRepo/cli:debian-stretch-stable"
     echo "$prodPmeImageRepo/cli:debian-stretch-stable">>"$outPmeFile"
 
-    docker tag "$cliBusterImage" "$prodPmeImageRepo/cli-buster:debian-buster-stable"
-    echo "$prodPmeImageRepo/cli-buster:debian-buster-stable">>"$outPmeFile"
+    docker tag "$cliBusterImage" "$prodPmeImageRepo/cli:debian-buster-stable"
+    echo "$prodPmeImageRepo/cli:debian-buster-stable">>"$outPmeFile"
+
+    docker tag "$cliBullseyeImage" "$prodPmeImageRepo/cli:debian-bullseye-stable"
+    echo "$prodPmeImageRepo/cli:debian-bullseye-stable">>"$outPmeFile"
 else
     echo "Not creating 'stable' or 'latest' tags as source branch is not 'main'. Current branch is $sourceBranchName"
 fi


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [X] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
The changes included in this PR removes CliBusterRepository and CliBullseyeRepository and modifies GetCliImage to get the appropriate image name from the corresponding debian flavor tags instead of the repository names
- [X] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
