### PR TITLE
Convert dotnet 8 runtime image to bookworm

### DIFF
--- a/build/__dotNetCoreRunTimeVersions.sh
+++ b/build/__dotNetCoreRunTimeVersions.sh
@@ -1,6 +1,6 @@
 # This file was auto-generated from 'constants.yaml'. Changes may be overridden.
 
-DOT_NET_CORE_RUNTIME_BASE_TAG='20230825.1'
+DOT_NET_CORE_RUNTIME_BASE_TAG='20230829.1'
 NET_CORE_APP_10='1.0.16'
 NET_CORE_APP_11='1.1.13'
 NET_CORE_APP_20='2.0.9'

--- a/build/buildRunTimeImages.sh
+++ b/build/buildRunTimeImages.sh
@@ -114,7 +114,7 @@ docker build \
     --build-arg DEBIAN_FLAVOR=bookworm \
     $REPO_DIR
 
-execAllGenerateDockerfiles "$runtimeImagesSourceDir" "generateDockerfiles.sh" "$runtimeImageDebianFlavor"
+# execAllGenerateDockerfiles "$runtimeImagesSourceDir" "generateDockerfiles.sh" "$runtimeImageDebianFlavor"
 
 # The common base image is built separately, so we ignore it
 dockerFiles=$(find $runtimeImagesSourceDir -type f \( -name "$runtimeImageDebianFlavor.Dockerfile" ! -path "$RUNTIME_IMAGES_SRC_DIR/commonbase/*" \) )

--- a/build/buildRunTimeImages.sh
+++ b/build/buildRunTimeImages.sh
@@ -114,7 +114,7 @@ docker build \
     --build-arg DEBIAN_FLAVOR=bookworm \
     $REPO_DIR
 
-# execAllGenerateDockerfiles "$runtimeImagesSourceDir" "generateDockerfiles.sh" "$runtimeImageDebianFlavor"
+execAllGenerateDockerfiles "$runtimeImagesSourceDir" "generateDockerfiles.sh" "$runtimeImageDebianFlavor"
 
 # The common base image is built separately, so we ignore it
 dockerFiles=$(find $runtimeImagesSourceDir -type f \( -name "$runtimeImageDebianFlavor.Dockerfile" ! -path "$RUNTIME_IMAGES_SRC_DIR/commonbase/*" \) )

--- a/build/constants.yaml
+++ b/build/constants.yaml
@@ -65,7 +65,7 @@
       file-name-prefix: __
 - name: dot-net-core-run-time-versions
   constants:
-    dot-net-core-runtime-base-tag: 20230825.1
+    dot-net-core-runtime-base-tag: 20230829.1
     net-core-app-10: 1.0.16
     net-core-app-11: 1.1.13
     net-core-app-20: 2.0.9

--- a/images/runtime/dotnetcore/8.0/base.bookworm.Dockerfile
+++ b/images/runtime/dotnetcore/8.0/base.bookworm.Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-gcdump
 #   dotnet-monitor --version 8.*
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 8.0.0-preview.7.23402
 
-FROM mcr.microsoft.com/mirror/docker/library/debian:bullseye-slim
+FROM mcr.microsoft.com/mirror/docker/library/debian:bookworm-slim
 ARG BUILD_DIR=/tmp/oryx/build
 ADD build ${BUILD_DIR}
 
@@ -20,8 +20,8 @@ RUN apt-get update \
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
-        libicu67 \
-        libssl1.1 \
+        libicu72 \
+        libssl3 \
         libstdc++6 \
         zlib1g \
         lldb \
@@ -45,7 +45,7 @@ RUN set -ex \
     && apt-get remove ca-certificates -y \
     && apt-get purge ca-certificates -y \
     && apt-get update \
-    && apt-get install -f ca-certificates=20210119 -y --no-install-recommends \
+    && apt-get install -f ca-certificates -y --no-install-recommends \
     && . ${BUILD_DIR}/__dotNetCoreRunTimeVersions.sh \
     && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Runtime/$NET_CORE_APP_80/dotnet-runtime-$NET_CORE_APP_80-linux-x64.tar.gz \
     && echo "$NET_CORE_APP_80_SHA dotnet.tar.gz" | sha512sum -c - \

--- a/src/BuildScriptGenerator/DotNetCore/DotNetCoreRunTimeVersions.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotNetCoreRunTimeVersions.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 {
     public static class DotNetCoreRunTimeVersions
     {
-        public const string DotNetCoreRuntimeBaseTag = "20230825.1";
+        public const string DotNetCoreRuntimeBaseTag = "20230829.1";
         public const string NetCoreApp10 = "1.0.16";
         public const string NetCoreApp11 = "1.1.13";
         public const string NetCoreApp20 = "2.0.9";


### PR DESCRIPTION
Runtime image for dotnet 8 was still based off of bullseye, and this converts it to bookworm