### PR TITLE
Revert change to TelemetryClient constructor to re-enable telemetry

### DIFF
--- a/src/BuildScriptGenerator.Common/Extensions/LoggerAiExtensions.cs
+++ b/src/BuildScriptGenerator.Common/Extensions/LoggerAiExtensions.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Extensions.Logging
 
         private static TelemetryClient GetTelemetryClient()
         {
-            var config = TelemetryConfiguration.CreateDefault();
-            var client = new TelemetryClient(config);
+            // Temporarily use obsolete empty client as mentioned in work item 1735437
+            var client = new TelemetryClient();
 
             ApplicationInsightsTarget aiTarget = (ApplicationInsightsTarget)NLog.LogManager.Configuration?.FindTargetByName("ai");
             if (aiTarget != null)


### PR DESCRIPTION
More information found in work item 1735437.

Temporarily reverting back to the _obsolete_ empty `TelemetryClient` constructor to re-enable telemetry coming from the Oryx CLI.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
