### PR TITLE
Update to fix version sorting

### DIFF
--- a/build/tools/Automation/DotNet/DotNetAutomator.cs
+++ b/build/tools/Automation/DotNet/DotNetAutomator.cs
@@ -82,6 +82,15 @@ namespace Microsoft.Oryx.Automation.DotNet
             }
         }
 
+        /// <summary>
+        /// Retrieves a list of new .NET versions from the .NET release website,
+        /// and filters the list based on specified criteria.
+        /// The resulting list includes SDK versions, .NET Core runtime versions,
+        /// and ASP.NET Core runtime versions, and is sorted by semantic version number.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result contains a list of DotNetVersion objects representing the new
+        /// .NET versions that meet the specified criteria.</returns>
         public async Task<List<DotNetVersion>> GetNewDotNetVersionsAsync()
         {
             List<DotNetVersion> dotNetVersions = new List<DotNetVersion>();
@@ -118,7 +127,7 @@ namespace Microsoft.Oryx.Automation.DotNet
                 }
             }
 
-            return dotNetVersions.OrderBy(v => v.Version).ToList();
+            return dotNetVersions.OrderBy(v => new Version(v.Version)).ToList();
         }
 
         private async Task<List<ReleaseNote>> GetReleasesIndexAsync()

--- a/build/tools/Automation/DotNet/DotNetAutomator.cs
+++ b/build/tools/Automation/DotNet/DotNetAutomator.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Oryx.Automation.DotNet
                 }
             }
 
-            return dotNetVersions.OrderBy(v => new Version(v.Version)).ToList();
+            return dotNetVersions.Order().ToList();
         }
 
         private async Task<List<ReleaseNote>> GetReleasesIndexAsync()

--- a/build/tools/Automation/DotNet/Models/DotNetVersion.cs
+++ b/build/tools/Automation/DotNet/Models/DotNetVersion.cs
@@ -2,10 +2,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 // --------------------------------------------------------------------------------------------
+using System;
+
 namespace Microsoft.Oryx.Automation.DotNet.Models
 {
     // </Summary>
-    public class DotNetVersion
+    public class DotNetVersion : IComparable
     {
         /// <Summary>
         /// The version of the platfom.
@@ -24,5 +26,18 @@ namespace Microsoft.Oryx.Automation.DotNet.Models
         /// Example: sdk, aspnetcore, netcore, etc.
         /// </Summary>
         public string VersionType { get; set; } = string.Empty;
+
+        public int CompareTo(object obj)
+        {
+            var objDotNetVersion = obj as DotNetVersion;
+            if (objDotNetVersion == null)
+            {
+                return 1;
+            }
+
+            var thisVersion = new Version(this.Version);
+            var objVersion = new Version(objDotNetVersion.Version);
+            return thisVersion.CompareTo(objVersion);
+        }
     }
 }

--- a/build/tools/Automation/Python/Models/PythonVersion.cs
+++ b/build/tools/Automation/Python/Models/PythonVersion.cs
@@ -1,9 +1,24 @@
-﻿namespace Microsoft.Oryx.Automation.Python.Models
+﻿using System;
+
+namespace Microsoft.Oryx.Automation.Python.Models
 {
-    public class PythonVersion
+    public class PythonVersion : IComparable
     {
         public string Version { get; set; } = string.Empty;
 
         public string GpgKey { get; set; } = string.Empty;
+
+        public int CompareTo(object obj)
+        {
+            var objPythonVersion = obj as PythonVersion;
+            if (objPythonVersion == null)
+            {
+                return 1;
+            }
+
+            var thisVersion = new Version(this.Version);
+            var objVersion = new Version(objPythonVersion.Version);
+            return thisVersion.CompareTo(objVersion);
+        }
     }
 }

--- a/build/tools/Automation/Python/Models/PythonVersion.cs
+++ b/build/tools/Automation/Python/Models/PythonVersion.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+using System;
 
 namespace Microsoft.Oryx.Automation.Python.Models
 {

--- a/build/tools/Automation/Python/Models/Release.cs
+++ b/build/tools/Automation/Python/Models/Release.cs
@@ -1,4 +1,8 @@
-﻿namespace Microsoft.Oryx.Automation.Python.Models
+﻿// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+namespace Microsoft.Oryx.Automation.Python.Models
 {
     public class Release
     {

--- a/build/tools/Automation/Python/PythonAutomator.cs
+++ b/build/tools/Automation/Python/PythonAutomator.cs
@@ -70,6 +70,14 @@ namespace Microsoft.Oryx.Automation.Python
             }
         }
 
+        /// <summary>
+        /// Retrieves a list of new Python versions from the Python release website,
+        /// and filters the list based on specified criteria.
+        /// The resulting list is sorted by semantic version number.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result contains a list of PythonVersion
+        /// objects representing the new Python versions that meet the specified criteria.</returns>
         public async Task<List<PythonVersion>> GetNewPythonVersionsAsync()
         {
             var response = await this.httpService.GetDataAsync(PythonConstants.PythonReleaseUrl);
@@ -99,7 +107,7 @@ namespace Microsoft.Oryx.Automation.Python
                 }
             }
 
-            return pythonVersions;
+            return pythonVersions.OrderBy(v => new Version(v.Version)).ToList();
         }
 
         private void UpdateOryxConstantsForNewVersions(

--- a/build/tools/Automation/Python/PythonAutomator.cs
+++ b/build/tools/Automation/Python/PythonAutomator.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Oryx.Automation.Python
                 }
             }
 
-            return pythonVersions.OrderBy(v => new Version(v.Version)).ToList();
+            return pythonVersions.Order().ToList();
         }
 
         private void UpdateOryxConstantsForNewVersions(


### PR DESCRIPTION
This is for Automation. This PR will fix version sorting, to sort by sematic version, to get the latest version in constants.yaml. Related story https://devdiv.visualstudio.com/DevDiv/_boards/board/t/Oryx/Stories/?workitem=1816926

This was not an issue before since we were always getting a single version. This bug showed up after attempting to release multiple versions.