### PR TITLE
Fixed yarn version spec templating

### DIFF
--- a/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
@@ -110,9 +110,11 @@ then
 		cp -f "$SOURCE_DIR/.yarnrc.yml" .
 	fi
 
-	if [ YarnVersionSpec | IsNotBlank ] && [ -f "$SOURCE_DIR/.yarn/releases/yarn-${YarnVersionSpec}"* ]; then
-		cp -f "$SOURCE_DIR/.yarn/releases/yarn-${YarnVersionSpec}"* .
+	{{ if YarnVersionSpec | IsNotBlank }}
+	if [ -f "$SOURCE_DIR/.yarn/releases/yarn-{{ YarnVersionSpec }}"* ]; then
+		cp -f "$SOURCE_DIR/.yarn/releases/yarn-{{ YarnVersionSpec }}"* .
 	fi
+	{{ end }}
 	
 	echo
 	echo "Installing production dependencies in '$SOURCE_DIR/$prodModulesDirName'..."


### PR DESCRIPTION
Fix for the issue brought up in https://github.com/microsoft/Oryx/issues/1981
<details>
<summary>Original error logs (note "IsNotBlank: command not found" in output)</summary>
<br>  

```
$ docker run -it -v C:/users/pauldorsch/source/repos/Oryx/tests/SampleApps/nodejs/webfrontend://tmp/test/ mcr.microsoft.com/oryx/build:github-actions-debian-bullseye //bin/bash
root@65ebe0a47461:/# export PRUNE_DEV_DEPENDENCIES=true
root@65ebe0a47461:/# cp -R /tmp/test/ /app/; oryx build /app/ -p prune_dev_dependencies=true
Operation performed by Microsoft Oryx, https://github.com/Microsoft/Oryx
You can report issues at https://github.com/Microsoft/Oryx/issues

Oryx Version: 0.2.20230317.1, Commit: 2baf5f02a27e9045bc752b7c15a55b609b53ae82, ReleaseTagName: 20230317.1

Build Operation ID: 1ba6ec3ae7e70099
OS Type           : bullseye
Image Type        : githubactions

Detecting platforms...
Detected following platforms:
  nodejs: 16.20.0
Version '16.20.0' of platform 'nodejs' is not installed. Generating script to install it...
Detected the following frameworks: Express


Source directory     : /app
Destination directory: /app


Downloading and extracting 'nodejs' version '16.20.0' to '/tmp/oryx/platforms/nodejs/16.20.0'...
Detected image debian flavor: bullseye.
Downloaded in 3 sec(s).
Verifying checksum...
Extracting contents...
performing sha512 checksum for: nodejs...
Done in 4 sec(s).

Removing existing manifest file
Creating directory for command manifest file if it does not exist
Creating a manifest file...
Node Build Command Manifest file created.

Using Node version:
v16.20.0

Using Npm version:
8.19.4
/tmp/BuildScriptGenerator/c14a2efa60334482bc2fae977a4ccbe1/build.sh: line 340: [: missing `]'
/tmp/BuildScriptGenerator/c14a2efa60334482bc2fae977a4ccbe1/build.sh: line 340: IsNotBlank: command not found

Installing production dependencies in '/app/.oryx_prod_node_modules'...

Running 'npm install --production'...

npm WARN config production Use `--omit=dev` instead.
npm WARN deprecated hoek@4.2.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated sntp@2.1.0: This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
npm WARN deprecated cryptiles@3.1.4: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated boom@4.3.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated har-validator@5.0.3: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated hawk@6.0.2: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
npm WARN deprecated boom@5.2.0: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated request@2.83.0: request has been deprecated, see https://github.com/request/request/issues/3142

added 106 packages, and audited 107 packages in 6s

7 packages are looking for funding
  run `npm fund` for details

5 vulnerabilities (2 moderate, 1 high, 2 critical)

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
npm notice
npm notice New major version of npm available! 8.19.4 -> 9.6.6
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.6.6>
npm notice Run `npm install -g npm@9.6.6` to update!
npm notice

