### PR TITLE
Add 'oryx telemetry' command to send generic events to App Insights

### DIFF
--- a/src/BuildScriptGenerator.Common/Extensions/LoggerAiExtensions.cs
+++ b/src/BuildScriptGenerator.Common/Extensions/LoggerAiExtensions.cs
@@ -91,6 +91,14 @@ namespace Microsoft.Extensions.Logging
             return new EventStopwatch(GetTelemetryClient(), eventName, props);
         }
 
+        public static void LogTimedEvent(this ILogger logger, string eventName, double processingTime, IDictionary<string, string> props = null)
+        {
+            GetTelemetryClient().TrackEvent(
+                eventName,
+                props,
+                new Dictionary<string, double> { { "processingTime", processingTime } });
+        }
+
         private static TelemetryClient GetTelemetryClient()
         {
             // Temporarily use obsolete empty client as mentioned in work item 1735437

--- a/src/BuildScriptGeneratorCli/Commands/OptionTemplates.cs
+++ b/src/BuildScriptGeneratorCli/Commands/OptionTemplates.cs
@@ -26,5 +26,9 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
         public const string AppType = "--apptype <application-type>";
         public const string CompressDestinationDir = "--compress-destination-dir";
         public const string DynamicInstallRootDir = "--dynamic-install-root-dir <dir-path>";
+
+        public const string EventName = "--event-name <event-name>";
+        public const string ProcessingTime = "--processing-time <processing-time>";
+        public const string CallerId = "--caller-id <caller-id>";
     }
 }

--- a/src/BuildScriptGeneratorCli/Commands/TelemetryCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/TelemetryCommand.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Oryx.BuildScriptGenerator.Common;
+
+namespace Microsoft.Oryx.BuildScriptGeneratorCli
+{
+    [Command(Name, Description = "Logs an event in Oryx telemetry.")]
+    internal class TelemetryCommand : CommandBase
+    {
+        public const string Name = "telemetry";
+
+        [Option(
+            OptionTemplates.EventName,
+            CommandOptionType.SingleValue,
+            Description = "The name of the event to log for telemetry.")]
+        public string EventName { get; set; }
+
+        [Option(
+            OptionTemplates.ProcessingTime,
+            CommandOptionType.SingleValue,
+            Description = "The processing time of the event, in milliseconds")]
+        public double ProcessingTime { get; set; }
+
+        [Option(
+            OptionTemplates.Property,
+            CommandOptionType.MultipleValue,
+            Description = "Additional information that should be logged with the event, in the form --property KEY=VALUE.")]
+        public string[] Properties { get; set; }
+
+        internal override int Execute(IServiceProvider serviceProvider, IConsole console)
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<TelemetryCommand>>();
+
+            var eventProps = new Dictionary<string, string>();
+            if (this.Properties?.Length > 0)
+            {
+                foreach (var prop in this.Properties)
+                {
+                    var propSplit = prop.Split('=');
+                    if (propSplit.Length != 2)
+                    {
+                        console.WriteErrorLine($"Invalid property, '{prop}', provided and will be skipped. Properties must be in the format --property KEY=VALUE");
+                        continue;
+                    }
+
+                    eventProps.Add(propSplit[0], propSplit[1]);
+                }
+            }
+
+            if (this.ProcessingTime > 0)
+            {
+                logger.LogTimedEvent(this.EventName, this.ProcessingTime, eventProps);
+            }
+            else
+            {
+                logger.LogEvent(this.EventName, eventProps);
+            }
+
+            return ProcessConstants.ExitSuccess;
+        }
+
+        internal override bool IsValidInput(IServiceProvider serviceProvider, IConsole console)
+        {
+            if (string.IsNullOrEmpty(this.EventName))
+            {
+                console.WriteErrorLine("The 'oryx telemetry' command requires a value for --event-name.");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/BuildScriptGeneratorCli/Commands/TelemetryCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/TelemetryCommand.cs
@@ -12,27 +12,18 @@ using Microsoft.Oryx.BuildScriptGenerator.Common;
 
 namespace Microsoft.Oryx.BuildScriptGeneratorCli
 {
-    [Command(Name, Description = "Logs an event in Oryx telemetry.")]
+    [Command(Name, Description = "[INTERNAL ONLY COMMAND]", ShowInHelpText = false)]
     internal class TelemetryCommand : CommandBase
     {
         public const string Name = "telemetry";
 
-        [Option(
-            OptionTemplates.EventName,
-            CommandOptionType.SingleValue,
-            Description = "The name of the event to log for telemetry.")]
+        [Option(OptionTemplates.EventName, CommandOptionType.SingleValue, ShowInHelpText = false)]
         public string EventName { get; set; }
 
-        [Option(
-            OptionTemplates.ProcessingTime,
-            CommandOptionType.SingleValue,
-            Description = "The processing time of the event, in milliseconds")]
+        [Option(OptionTemplates.ProcessingTime, CommandOptionType.SingleValue, ShowInHelpText = false)]
         public double ProcessingTime { get; set; }
 
-        [Option(
-            OptionTemplates.Property,
-            CommandOptionType.MultipleValue,
-            Description = "Additional information that should be logged with the event, in the form --property KEY=VALUE.")]
+        [Option(OptionTemplates.Property, CommandOptionType.MultipleValue, ShowInHelpText = false)]
         public string[] Properties { get; set; }
 
         internal override int Execute(IServiceProvider serviceProvider, IConsole console)

--- a/src/BuildScriptGeneratorCli/Program.cs
+++ b/src/BuildScriptGeneratorCli/Program.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
     [Subcommand(typeof(BuildpackBuildCommand))]
     [Subcommand(typeof(DockerfileCommand))]
     [Subcommand(typeof(PrepareEnvironmentCommand))]
+    [Subcommand(typeof(TelemetryCommand))]
     internal class Program
     {
         public const string GitCommit = "GitCommit";

--- a/tests/BuildScriptGeneratorCli.Tests/TelemetryCommandTest.cs
+++ b/tests/BuildScriptGeneratorCli.Tests/TelemetryCommandTest.cs
@@ -1,0 +1,37 @@
+﻿// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+
+using Microsoft.Oryx.Tests.Common;
+using Xunit;
+
+namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
+{
+    public class TelemetryCommandTest : IClassFixture<TestTempDirTestFixture>
+    {
+        internal static TestTempDirTestFixture _testDir;
+        internal static string _testDirPath;
+
+        public TelemetryCommandTest(TestTempDirTestFixture testFixture)
+        {
+            _testDir = testFixture;
+            _testDirPath = testFixture.RootDirPath;
+        }
+
+        [Fact]
+        public void IsValidInput_IsFalse_WhenEventNameNotProvided()
+        {
+            // Arrange
+            var telemetryCommand = new TelemetryCommand();
+            var testConsole = new TestConsole();
+
+            // Act
+            var isValidInput = telemetryCommand.IsValidInput(null, testConsole);
+
+            // Assert
+            Assert.False(isValidInput);
+            Assert.Contains("The 'oryx telemetry' command requires a value for --event-name.", testConsole.StdError);
+        }
+    }
+}


### PR DESCRIPTION
Introduces `oryx telemetry` command that will allow us to send events to App Insights from sources such as our GitHub Action and ADO Task.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
