### PR TITLE
fixed runTimeImagebase script issue

### DIFF
--- a/build/buildRunTimeImageBases.sh
+++ b/build/buildRunTimeImageBases.sh
@@ -43,7 +43,7 @@ then
 fi
 
 # checking and retrieving token for the `oryxsdksstaging` account.
-retrieveSastokenFromKeyvault $PRIVATE_STAGING_SDK_STORAGE_BASE_URL
+retrieveSastokenFromKeyVault $PRIVATE_STAGING_SDK_STORAGE_BASE_URL
 
 echo
 echo "Building the common base image wih bullseye, buster, and bookworm flavor '$RUNTIME_BASE_IMAGE_NAME'..."


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.


A naming bug(`retrieveSastokenFromKeyVault` vs `retrieveSastokenFromKeyvault`) created because of the changes in two branches at the same time. Here is the tiny PR to fix it.