### PR TITLE
Update to ignore fpm-runtime-versions

### DIFF
--- a/build/tools/SharedCodeGenerator/Outputs/ShellOutput.cs
+++ b/build/tools/SharedCodeGenerator/Outputs/ShellOutput.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Oryx.SharedCodeGenerator.Outputs
             if (this.collection.ListConstants?.Any() ?? false)
             {
                 // exclude runtime versions constants lists, as they will just overwrite each other in shell
-                foreach (var constant in this.collection.ListConstants.Where(c => !c.Key.Equals("runtime-versions")))
+                foreach (var constant in this.collection.ListConstants.Where(c => !c.Key.Equals("runtime-versions") && !c.Key.Equals("fpm-runtime-versions")))
                 {
                     string name = constant.Key.Replace(ConstantCollection.NameSeparator[0], '_').ToUpper();
                     var value = constant.Value.Count != 0


### PR DESCRIPTION
- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a [reference ](url)as: 
  - We ignore `fpm-runtime-versions` because `/bin/sh` does not support arrays and will cause pipeline failures. 
  - Failure: 
![image](https://github.com/microsoft/Oryx/assets/86327553/a9b6569f-ed8b-4b72-ab14-6721a7cb789c)

- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
