### PR TITLE
Added missing tag for release

### DIFF
--- a/vsts/scripts/tagBuilderImagesForRelease.sh
+++ b/vsts/scripts/tagBuilderImagesForRelease.sh
@@ -46,6 +46,7 @@ function tagBuilderImage() {
 
 tagBuilderImage "$ACR_PUBLIC_PREFIX/builder:$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "latest" "$RELEASE_TAG_NAME"
 tagBuilderImage "$ACR_PUBLIC_PREFIX/builder:capps-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "capps" "capps-$RELEASE_TAG_NAME"
+tagBuilderImage "$ACR_PUBLIC_PREFIX/builder:buildpack-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "buildpack" "buildpack-$RELEASE_TAG_NAME"
 tagBuilderImage "$ACR_PUBLIC_PREFIX/builder:stack-base-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "stack-base" "stack-base-$RELEASE_TAG_NAME"
 tagBuilderImage "$ACR_PUBLIC_PREFIX/builder:stack-build-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "stack-build" "stack-build-$RELEASE_TAG_NAME"
 tagBuilderImage "$ACR_PUBLIC_PREFIX/builder:stack-run-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME" "stack-run" "stack-run-$RELEASE_TAG_NAME"


### PR DESCRIPTION
Oryx CI successfully released the following images today:
```
cli:builder-debian-bullseye-20230327.1
cli:builder-debian-bullseye-stable
builder:20230327.1
builder:latest
builder:capps-20230327.1
builder:capps
builder:stack-base
builder:stack-base-20230327.1
builder:stack-build
builder:stack-build-20230327.1
builder:stack-run
builder:stack-run-20230327.1
```
but was missing
```
builder:buildpack
builder:buildpack-20230327.1
```
which this should add