### PR TITLE
Ensure all runtime images are pushed to production during release phase

### DIFF
--- a/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
+++ b/tests/Oryx.BuildImage.Tests/DotNetCore/DotNetCoreDynamicInstallTest.cs
@@ -571,13 +571,13 @@ namespace Microsoft.Oryx.BuildImage.Tests
 
                 // buster
                 data.Add(
-                    DotNetCoreRunTimeVersions.NetCoreApp60,
-                    DotNetCoreSdkVersions.DotNet60SdkVersion,
+                    "6.0.20",  // Hard-code .NET 6.0 values for buster while the latest binaries have known issues
+                    "6.0.412",
                     NetCore6PreviewWebApp,
                     imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBuster));
                 data.Add(
-                    DotNetCoreRunTimeVersions.NetCoreApp70,
-                    DotNetCoreSdkVersions.DotNet70SdkVersion,
+                    "7.0.9",   // Hard-code .NET 7.0 values for buster while the latest binaries have known issues
+                    "7.0.306",
                     NetCore7PreviewMvcApp,
                     imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBuster));
 

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -198,12 +198,6 @@ steps:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)'
       AdditionalComponentDetectorArgs: '--DirectoryExclusionList **/SampleApps/**'
 
-- script: |
-    echo "Writing Debian-specific runtime image tags to known file"
-    cat $(Build.ArtifactStagingDirectory)/images/runtime-images-acr.${{ parameters.imageType }}.txt >> '$(Build.ArtifactStagingDirectory)/images/runtime-images-acr.txt'
-  displayName: 'Writing Debian-specific runtime image tags to known file'
-  condition: and(succeeded(), eq(variables['BuildRuntimeImages'], 'true'))
-
 - task: PublishTestResults@2
   inputs:
     testRunner: 'xUnit'

--- a/vsts/pipelines/templates/_buildTemplate.yml
+++ b/vsts/pipelines/templates/_buildTemplate.yml
@@ -148,7 +148,7 @@ steps:
   inputs:
     type: FilePath
     scriptPath: ./vsts/scripts/pullAndTag.sh
-    args: $(System.ArtifactsDirectory)/drop/images/build-images-acr.txt $(System.ArtifactsDirectory)/drop/images/runtime-images-acr.txt
+    args: $(System.ArtifactsDirectory)/drop/images/build-images-acr.txt
   condition: and(succeeded(), eq(variables['TestIntegration'], 'true'))
 
 - task: ms-devlabs.utilitytasks.task-Shellpp.Shell++@0
@@ -224,7 +224,7 @@ steps:
     azureContainerRegistry: ${{ parameters.acrName }}
     command: 'Push an image'
     pushMultipleImages: true
-    imageNamesPath: '$(Build.ArtifactStagingDirectory)/images/runtime-images-acr.txt'
+    imageNamesPath: '$(Build.ArtifactStagingDirectory)/images/runtime-images-acr.${{ parameters.imageType }}.txt'
     includeLatestTag: false
     enforceDockerNamingConvention: false
   condition: and(succeeded(), eq(variables['PushRuntimeImages'], 'true'), eq(variables['BuildRuntimeImages'], 'true'))

--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -127,10 +127,10 @@ if [ -n "$TESTINTEGRATIONCASEFILTER" ];then
 		# Note: we don't write this file to the drop folder as we don't want this file written to for every integration test job
 		sourceFile="$BUILD_SOURCESDIRECTORY/temp/images/runtime-images-acr.txt"
 
-		# Consolidate the different Debian runtime image files into one to be read from
-		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> '$sourceFile'
-		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> '$sourceFile'
-		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> '$sourceFile'
+		for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
+		do
+			(cat "$FILE"; echo) >> "$sourceFile"
+		done
 
 		while read sourceImage; do
   		# Always use specific build number based tag and then use the same tag

