### PR TITLE
fixing the issue of validation pipeline

### DIFF
--- a/vsts/pipelines/copyAllBlobsToProd.yml
+++ b/vsts/pipelines/copyAllBlobsToProd.yml
@@ -34,7 +34,7 @@ jobs:
       - task: UseDotNet@2
         displayName: 'Use .NET Core sdk 7.x'
         inputs:
-          version: 7.x
+          version: 7.0.306
 
       - task: ShellScript@2
         displayName: 'Copy all blobs from a source storage account to the prod storage account'

--- a/vsts/pipelines/copySdksFromProdToStorageAccount.yml
+++ b/vsts/pipelines/copySdksFromProdToStorageAccount.yml
@@ -36,7 +36,7 @@ jobs:
       - task: UseDotNet@2
         displayName: 'Use .NET Core sdk 7.x'
         inputs:
-          version: 7.x
+          version: 7.0.306
 
       - task: ShellScript@2
         displayName: 'Copy SDKs from the prod storage account to a destination storage account'

--- a/vsts/pipelines/publishSdkToProd.yml
+++ b/vsts/pipelines/publishSdkToProd.yml
@@ -21,7 +21,7 @@ stages:
       - task: UseDotNet@2
         displayName: 'Use .NET Core sdk 7.x'
         inputs:
-          version: 7.x
+          version: 7.0.306
 
       - task: ShellScript@2
         displayName: '(Dry run) Publish SDKs from dev to prod storage account'
@@ -56,7 +56,7 @@ stages:
             - task: UseDotNet@2
               displayName: 'Use .NET Core sdk 7.x'
               inputs:
-                version: 7.x
+                version: 7.0.306
 
             - task: ShellScript@2
               displayName: 'Publish SDKs from dev to prod storage account'

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -42,7 +42,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 7.x'
   inputs:
-    version: 7.x
+    version: 7.0.306
 
 - script: |
     dotnet --version && dotnet msbuild -version && echo

--- a/vsts/pipelines/templates/_buildTemplateDetector.yml
+++ b/vsts/pipelines/templates/_buildTemplateDetector.yml
@@ -5,7 +5,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core SDK 7.x'
   inputs:
-    version: 7.x
+    version: 7.0.306
 
 - task: ShellScript@2
   displayName: 'Build Detector.sln'

--- a/vsts/pipelines/templates/_integrationJobTemplate.yml
+++ b/vsts/pipelines/templates/_integrationJobTemplate.yml
@@ -41,7 +41,7 @@ jobs:
   - task: UseDotNet@2
     displayName: 'Use .NET Core sdk 7.x'
     inputs:
-      version: 7.x
+      version: 7.0.306
 
   - task: ShellScript@2
     displayName: 'Test Dev storage account'

--- a/vsts/pipelines/templates/_platformBinariesReleaseTemplate.yml
+++ b/vsts/pipelines/templates/_platformBinariesReleaseTemplate.yml
@@ -31,7 +31,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core SDK 7.x'
   inputs:
-    version: 7.x
+    version: 7.0.306
 
 - task: ShellScript@2
   displayName: 'Test Dev storage account'

--- a/vsts/pipelines/templates/_platformBinariesTemplate.yml
+++ b/vsts/pipelines/templates/_platformBinariesTemplate.yml
@@ -15,7 +15,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 7.x'
   inputs:
-    version: 7.x
+    version: 7.0.306
 
 - task: ShellScript@2
   displayName: 'Building platform binaries'

--- a/vsts/pipelines/templates/_releaseStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseStepTemplate.yml
@@ -117,7 +117,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 7.x'
   inputs:
-    version: 7.x
+    version: 7.0.306
 
 - task: ShellScript@2
   displayName: 'Test runtime images for pme staging registry'

--- a/vsts/pipelines/templates/_signBinary.yml
+++ b/vsts/pipelines/templates/_signBinary.yml
@@ -34,7 +34,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core sdk 7.x'
   inputs:
-    version: 7.x
+    version: 7.0.306
 
 - powershell: |
     Write-Host "Setting up git_commit and build_number as env variable"

--- a/vsts/pipelines/templates/_signBinaryDetector.yml
+++ b/vsts/pipelines/templates/_signBinaryDetector.yml
@@ -15,7 +15,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Use .NET Core SDK 7.x'
   inputs:
-    version: 7.x
+    version: 7.0.306
 
 - powershell: |
     Write-Host "Setting up git_commit and build_number as env variable"


### PR DESCRIPTION
our pipelines are blocked because of the new version release of .NET which is 7.0.400. it is causing the below error:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8255579&view=logs&j=4511d90e-8791-5de3-be63-8ad9ad965067&t=8ffc9d55-0a47-505e-afae-2fa7d51f579f&l=133#:~:text=CSC%20%3A%20error%20CS9057,BuildServer/BuildServer.csproj%5D