### PR TITLE
Fix gRPC by specifying the right HTTP1 protocol env var

### DIFF
--- a/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/dotnetcore/scriptgenerator.go
@@ -123,7 +123,8 @@ func (gen *DotnetCoreStartupScriptGenerator) GenerateEntrypointScript(scriptBuil
 	scriptBuilder.WriteString("if [ ! -z \"$PORT2\" ]; then" + "\n")
 	scriptBuilder.WriteString("		export Kestrel__Endpoints__Http2__Url=http://*:$PORT2\n")
 	scriptBuilder.WriteString("		export Kestrel__Endpoints__Http2__Protocols=Http2\n")
-	scriptBuilder.WriteString("		export Kestrel__Endpoints__Http1__Url=http://*:$PORT\n\n")
+	scriptBuilder.WriteString("		export Kestrel__Endpoints__Http1__Url=http://*:$PORT\n")
+	scriptBuilder.WriteString("		export Kestrel__Endpoints__Http1__Protocols=Http1\n\n")
 	scriptBuilder.WriteString("fi")
 	scriptBuilder.WriteString("\n\n")
 


### PR DESCRIPTION
Ask coming from our VS partner team. As the HTTP1 protocol is not defined in this case (but that other components in VS do define HTTP2 as the default protocol), the HTTP1 endpoint ends up using HTTP2.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.

Not applicable:
<s>- [ ] Tests are included and/or updated for code changes.</s>
<s>- [ ] Proper license headers are included in each file.</s>