--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -128,10 +128,9 @@ if [ -n "$TESTINTEGRATIONCASEFILTER" ];then
 		sourceFile="$BUILD_SOURCESDIRECTORY/temp/images/runtime-images-acr.txt"
 
 		# Consolidate the different Debian runtime image files into one to be read from
-		for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
-		do
-  			(cat $FILE; echo) >> '$sourceFile'
-		done
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> '$sourceFile'
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> '$sourceFile'
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> '$sourceFile'
 
 		while read sourceImage; do
   		# Always use specific build number based tag and then use the same tag

--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -127,13 +127,16 @@ if [ -n "$TESTINTEGRATIONCASEFILTER" ];then
 		# Note: we don't write this file to the drop folder as we don't want this file written to for every integration test job
 		sourceFile="$BUILD_SOURCESDIRECTORY/temp/images/runtime-images-acr.txt"
 
+		if [[ ! -f "$sourceFile" ]]; then
+			echo "Creating consolidated runtime image file '$sourceFile'..."
+			touch "$sourceFile"
+		fi
+
 		echo "Consolidating runtime image files into '$sourceFile'..."
 
-		for FILE in $(find "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images" -name "runtime-images-acr.*.txt")
-		do
-			echo "Adding contents of '$FILE' to '$sourceFile' ..."
-			(cat "$FILE"; echo) >> "$sourceFile"
-		done
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> "$sourceFile"
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> "$sourceFile"
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> "$sourceFile"
 
 		echo "Iterating over previously pushed images defined in new '$sourceFile' file..."
 

--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -127,10 +127,15 @@ if [ -n "$TESTINTEGRATIONCASEFILTER" ];then
 		# Note: we don't write this file to the drop folder as we don't want this file written to for every integration test job
 		sourceFile="$BUILD_SOURCESDIRECTORY/temp/images/runtime-images-acr.txt"
 
-		for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
+		echo "Consolidating runtime image files into '$sourceFile'..."
+
+		for FILE in $(find "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images" -name "runtime-images-acr.*.txt")
 		do
+			echo "Adding contents of '$FILE' to '$sourceFile' ..."
 			(cat "$FILE"; echo) >> "$sourceFile"
 		done
+
+		echo "Iterating over previously pushed images defined in new '$sourceFile' file..."
 
 		while read sourceImage; do
   		# Always use specific build number based tag and then use the same tag

--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -129,6 +129,7 @@ if [ -n "$TESTINTEGRATIONCASEFILTER" ];then
 
 		if [[ ! -f "$sourceFile" ]]; then
 			echo "Creating consolidated runtime image file '$sourceFile'..."
+			mkdir -p "$BUILD_SOURCESDIRECTORY/temp/images"
 			touch "$sourceFile"
 		fi
 

--- a/vsts/scripts/pullAndTag.sh
+++ b/vsts/scripts/pullAndTag.sh
@@ -6,7 +6,6 @@
 
 set -euo pipefail
 # $1 > buildimage-acr.txt
