### PR TITLE
Add GDAL libraries to GitHub Actions images for GeoDjango scenarios

### DIFF
--- a/images/build/Dockerfiles/gitHubActions.Dockerfile
+++ b/images/build/Dockerfiles/gitHubActions.Dockerfile
@@ -54,6 +54,11 @@ RUN apt-get update \
         lzma \
         lzma-dev \
         zlib1g-dev \
+        # GIS libraries for GeoDjango (https://docs.djangoproject.com/en/3.2/ref/contrib/gis/install/geolibs/)
+        binutils \
+        libproj-dev \
+        gdal-bin \
+        libgdal-dev \
     && rm -rf /var/lib/apt/lists/* \
     # This is the folder containing 'links' to benv and build script generator
     && mkdir -p /opt/oryx
@@ -89,7 +94,7 @@ FROM main AS intermediate
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/support-files-image-for-build /tmp/oryx/ /opt/tmp
 COPY --from=oryxdevmcr.azurecr.io/private/oryx/buildscriptgenerator /opt/buildscriptgen/ /opt/buildscriptgen/
 ARG BUILD_DIR="/opt/tmp/build"
-ARG IMAGES_DIR="/opt/tmp/images" 
+ARG IMAGES_DIR="/opt/tmp/images"
 RUN ${IMAGES_DIR}/build/installHugo.sh
 RUN set -ex \
  && yarnCacheFolder="/usr/local/share/yarn-cache" \
@@ -140,7 +145,7 @@ RUN if [ "${DEBIAN_FLAVOR}" = "buster" ] || [ "${DEBIAN_FLAVOR}" = "bullseye" ];
     --no-install-recommends && rm -r /var/lib/apt/lists/* ; \
     else \
         .${IMAGES_DIR}/build/php/prereqs/installPrereqs.sh ; \
-    fi 
+    fi
 
 RUN tmpDir="/opt/tmp" \
     && cp -f $tmpDir/images/build/benv.sh /opt/oryx/benv \
@@ -169,11 +174,11 @@ RUN tmpDir="/opt/tmp" \
     && echo "DEBIAN|${DEBIAN_FLAVOR}" | tr '[a-z]' '[A-Z]' > /opt/oryx/.ostype
 
 # Docker has an issue with variable expansion when all are used in a single ENV command.
-# For example here the $LASTNAME in the following example does not expand to JORDAN but instead is empty: 
+# For example here the $LASTNAME in the following example does not expand to JORDAN but instead is empty:
 #   ENV LASTNAME="JORDAN" \
 #       NAME="MICHAEL $LASTNAME"
 #
-# Even though this adds a new docker layer we are doing this 
+# Even though this adds a new docker layer we are doing this
 # because we want to avoid duplication (which is always error-prone)
 ENV ORYX_PATHS="/opt/oryx:/opt/yarn/stable/bin:/opt/hugo/lts"
 

--- a/tests/SampleApps/python/django-app/myproject/settings.py
+++ b/tests/SampleApps/python/django-app/myproject/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.gis',
     'boards',
     'uservoice'
 ]


### PR DESCRIPTION
Resolves issue https://github.com/microsoft/Oryx/issues/2003

The GDAL libraries used for GeoDjango scenarios in Python were previously added to (and still exist in) our LTS images, which are no longer consumed by App Service. This PR aims to bake these libraries into the GitHub Actions image to re-enable this scenario for customers.

A snippet was added to the `settings.py` file in `django-app` that will fail any test that tries to build the app within an image that doesn't have the GDAL libraries installed in it.

I confirmed locally that the updated `github-actions-debian-bullseye` build image runs successfully against this app, but assume other tests will fail due to their lack of the GDAL library (specifically, the `debian-stretch` images).

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [x] Tests are included and/or updated for code changes.
~- [ ] Proper license headers are included in each file.~
