### PR TITLE
Bump version of the base builder used

### DIFF
--- a/builders/container-apps-internal-registry-demo/Dockerfile
+++ b/builders/container-apps-internal-registry-demo/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER_IMAGE="mcr.microsoft.com/oryx/builder:debian-bullseye-20231107.1"
+ARG BASE_BUILDER_IMAGE="mcr.microsoft.com/oryx/builder:debian-bullseye-20231107.2"
 FROM ${BASE_BUILDER_IMAGE}
 
 # these environment variables are generally going to be overwritten:


### PR DESCRIPTION
Update the base builder's image tag to reflect the latest version available to use when building the ACA builder.

~- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.~
~- [ ] Tests are included and/or updated for code changes.~
~- [ ] Proper license headers are included in each file.~