-# $2 > runtime-images-acr.txt
 declare imagefilter="oryxdevmcr.azurecr.io/public/oryx"
 
 function tagBuildImageForIntegrationTest() {
@@ -42,11 +41,11 @@ function tagBuildImageForIntegrationTest() {
 
 	echo
 	echo "Tagging the source image with tag $newtag ..."
-	
+
 	docker tag "$buildImage" "$newtag" | sed 's/^/     /'
 	echo
 	echo -------------------------------------------------------------------------------
-  
+
 }
 
 buildImageFilter=""
@@ -124,8 +123,18 @@ if [ -n "$TESTINTEGRATIONCASEFILTER" ];then
 		# Always convert filter for runtime images to lower case
 		echo "Runtime image filter is set for $platformFilter with version $platformVersionFilter"
 
+		# Create a local file that consolidates the different runtime image files into one to be read from
+		# Note: we don't write this file to the drop folder as we don't want this file written to for every integration test job
+		sourceFile="$BUILD_SOURCESDIRECTORY/temp/images/runtime-images-acr.txt"
+
+		# Consolidate the different Debian runtime image files into one to be read from
+		for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
+		do
+  			(cat $FILE; echo) >> '$sourceFile'
+		done
+
 		while read sourceImage; do
-  		# Always use specific build number based tag and then use the same tag 
+  		# Always use specific build number based tag and then use the same tag
 		# to create a version tag and push it
   			if [[ "$sourceImage" != *:latest ]]; then
 				if [[ "$sourceImage" == *"$platformFilter:$platformVersionFilter"* ]]; then
@@ -154,7 +163,7 @@ if [ -n "$TESTINTEGRATIONCASEFILTER" ];then
 					echo -------------------------------------------------------------------------------
 				fi
   			fi
-		done <"$2"
+		done <"$sourceFile"
 	fi
 fi
 

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -12,13 +12,16 @@ sourceBranchName=$BUILD_SOURCEBRANCHNAME
 outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runtime-images-mcr.txt"
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
 
-echo "Consolidating runtime image files into '$sourceFile' ..."
+if [[ ! -f "$sourceFile" ]]; then
+			echo "Creating consolidated runtime image file '$sourceFile'..."
+			touch "$sourceFile"
+		fi
 
-for FILE in $(find "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images" -name "runtime-images-acr.*.txt")
-do
-  echo "Adding contents of '$FILE' to '$sourceFile'..."
-  (cat "$FILE"; echo) >> "$sourceFile"
-done
+		echo "Consolidating runtime image files into '$sourceFile'..."
+
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> "$sourceFile"
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> "$sourceFile"
+		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> "$sourceFile"
 
 if [ -f "$outFilePmeMCR" ]; then
     rm $outFilePmeMCR

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -12,10 +12,10 @@ sourceBranchName=$BUILD_SOURCEBRANCHNAME
 outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runtime-images-mcr.txt"
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
 
-# Consolidate the different Debian runtime image files into one to be read from
-(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> '$sourceFile'
-(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> '$sourceFile'
-(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> '$sourceFile'
+for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
+		do
+			(cat "$FILE"; echo) >> "$sourceFile"
+		done
 
 if [ -f "$outFilePmeMCR" ]; then
     rm $outFilePmeMCR

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -14,6 +14,7 @@ sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
 
 if [[ ! -f "$sourceFile" ]]; then
 			echo "Creating consolidated runtime image file '$sourceFile'..."
+      mkdir -p "$BUILD_SOURCESDIRECTORY/temp/images"
 			touch "$sourceFile"
 		fi
 

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -13,10 +13,9 @@ outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runti
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
 
 # Consolidate the different Debian runtime image files into one to be read from
-for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
-do
-  (cat $FILE; echo) >> '$sourceFile'
-done
+(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> '$sourceFile'
+(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> '$sourceFile'
+(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> '$sourceFile'
 
 if [ -f "$outFilePmeMCR" ]; then
     rm $outFilePmeMCR

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -11,6 +11,14 @@ acrPmeProdRepo="oryxprodmcr"
 sourceBranchName=$BUILD_SOURCEBRANCHNAME
 outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runtime-images-mcr.txt"
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
+debianBusterSourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"
+debianBullseyeSourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"
+debianBookwormSourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"
+
+# Consolidate the different Debian runtime image files into one to be read from
+cat $debianBusterSourceFile >> '$sourceFile'
+cat $debianBullseyeSourceFile >> '$sourceFile'
+cat $debianBookwormSourceFile >> '$sourceFile'
 
 if [ -f "$outFilePmeMCR" ]; then
     rm $outFilePmeMCR

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -12,14 +12,19 @@ sourceBranchName=$BUILD_SOURCEBRANCHNAME
 outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runtime-images-mcr.txt"
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
 
-for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
-		do
-			(cat "$FILE"; echo) >> "$sourceFile"
-		done
+echo "Consolidating runtime image files into '$sourceFile' ..."
+
+for FILE in $(find "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images" -name "runtime-images-acr.*.txt")
+do
+  echo "Adding contents of '$FILE' to '$sourceFile'..."
+  (cat "$FILE"; echo) >> "$sourceFile"
+done
 
 if [ -f "$outFilePmeMCR" ]; then
     rm $outFilePmeMCR
 fi
+
+echo "Iterating over previously pushed images defined in new '$sourceFile' file..."
 
 while read sourceImage; do
   # Always use specific build number based tag and then use the same tag to create a 'latest' tag and push it

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -13,19 +13,19 @@ outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runti
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
 
 if [[ ! -f "$sourceFile" ]]; then
-			echo "Creating consolidated runtime image file '$sourceFile'..."
-      mkdir -p "$BUILD_SOURCESDIRECTORY/temp/images"
-			touch "$sourceFile"
-		fi
+  echo "Creating consolidated runtime image file '$sourceFile'..."
+  mkdir -p "$BUILD_SOURCESDIRECTORY/temp/images"
+  touch "$sourceFile"
+fi
 
-		echo "Consolidating runtime image files into '$sourceFile'..."
+echo "Consolidating runtime image files into '$sourceFile'..."
 
-		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> "$sourceFile"
-		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> "$sourceFile"
-		(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> "$sourceFile"
+(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"; echo) >> "$sourceFile"
+(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"; echo) >> "$sourceFile"
+(cat "$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"; echo) >> "$sourceFile"
 
 if [ -f "$outFilePmeMCR" ]; then
-    rm $outFilePmeMCR
+  rm $outFilePmeMCR
 fi
 
 echo "Iterating over previously pushed images defined in new '$sourceFile' file..."

--- a/vsts/scripts/tagRunTimeImagesForRelease.sh
+++ b/vsts/scripts/tagRunTimeImagesForRelease.sh
@@ -11,14 +11,12 @@ acrPmeProdRepo="oryxprodmcr"
 sourceBranchName=$BUILD_SOURCEBRANCHNAME
 outFilePmeMCR="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/$acrPmeProdRepo-runtime-images-mcr.txt"
 sourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.txt"
-debianBusterSourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.buster.txt"
-debianBullseyeSourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bullseye.txt"
-debianBookwormSourceFile="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/runtime-images-acr.bookworm.txt"
 
 # Consolidate the different Debian runtime image files into one to be read from
-cat $debianBusterSourceFile >> '$sourceFile'
-cat $debianBullseyeSourceFile >> '$sourceFile'
-cat $debianBookwormSourceFile >> '$sourceFile'
+for FILE in $(find $BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images -name 'runtime-images-acr.*.txt')
+do
+  (cat $FILE; echo) >> '$sourceFile'
+done
 
 if [ -f "$outFilePmeMCR" ]; then
     rm $outFilePmeMCR
@@ -54,7 +52,7 @@ while read sourceImage; do
 
     echo
     echo "Tagging the source image with tag $acrPmeSpecific..."
-    
+
     echo "$acrPmeSpecific">>"$outFilePmeMCR"
     docker tag "$sourceImage" "$acrPmeSpecific"
 


### PR DESCRIPTION
Currently, during the release phase of our CI pipeline that pushes the runtime images to production, only one set of Debian flavor images will be pushed (whichever job finished last) -- this is due to the fact that all three Debian flavor runtime jobs are writing the list of runtime images built and pushed within the scope of the job to a `runtime-images-acr.txt` file that is dropped as an artifact of the job. This artifact is seemingly overridden when it shares its name with the same artifact dropped by a separate job later, so if the bookworm job finishes first and drops an artifact named `runtime-images-acr.txt`, it will be overridden when the buster job finishes next and drops an artifact with the same name.

To resolve this, each job is already dropping an artifact that includes the Debian flavor in the name (_e.g._, `runtime-images-acr.bookworm.txt`), so before we read the list of runtime images built and pushed in the `runtime-images-acr.txt` file, we will consolidate all of the images in each Debian flavor `.txt` file to this `runtime-images-acr.txt` file.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
