### PR TITLE
Add missing ARG to enable telemetry in CLI and Full images

### DIFF
--- a/images/build/Dockerfiles/cli.Dockerfile
+++ b/images/build/Dockerfiles/cli.Dockerfile
@@ -4,6 +4,7 @@ ARG DEBIAN_FLAVOR
 FROM buildpack-deps:${DEBIAN_FLAVOR}-curl as main
 ARG DEBIAN_FLAVOR
 ARG SDK_STORAGE_BASE_URL_VALUE="https://oryx-cdn.microsoft.io"
+ARG AI_KEY
 ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR
 
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/buildscriptgenerator /opt/buildscriptgen/ /opt/buildscriptgen/

--- a/images/build/Dockerfiles/full.Dockerfile
+++ b/images/build/Dockerfiles/full.Dockerfile
@@ -21,6 +21,7 @@ RUN ./build.sh golang     /opt/startupcmdgen/golang
 FROM buildpack-deps:${DEBIAN_FLAVOR}-curl
 ARG DEBIAN_FLAVOR
 ARG SDK_STORAGE_BASE_URL_VALUE="https://oryx-cdn.microsoft.io"
+ARG AI_KEY
 ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR
 ENV ORYX_SDK_STORAGE_BASE_URL=${SDK_STORAGE_BASE_URL_VALUE}
 


### PR DESCRIPTION
The CLI and Full images are missing a reference to the `AI_KEY` argument that's provided to their Dockerfiles to enable telemetry.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
