### PR TITLE
Snehapar/remove shell tracing output

### DIFF
--- a/images/build/installHugo.sh
+++ b/images/build/installHugo.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 # --------------------------------------------------------------------------------------------
 
-set -ex
+set -e
 
 __CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$__CURRENT_DIR/../../build/__hugoConstants.sh"


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.

https://github.com/Azure/static-web-apps/issues/1183

`set -ex` enables shell tracing and the shell tracing output is written to stderr by design. So, there is no straightforward way to just change the color of the shell tracing output.

We can remove it if it's not valuable information for customers and just exit on error instead be running `set -e` or let the customer know why they are seeing it and evaluate if we should remove it or not based on their response.

Here is how it looks after the change (without the statements beginning with ++)

![image](https://github.com/microsoft/Oryx/assets/108305436/6cff5dde-9a86-42da-b505-5d0e7df22ad0)


Before change : 

![image](https://github.com/microsoft/Oryx/assets/108305436/59d31b8c-52b8-4f51-8b2c-49a65ab00059)


