### PR TITLE
Pauld/improve error handling builder

### DIFF
--- a/builders/container-apps-internal-registry-demo/Dockerfile
+++ b/builders/container-apps-internal-registry-demo/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER_IMAGE="mcr.microsoft.com/oryx/builder:debian-bullseye-20231025.1"
+ARG BASE_BUILDER_IMAGE="mcr.microsoft.com/oryx/builder:debian-bullseye-20231107.1"
 FROM ${BASE_BUILDER_IMAGE}
 
 # these environment variables are generally going to be overwritten:

--- a/builders/container-apps-internal-registry-demo/Dockerfile
+++ b/builders/container-apps-internal-registry-demo/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER_IMAGE="mcr.microsoft.com/oryx/builder:debian-bullseye-20231018.1"
+ARG BASE_BUILDER_IMAGE="mcr.microsoft.com/oryx/builder:debian-bullseye-20231025.1"
 FROM ${BASE_BUILDER_IMAGE}
 
 # these environment variables are generally going to be overwritten:

--- a/builders/container-apps-internal-registry-demo/buildCappsBuilder.sh
+++ b/builders/container-apps-internal-registry-demo/buildCappsBuilder.sh
@@ -12,7 +12,6 @@ source $REPO_DIR/build/__variables.sh
 destinationFqdn="oryxprodmcr.azurecr.io"
 destinationRepo="public/oryx/builder"
 destinationTag="capps-20230208.1"
-baseBuilderImage="mcr.microsoft.com/oryx/builder:debian-bullseye-20231016.1"
 
 PARAMS=""
 while (( "$#" )); do
@@ -27,10 +26,6 @@ while (( "$#" )); do
       ;;
     -t|--destination-tag)
       destinationTag=$2
-      shift 2
-      ;;
-    -b|--base-builder-tag)
-      baseBuilderImage=$2
       shift 2
       ;;
     --) # end argument parsing
@@ -60,7 +55,6 @@ echo "Building '$BUILD_IMAGE'..."
 echo
 cd $SCRIPT_DIR
 docker build \
-  --build-arg BASE_BUILDER_IMAGE=$baseBuilderImage \
   -t $BUILD_IMAGE \
   -f Dockerfile \
   .

--- a/builders/container-apps-internal-registry-demo/startup-script.sh
+++ b/builders/container-apps-internal-registry-demo/startup-script.sh
@@ -52,8 +52,8 @@ token=$(printf "%s" "$REGISTRY_AUTH_USERNAME:$REGISTRY_AUTH_PASSWORD" | base64)
 acr_access_string="Basic $token"
 export CNB_REGISTRY_AUTH='{"'$ACR_RESOURCE_NAME'":"'$acr_access_string'"}'
 
-echo "Initiating buildpack build..."
-echo "Correlation id: '$CORRELATION_ID'"
+echo "----- Initiating buildpack build -----"
+echo "----- Cloud Build correlation id: '$CORRELATION_ID' -----"
 echo 
 
 RETRY_DELAY=2
@@ -64,7 +64,7 @@ function fail_if_retry_exceeded() {
   exitCode=$2
   if [ "$retries" -ge $RETRY_ATTEMPTS ]; then
     echo "----- Retry attempts exceeded -----"
-    echo "Build process failed with exit code '$exitCode'. Exiting..."
+    echo "----- Cloud Build failed with exit code '$lifecycleExitCode' -----"
     exit $exitCode
   fi
 }
@@ -162,8 +162,7 @@ echo "===== Executing the extend phase ====="
 
 lifecycleExitCode=$?
 if [ $lifecycleExitCode -ne 0 ]; then
-    echo "----- Build failed -----"
-    echo "Build process failed with exit code '$lifecycleExitCode'. Exiting..."
+    echo "----- Cloud Build failed with exit code '$lifecycleExitCode' -----"
     exit $lifecycleExitCode
 fi
 

