### PR TITLE
Add token

### DIFF
--- a/.github/workflows/automationTemplate.yaml
+++ b/.github/workflows/automationTemplate.yaml
@@ -82,6 +82,8 @@ jobs:
         with:
           branch: automation/add-new-${{ inputs.platformName }}-versions-${{ env.RELEASE_DATE }}
           title: New ${{ env.PLATFORM_NAME_CAMEL_CASE }} Sdks ${{ env.RELEASE_DATE }}
+          token: ${{ secrets.GH_TOKEN }}
+
       
       - if: ${{ env.CANCEL_WORKFLOW == 0 }}
         name: Install jq


### PR DESCRIPTION
- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as: the external modules that Automation uses to open pull requests now requires GH_TOKEN secrets. These are the only permission I am permitting: 
![image](https://user-images.githubusercontent.com/86327553/219823148-696dc3b5-b3d6-4245-8656-847d6171f3f8.png)

External module: https://github.com/peter-evans/create-pull-request#workflow-permissions
Fix reference: https://github.com/peter-evans/create-pull-request/issues/1175
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~