### PR TITLE
hotfix baseimage scirpt

### DIFF
--- a/build/buildRunTimeImageBases.sh
+++ b/build/buildRunTimeImageBases.sh
@@ -42,6 +42,9 @@ then
     fi
 fi
 
+# checking and retrieving token for the `oryxsdksstaging` account.
+retrieveSastokenFromKeyvault $PRIVATE_STAGING_SDK_STORAGE_BASE_URL
+
 echo
 echo "Building the common base image wih bullseye and buster flavor '$RUNTIME_BASE_IMAGE_NAME'..."
 echo

--- a/images/build/installDotNetCore.sh
+++ b/images/build/installDotNetCore.sh
@@ -16,10 +16,17 @@ if [ -z "$sdkStorageAccountUrl" ]; then
 fi
 if [ "$sdkStorageAccountUrl" == "$PRIVATE_STAGING_SDK_STORAGE_BASE_URL" ]; then
     set +x
+    isSasTokenEmpty=1 
     sasToken=$ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN
-    set -x
     if [ -z "$sasToken" ]; then
+      isSasTokenEmpty=0
+    fi
+    set -x
+    
+    if [ $isSasTokenEmpty -eq 0 ]; then
       echo "sasToken cannot be empty for $sdkStorageAccountUrl."
+    else
+        echo "sasToken is valid for $sdkStorageAccountUrl."
     fi
 fi
 echo

--- a/images/installPlatform.sh
+++ b/images/installPlatform.sh
@@ -50,11 +50,18 @@ if [ -z "$sdkStorageAccountUrl" ]; then
   sdkStorageAccountUrl=$PRIVATE_STAGING_SDK_STORAGE_BASE_URL
 fi
 if [ "$sdkStorageAccountUrl" == "$PRIVATE_STAGING_SDK_STORAGE_BASE_URL" ]; then
-    set +x 
+    set +x
+    isSasTokenEmpty=1 
     sasToken=$ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN
-    set -x
     if [ -z "$sasToken" ]; then
+      isSasTokenEmpty=0
+    fi
+    set -x
+    
+    if [ $isSasTokenEmpty -eq 0 ]; then
       echo "sasToken cannot be empty for $sdkStorageAccountUrl."
+    else
+        echo "sasToken is valid for $sdkStorageAccountUrl."
     fi
 fi
 if [ -z "$debianFlavor" ] || [ "$debianFlavor" == "stretch" ]; then


### PR DESCRIPTION
- buildRunImageBases.sh script was failing because the sastoken is not passed through it. 
- added condition to log the info when the sasToken is valid in a couple of platform-installing scripts.