### PR TITLE
Fix Debian Stretch Build Image Failure

### DIFF
--- a/images/build/Dockerfiles/azureFunctions.JamStack.Dockerfile
+++ b/images/build/Dockerfiles/azureFunctions.JamStack.Dockerfile
@@ -14,6 +14,13 @@ ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR \
     LC_ALL="C.UTF-8" \
     ORYX_PATHS="/opt/oryx:/opt/nodejs/lts/bin:/opt/python/latest/bin:/opt/yarn/stable/bin"
     
+# stretch was removed from security.debian.org and deb.debian.org, so update the sources to point to the archived mirror
+RUN if [ "${DEBIAN_FLAVOR}" = "stretch" ]; then \
+        sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch-updates/# deb http:\/\/deb.debian.org\/debian stretch-updates/g' /etc/apt/sources.list  \
+        && sed -i 's/^deb http:\/\/security.debian.org\/debian-security stretch/deb http:\/\/archive.debian.org\/debian-security stretch/g' /etc/apt/sources.list \
+        && sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch/deb http:\/\/archive.debian.org\/debian stretch/g' /etc/apt/sources.list ; \
+    fi
+
 RUN set -ex \
     # Install Python SDKs
     # Upgrade system python

--- a/images/build/Dockerfiles/cli.Dockerfile
+++ b/images/build/Dockerfiles/cli.Dockerfile
@@ -7,6 +7,13 @@ ARG SDK_STORAGE_BASE_URL_VALUE="https://oryx-cdn.microsoft.io"
 ARG AI_CONNECTION_STRING
 ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR
 
+# stretch was removed from security.debian.org and deb.debian.org, so update the sources to point to the archived mirror
+RUN if [ "${DEBIAN_FLAVOR}" = "stretch" ]; then \
+        sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch-updates/# deb http:\/\/deb.debian.org\/debian stretch-updates/g' /etc/apt/sources.list  \
+        && sed -i 's/^deb http:\/\/security.debian.org\/debian-security stretch/deb http:\/\/archive.debian.org\/debian-security stretch/g' /etc/apt/sources.list \
+        && sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch/deb http:\/\/archive.debian.org\/debian stretch/g' /etc/apt/sources.list ; \
+    fi
+
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/buildscriptgenerator /opt/buildscriptgen/ /opt/buildscriptgen/
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/support-files-image-for-build /tmp/oryx/ /opt/tmp
 

--- a/images/build/Dockerfiles/cliBuilder.Dockerfile
+++ b/images/build/Dockerfiles/cliBuilder.Dockerfile
@@ -7,6 +7,13 @@ ARG SDK_STORAGE_BASE_URL_VALUE="https://oryx-cdn.microsoft.io"
 ARG AI_CONNECTION_STRING
 ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR
 
+# stretch was removed from security.debian.org and deb.debian.org, so update the sources to point to the archived mirror
+RUN if [ "${DEBIAN_FLAVOR}" = "stretch" ]; then \
+        sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch-updates/# deb http:\/\/deb.debian.org\/debian stretch-updates/g' /etc/apt/sources.list  \
+        && sed -i 's/^deb http:\/\/security.debian.org\/debian-security stretch/deb http:\/\/archive.debian.org\/debian-security stretch/g' /etc/apt/sources.list \
+        && sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch/deb http:\/\/archive.debian.org\/debian stretch/g' /etc/apt/sources.list ; \
+    fi
+
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/buildscriptgenerator /opt/buildscriptgen/ /opt/buildscriptgen/
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/support-files-image-for-build /tmp/oryx/ /opt/tmp
 