--- a/builders/container-apps-internal-registry-demo/startup-script.sh
+++ b/builders/container-apps-internal-registry-demo/startup-script.sh
@@ -80,7 +80,7 @@ lifecycleExitCode=0
 until [ "$retryCount" -ge $RETRY_ATTEMPTS ]
 do
   if [ "$retryCount" -ge 1 ]; then
-    echo "----- Retrying analyze phase (attempt $retryCount) -----"
+    echo "===== Retrying analyze phase (attempt $retryCount) ====="
   fi
 
   /lifecycle/analyzer \
@@ -107,7 +107,7 @@ lifecycleExitCode=0
 until [ "$retryCount" -ge $RETRY_ATTEMPTS ]
 do
   if [ "$retryCount" -ge 1 ]; then
-    echo "----- Retrying detect phase (attempt $retryCount) -----"
+    echo "===== Retrying detect phase (attempt $retryCount) ====="
   fi
 
   /lifecycle/detector \
@@ -133,7 +133,7 @@ lifecycleExitCode=0
 until [ "$retryCount" -ge $RETRY_ATTEMPTS ]
 do
   if [ "$retryCount" -ge 1 ]; then
-    echo "----- Retrying restore phase (attempt $retryCount) -----"
+    echo "===== Retrying restore phase (attempt $retryCount) ====="
   fi
 
   /lifecycle/restorer \
@@ -174,7 +174,7 @@ lifecycleExitCode=0
 until [ "$retryCount" -ge $RETRY_ATTEMPTS ]
 do
   if [ "$retryCount" -ge 1 ]; then
-    echo "----- Retrying export phase (attempt $retryCount) -----"
+    echo "===== Retrying export phase (attempt $retryCount) ====="
   fi
 
   /lifecycle/exporter \

--- a/builders/container-apps-internal-registry-demo/startup-script.sh
+++ b/builders/container-apps-internal-registry-demo/startup-script.sh
@@ -88,7 +88,7 @@ do
     -run-image mcr.microsoft.com/oryx/builder:stack-run-debian-bullseye-20230926.1 \
     $APP_IMAGE
 
-  $lifecycleExitCode=$?
+  lifecycleExitCode=$?
   if [ "$lifecycleExitCode" -eq 0 ]; then
     break
   fi
@@ -114,7 +114,7 @@ do
     -log-level debug \
     -app $CNB_APP_DIR
 
-  $lifecycleExitCode=$?
+  lifecycleExitCode=$?
   if [ "$lifecycleExitCode" -eq 0 ]; then
     break
   fi
@@ -140,7 +140,7 @@ do
     -log-level debug \
     -build-image mcr.microsoft.com/oryx/builder:stack-build-debian-bullseye-20230926.1
 
-  $lifecycleExitCode=$?
+  lifecycleExitCode=$?
   if [ "$lifecycleExitCode" -eq 0 ]; then
     break
   fi
@@ -160,9 +160,11 @@ echo "===== Executing the extend phase ====="
   -log-level debug \
   -app $CNB_APP_DIR
 
-if [ $? -ne 0 ]; then
+lifecycleExitCode=$?
+if [ $lifecycleExitCode -ne 0 ]; then
     echo "----- Build failed -----"
-    echo "Build process failed with exit code '$exitCode'. Exiting..."
+    echo "Build process failed with exit code '$lifecycleExitCode'. Exiting..."
+    exit $lifecycleExitCode
 fi
 
 # Execute the export phase
@@ -181,7 +183,7 @@ do
     -app $CNB_APP_DIR \
     $APP_IMAGE
 
-  $lifecycleExitCode=$?
+  lifecycleExitCode=$?
   if [ "$lifecycleExitCode" -eq 0 ]; then
     break
   fi


### PR DESCRIPTION
Updates the builder error handling so that we parse the exit codes from each of the lifecycle commands rather than using the `e` flag to immediately exit. This allows us to have a custom error message that we can parse using the CLI:
- `Build process failed with exit code` (this can be whatever we want, I did not spend much time thinking about it so let me know if anyone has suggestions)
