### PR TITLE
python base image sastoken related issue fix

### DIFF
--- a/images/build/installDotNetCore.sh
+++ b/images/build/installDotNetCore.sh
@@ -18,6 +18,9 @@ if [ "$sdkStorageAccountUrl" == "$PRIVATE_STAGING_SDK_STORAGE_BASE_URL" ]; then
     set +x
     sasToken=$ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN
     set -x
+    if [ -z "$sasToken" ]; then
+      echo "sasToken cannot be empty for $sdkStorageAccountUrl."
+    fi
 fi
 echo
 echo "Installing .NET Core SDK $DOTNET_SDK_VER from $sdkStorageAccountUrl ..."

--- a/images/installPlatform.sh
+++ b/images/installPlatform.sh
@@ -53,6 +53,9 @@ if [ "$sdkStorageAccountUrl" == "$PRIVATE_STAGING_SDK_STORAGE_BASE_URL" ]; then
     set +x 
     sasToken=$ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN
     set -x
+    if [ -z "$sasToken" ]; then
+      echo "sasToken cannot be empty for $sdkStorageAccountUrl."
+    fi
 fi
 if [ -z "$debianFlavor" ] || [ "$debianFlavor" == "stretch" ]; then
   # Use default sdk file name

--- a/images/runtime/python/3.10/base.bullseye.Dockerfile
+++ b/images/runtime/python/3.10/base.bullseye.Dockerfile
@@ -53,7 +53,11 @@ RUN chmod +x /tmp/build.sh && \
         uuid-dev \
         libgeos-dev
 
-RUN ${BUILD_DIR}/buildPythonSdkByVersion.sh $PYTHON_VERSION
+RUN --mount=type=secret,id=oryx_sdk_storage_account_access_token \
+    set -e \
+    && export ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN="$(cat /run/secrets/oryx_sdk_storage_account_access_token)" \
+    && ${BUILD_DIR}/buildPythonSdkByVersion.sh $PYTHON_VERSION \
+    && export ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN=""
 
 RUN set -ex \
  && cd /opt/python/ \

--- a/images/runtime/python/3.11/base.bullseye.Dockerfile
+++ b/images/runtime/python/3.11/base.bullseye.Dockerfile
@@ -51,7 +51,11 @@ RUN chmod +x /tmp/build.sh && \
         uuid-dev \
         libgeos-dev
 
-RUN ${BUILD_DIR}/buildPythonSdkByVersion.sh $PYTHON_VERSION
+RUN --mount=type=secret,id=oryx_sdk_storage_account_access_token \
+    set -e \
+    && export ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN="$(cat /run/secrets/oryx_sdk_storage_account_access_token)" \
+    && ${BUILD_DIR}/buildPythonSdkByVersion.sh $PYTHON_VERSION \
+    && export ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN=""
 
 RUN set -ex \
  && cd /opt/python/ \


### PR DESCRIPTION
For the python base images, the sasToken is not passed which failing the pipelines..

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8281857&view=logs&j=1233d667-05d8-57bf-a038-dc2eeedfc644&t=cb013880-852e-5007-8379-a5e92273d474#:~:text=0.855%20Verifying%20checksum...-,0.856%20sha512sum%3A%20%27standard%20input%27%3A%20no%20properly%20formatted%20SHA512%20checksum%20lines%20found,-%2D%2D%2D%2D%2D%2D

In this PR I have fixed the issue.