--- a/images/build/Dockerfiles/gitHubActions.Dockerfile
+++ b/images/build/Dockerfiles/gitHubActions.Dockerfile
@@ -3,6 +3,13 @@ FROM oryxdevmcr.azurecr.io/private/oryx/githubrunners-buildpackdeps-${DEBIAN_FLA
 ARG DEBIAN_FLAVOR
 ENV DEBIAN_FLAVOR=$DEBIAN_FLAVOR
 
+# stretch was removed from security.debian.org and deb.debian.org, so update the sources to point to the archived mirror
+RUN if [ "${DEBIAN_FLAVOR}" = "stretch" ]; then \
+        sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch-updates/# deb http:\/\/deb.debian.org\/debian stretch-updates/g' /etc/apt/sources.list  \
+        && sed -i 's/^deb http:\/\/security.debian.org\/debian-security stretch/deb http:\/\/archive.debian.org\/debian-security stretch/g' /etc/apt/sources.list \
+        && sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch/deb http:\/\/archive.debian.org\/debian stretch/g' /etc/apt/sources.list ; \
+    fi
+
 # Install basic build tools
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/images/build/Dockerfiles/ltsVersions.Dockerfile
+++ b/images/build/Dockerfiles/ltsVersions.Dockerfile
@@ -1,5 +1,14 @@
 FROM oryxdevmcr.azurecr.io/private/oryx/githubrunners-buildpackdeps-stretch AS main
 
+ENV DEBIAN_FLAVOR="stretch"
+
+# stretch was removed from security.debian.org and deb.debian.org, so update the sources to point to the archived mirror
+RUN if [ "${DEBIAN_FLAVOR}" = "stretch" ]; then \
+        sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch-updates/# deb http:\/\/deb.debian.org\/debian stretch-updates/g' /etc/apt/sources.list  \
+        && sed -i 's/^deb http:\/\/security.debian.org\/debian-security stretch/deb http:\/\/archive.debian.org\/debian-security stretch/g' /etc/apt/sources.list \
+        && sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch/deb http:\/\/archive.debian.org\/debian stretch/g' /etc/apt/sources.list ; \
+    fi
+
 # Install basic build tools
 # Configure locale (required for Python)
 # NOTE: Do NOT move it from here as it could have global implications

--- a/images/build/Dockerfiles/vso.Dockerfile
+++ b/images/build/Dockerfiles/vso.Dockerfile
@@ -13,6 +13,13 @@ ENV ORYX_PREFER_USER_INSTALLED_SDKS=true \
     DYNAMIC_INSTALL_ROOT_DIR="/opt" \
     DEBIAN_FLAVOR="stretch"
 
+# stretch was removed from security.debian.org and deb.debian.org, so update the sources to point to the archived mirror
+RUN if [ "${DEBIAN_FLAVOR}" = "stretch" ]; then \
+        sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch-updates/# deb http:\/\/deb.debian.org\/debian stretch-updates/g' /etc/apt/sources.list  \
+        && sed -i 's/^deb http:\/\/security.debian.org\/debian-security stretch/deb http:\/\/archive.debian.org\/debian-security stretch/g' /etc/apt/sources.list \
+        && sed -i 's/^deb http:\/\/deb.debian.org\/debian stretch/deb http:\/\/archive.debian.org\/debian stretch/g' /etc/apt/sources.list ; \
+    fi
+
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/support-files-image-for-build /tmp/oryx/ /opt/tmp
 
 RUN buildDir="/opt/tmp/build" \

--- a/images/build/php/prereqs/installPrereqs.sh
+++ b/images/build/php/prereqs/installPrereqs.sh
@@ -33,7 +33,9 @@ apt-get update \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ##<argon2>##
-# sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
+sed -i -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/^deb http:\/\/security.debian.org\/debian-security stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian stretch/^deb http:\/\/deb.debian.org\/debian stretch/g' \
+    -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';
 	echo 'Pin: release n=buster';

--- a/images/build/php/prereqs/installPrereqs.sh
+++ b/images/build/php/prereqs/installPrereqs.sh
@@ -33,8 +33,9 @@ apt-get update \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -i -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
+sed -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/deb http:\/\/archive.debian.org\/debian stretch/deb http:\/\/deb.debian.org\/debian stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';

--- a/images/build/php/prereqs/installPrereqs.sh
+++ b/images/build/php/prereqs/installPrereqs.sh
@@ -33,7 +33,7 @@ apt-get update \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
+# sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';
 	echo 'Pin: release n=buster';

--- a/images/build/php/prereqs/installPrereqs.sh
+++ b/images/build/php/prereqs/installPrereqs.sh
@@ -35,7 +35,6 @@ apt-get update \
 ##<argon2>##
 sed -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/deb http:\/\/archive.debian.org\/debian stretch/deb http:\/\/deb.debian.org\/debian stretch/g' \
-    -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';

--- a/images/build/php/prereqs/installPrereqs.sh
+++ b/images/build/php/prereqs/installPrereqs.sh
@@ -33,8 +33,8 @@ apt-get update \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -i -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/^deb http:\/\/security.debian.org\/debian-security stretch/g' \
-    -e 's/deb http:\/\/archive.debian.org\/debian stretch/^deb http:\/\/deb.debian.org\/debian stretch/g' \
+sed -i -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian stretch/deb http:\/\/deb.debian.org\/debian stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';

--- a/images/build/php/prereqs/installPrereqs.sh
+++ b/images/build/php/prereqs/installPrereqs.sh
@@ -33,8 +33,9 @@ apt-get update \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
+sed -e 's/# deb http:\/\/deb.debian.org\/debian stretch-updates/deb http:\/\/deb.debian.org\/debian stretch-updates/g' \
     -e 's/deb http:\/\/archive.debian.org\/debian stretch/deb http:\/\/deb.debian.org\/debian stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';

--- a/platforms/php/prereqs/installPrereqs.sh
+++ b/platforms/php/prereqs/installPrereqs.sh
@@ -33,6 +33,9 @@ add-apt-repository ppa:xapienz/curl34 -y \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 ##<argon2>##
+sed -i -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/^deb http:\/\/security.debian.org\/debian-security stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian stretch/^deb http:\/\/deb.debian.org\/debian stretch/g' \
+    -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 # sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';

--- a/platforms/php/prereqs/installPrereqs.sh
+++ b/platforms/php/prereqs/installPrereqs.sh
@@ -33,10 +33,10 @@ add-apt-repository ppa:xapienz/curl34 -y \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
+sed -e 's/# deb http:\/\/deb.debian.org\/debian stretch-updates/deb http:\/\/deb.debian.org\/debian stretch-updates/g' \
     -e 's/deb http:\/\/archive.debian.org\/debian stretch/deb http:\/\/deb.debian.org\/debian stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
-# sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';
 	echo 'Pin: release n=buster';

--- a/platforms/php/prereqs/installPrereqs.sh
+++ b/platforms/php/prereqs/installPrereqs.sh
@@ -33,7 +33,7 @@ add-apt-repository ppa:xapienz/curl34 -y \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
+# sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \
 	echo 'Package: *';
 	echo 'Pin: release n=buster';

--- a/platforms/php/prereqs/installPrereqs.sh
+++ b/platforms/php/prereqs/installPrereqs.sh
@@ -33,8 +33,9 @@ add-apt-repository ppa:xapienz/curl34 -y \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -i -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
-    -e 's/deb http:\/\/archive.debian.org\/debian stretch/^deb http:\/\/deb.debian.org\/debian stretch/g' \
+sed -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian stretch/deb http:\/\/deb.debian.org\/debian stretch/g' \
+    -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 # sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \

--- a/platforms/php/prereqs/installPrereqs.sh
+++ b/platforms/php/prereqs/installPrereqs.sh
@@ -33,7 +33,7 @@ add-apt-repository ppa:xapienz/curl34 -y \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 ##<argon2>##
-sed -i -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/^deb http:\/\/security.debian.org\/debian-security stretch/g' \
+sed -i -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/deb http:\/\/archive.debian.org\/debian stretch/^deb http:\/\/deb.debian.org\/debian stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 # sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;

--- a/platforms/php/prereqs/installPrereqs.sh
+++ b/platforms/php/prereqs/installPrereqs.sh
@@ -35,7 +35,6 @@ add-apt-repository ppa:xapienz/curl34 -y \
 ##<argon2>##
 sed -e 's/# deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/deb http:\/\/archive.debian.org\/debian stretch/deb http:\/\/deb.debian.org\/debian stretch/g' \
-    -e 's/deb http:\/\/archive.debian.org\/debian-security stretch/deb http:\/\/security.debian.org\/debian-security stretch/g' \
     -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 # sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list;
 { \


### PR DESCRIPTION
Debian recently moved stretch to archive, resulting in build image fail across pipelines. This PR is out to change the repo from deb.debian.org and other usual debian repos to archive debian repo. 

PHP prerequisite install shell script is also modified similarly to creating buster repo list.