### PR TITLE
Update publish 'sdks to prod' pipeline to dotnet 7

### DIFF
--- a/vsts/pipelines/publishSdkToProd.yml
+++ b/vsts/pipelines/publishSdkToProd.yml
@@ -19,9 +19,9 @@ stages:
           ignoreDirectories: '$(Build.SourcesDirectory)/tests'
       
       - task: UseDotNet@2
-        displayName: 'Use .NET Core sdk 3.1.x'
+        displayName: 'Use .NET Core sdk 7.x'
         inputs:
-          version: 3.1.x
+          version: 7.x
 
       - task: ShellScript@2
         displayName: '(Dry run) Publish SDKs from dev to prod storage account'
@@ -53,9 +53,9 @@ stages:
                 ignoreDirectories: '$(Build.SourcesDirectory)/tests'
 
             - task: UseDotNet@2
-              displayName: 'Use .NET Core sdk 3.1.x'
+              displayName: 'Use .NET Core sdk 7.x'
               inputs:
-                version: 3.1.x
+                version: 7.x
 
             - task: ShellScript@2
               displayName: 'Publish SDKs from dev to prod storage account'

--- a/vsts/pipelines/templates/_integrationJobTemplate.yml
+++ b/vsts/pipelines/templates/_integrationJobTemplate.yml
@@ -42,6 +42,7 @@ jobs:
     displayName: 'Use .NET Core sdk 7.x'
     inputs:
       version: 7.x
+
   - task: ShellScript@2
     displayName: 'Test Dev storage account'
     env:


### PR DESCRIPTION
Fixing the following error in the Oryx-PublishSdkToProd pipeline: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7654748&view=logs&j=9b0d530e-cf64-58a6-9150-38de442bc22a&t=58bf10bb-d869-5b2f-6393-3371f38f0e13&s=edd71fa3-2764-5250-74d4-17fb935a4e9d
![image](https://user-images.githubusercontent.com/107068277/233380186-f6b6d8fa-5875-48f9-8a58-27e803c90b5f.png)
