### PR TITLE
Fix typo in `buildManifestHelper.go`

### DIFF
--- a/src/startupscriptgenerator/src/common/buildManifestHelper.go
+++ b/src/startupscriptgenerator/src/common/buildManifestHelper.go
@@ -46,7 +46,7 @@ func GetBuildManifest(manifestDir *string, fullAppPath string) BuildManifest {
 		fmt.Printf("Found build manifest file at '%s'. Deserializing it...\n", manifestFileFullPath)
 		_buildManifest = deserializeBuildManifest(manifestFileFullPath)
 	} else {
-		fmt.Printf("Cound not find build manifest file at '%s'\n", manifestFileFullPath)
+		fmt.Printf("Could not find build manifest file at '%s'\n", manifestFileFullPath)
 	}
 
 	_hasResult = true


### PR DESCRIPTION
While checking the logs of my web app I noticed this typo - as I assume, if I'm wrong, let me know.

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