Copying production dependencies from '/app/.oryx_prod_node_modules' to '/app/node_modules'...
Done in 0 sec(s).

Running 'npm install'...


removed 3 packages, and audited 324 packages in 1s

9 packages are looking for funding
  run `npm fund` for details

13 vulnerabilities (6 moderate, 5 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

Copy '/app/node_modules' with all dependencies to '/app/.oryx_all_node_modules'...

Copying production dependencies from '/app/.oryx_prod_node_modules/node_modules' to '/app/node_modules'...

Removing existing manifest file
Creating a manifest file...
Manifest file created.
Copying .ostype to manifest output directory.

Done in 11 sec(s).
``` 
</details>

<details>
<summary>Fixed logs (no error)</summary>
<br>  

```
$ docker run -it -v C:/users/pauldorsch/source/repos/Oryx/tests/SampleApps/nodejs/webfrontend://tmp/test/ oryxdevmcr.azurecr.io/public/oryx/build:github-actions-debian-buster //bin/bash
root@ecf9c5d26196:/# export PRUNE_DEV_DEPENDENCIES=true
root@ecf9c5d26196:/# cp -R /tmp/test/ /app/; oryx build /app/ -p prune_dev_dependencies=true
Operation performed by Microsoft Oryx, https://github.com/Microsoft/Oryx
You can report issues at https://github.com/Microsoft/Oryx/issues

Oryx Version: 0.2.0.0, Commit: 6e94268a098f4ea97b5169f4c04d9035c9dd0134, ReleaseTagName:

Build Operation ID: 7a14931f89de3e59
OS Type           : buster
Image Type        : githubactions

Detecting platforms...
Detected following platforms:
  nodejs: 16.20.0
Version '16.20.0' of platform 'nodejs' is not installed. Generating script to install it...
Detected the following frameworks: Express


Source directory     : /app
Destination directory: /app


Downloading and extracting 'nodejs' version '16.20.0' to '/tmp/oryx/platforms/nodejs/16.20.0'...
Detected image debian flavor: buster.
Downloaded in 3 sec(s).
Verifying checksum...
Extracting contents...
performing sha512 checksum for: nodejs...
Done in 3 sec(s).

Removing existing manifest file
Creating directory for command manifest file if it does not exist
Creating a manifest file...
Node Build Command Manifest file created.

Using Node version:
v16.20.0

Using Npm version:
8.19.4

Installing production dependencies in '/app/.oryx_prod_node_modules'...

Running 'npm install --production'...

npm WARN config production Use `--omit=dev` instead.
npm WARN deprecated sntp@2.1.0: This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
npm WARN deprecated hoek@4.2.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated cryptiles@3.1.4: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated boom@4.3.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated har-validator@5.0.3: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated hawk@6.0.2: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
npm WARN deprecated boom@5.2.0: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
npm WARN deprecated request@2.83.0: request has been deprecated, see https://github.com/request/request/issues/3142

added 106 packages, and audited 107 packages in 5s

7 packages are looking for funding
  run `npm fund` for details

5 vulnerabilities (2 moderate, 1 high, 2 critical)

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
npm notice
npm notice New major version of npm available! 8.19.4 -> 9.6.6
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.6.6>
npm notice Run `npm install -g npm@9.6.6` to update!
npm notice

Copying production dependencies from '/app/.oryx_prod_node_modules' to '/app/node_modules'...
Done in 0 sec(s).

Running 'npm install'...


removed 3 packages, and audited 324 packages in 1s

9 packages are looking for funding
  run `npm fund` for details

13 vulnerabilities (6 moderate, 5 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

Copy '/app/node_modules' with all dependencies to '/app/.oryx_all_node_modules'...

Copying production dependencies from '/app/.oryx_prod_node_modules/node_modules' to '/app/node_modules'...

Removing existing manifest file
Creating a manifest file...
Manifest file created.
Copying .ostype to manifest output directory.

Done in 10 sec(s).
``` 
</details>
