### PR TITLE
Sync php versions from constants.yaml

### DIFF
--- a/build/__phpVersions.sh
+++ b/build/__phpVersions.sh
@@ -36,4 +36,3 @@ PHP70_TAR_SHA256='ab8c5be6e32b1f8d032909dedaaaa4bbb1a209e519abb01a52ce3914f9a13d
 PHP56_VERSION='5.6.40'
 PHP56_KEYS='0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3'
 PHP56_TAR_SHA256='1369a51eee3995d7fbd1c5342e5cc917760e276d561595b6052b21ace2656d1c'
-FPM_RUNTIME_VERSIONS=("7.4-fpm-debian-bullseye" "7.4-fpm-debian-buster" "8.0-fpm-debian-bullseye" "8.0-fpm-debian-buster" "8.1-fpm-debian-bullseye" "8.1-fpm-debian-buster" "8.2-fpm-debian-bullseye" "8.2-fpm-debian-buster")

--- a/build/__phpVersions.sh
+++ b/build/__phpVersions.sh
@@ -36,3 +36,4 @@ PHP70_TAR_SHA256='ab8c5be6e32b1f8d032909dedaaaa4bbb1a209e519abb01a52ce3914f9a13d
 PHP56_VERSION='5.6.40'
 PHP56_KEYS='0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3'
 PHP56_TAR_SHA256='1369a51eee3995d7fbd1c5342e5cc917760e276d561595b6052b21ace2656d1c'
+FPM_RUNTIME_VERSIONS=("7.4-fpm-debian-bullseye" "7.4-fpm-debian-buster" "8.0-fpm-debian-bullseye" "8.0-fpm-debian-buster" "8.1-fpm-debian-bullseye" "8.1-fpm-debian-buster" "8.2-fpm-debian-bullseye" "8.2-fpm-debian-buster")

--- a/build/constants.yaml
+++ b/build/constants.yaml
@@ -222,15 +222,6 @@
       - 8.1-debian-buster
       - 8.2-debian-bullseye
       - 8.2-debian-buster
-    fpm-runtime-versions:
-      - 7.4-fpm-debian-bullseye
-      - 7.4-fpm-debian-buster
-      - 8.0-fpm-debian-bullseye
-      - 8.0-fpm-debian-buster
-      - 8.1-fpm-debian-bullseye
-      - 8.1-fpm-debian-buster
-      - 8.2-fpm-debian-bullseye
-      - 8.2-fpm-debian-buster
   outputs:
     - type: csharp
       directory: src/BuildScriptGenerator

--- a/src/BuildScriptGenerator/PhpVersions.cs
+++ b/src/BuildScriptGenerator/PhpVersions.cs
@@ -43,6 +43,5 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Common
         public const string Php56Keys = "0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3";
         public const string Php56TarSha256 = "1369a51eee3995d7fbd1c5342e5cc917760e276d561595b6052b21ace2656d1c";
         public static readonly List<string> RuntimeVersions = new List<string> { "7.4-debian-bullseye", "7.4-debian-buster", "8.0-debian-bullseye", "8.0-debian-buster", "8.1-debian-bullseye", "8.1-debian-buster", "8.2-debian-bullseye", "8.2-debian-buster" };
-        public static readonly List<string> FpmRuntimeVersions = new List<string> { "7.4-fpm-debian-bullseye", "7.4-fpm-debian-buster", "8.0-fpm-debian-bullseye", "8.0-fpm-debian-buster", "8.1-fpm-debian-bullseye", "8.1-fpm-debian-buster", "8.2-fpm-debian-bullseye", "8.2-fpm-debian-buster" };
     }
 }

--- a/tests/Oryx.Tests.Common/ImageTestHelper.cs
+++ b/tests/Oryx.Tests.Common/ImageTestHelper.cs
@@ -495,12 +495,6 @@ namespace Microsoft.Oryx.Tests.Common
                 NodeVersions.RuntimeVersions
             },
             {
-                PhpConstants.PlatformName,
-                PhpVersions.RuntimeVersions
-                .Concat(PhpVersions.FpmRuntimeVersions)
-                .ToList()
-            },
-            {
                 PythonConstants.PlatformName,
                 PythonVersions.RuntimeVersions
             },


### PR DESCRIPTION
- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as:
  - this [php versions file](https://github.com/microsoft/Oryx/pull/2148/files#diff-c8a0a40b2a20e54011fc6e980f570aabbcd662f0966f2e7219e606b1aad9334bR39) is out of sync with the constants.yaml file, which is causing automation to create PRs since there are changes in constants.yaml not yet distributed throughout Oryx.
  - This PR will sync the php versions with what exists in the constants.yaml file
  - This file gets populated after running `./build/generateConstants.sh`
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
