### PR TITLE
Add logic to prevent automated PRs from stacking

### DIFF
--- a/.github/workflows/automationTemplate.yaml
+++ b/.github/workflows/automationTemplate.yaml
@@ -60,13 +60,20 @@ jobs:
           
           git status
           git add -A
-          git commit -m "Add new ${{ inputs.platformName }} SDK versions" && true
-          gitCommitExitCode=${PIPESTATUS[0]}
-          if [[ $gitCommitExitCode = 0 ]]; then
-            cancelWorkflow=0
-          else
+
+          # Check if build/constants.yaml has updates
+          if git diff --quiet --exit-code -- build/constants.yaml; then
             echo "No new ${{ inputs.platformName }} SDK versions detected. Canceling workflow..."
             cancelWorkflow=1
+          else
+            git commit -m "Add new ${{ inputs.platformName }} SDK versions" && true
+            gitCommitExitCode=${PIPESTATUS[0]}
+            if [[ $gitCommitExitCode = 0 ]]; then
+              cancelWorkflow=0
+            else
+              echo "Error committing changes. Canceling workflow..."
+              cancelWorkflow=1
+            fi
           fi
 
           echo "CANCEL_WORKFLOW=${cancelWorkflow}" >> $GITHUB_ENV


### PR DESCRIPTION
- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as:
  - This fixes Automation PRs from stacking.  We noticed this happening because there was a discrepancy where a file like [supportedPlatformVersions.md ](https://github.com/microsoft/Oryx/pull/2319/files#diff-66045e8cd0d3915daf150fa12604cfa391bb7e27ae62e3d8d1618af99b8081c7L158)is not up to date, which tricks Automation into thinking there are new updates. 
  - The solution is to only check `build/constants.yaml` for changes, instead of checking the Oryx repo for changes, before running Automation and submitting a PR. 
    - Example of stacking:
    - ![image](https://github.com/microsoft/Oryx/assets/86327553/c90f7a5c-ca24-48d8-8cd7-586e5ef5e287)
  - https://devdiv.visualstudio.com/DevDiv/_boards/board/t/Oryx/Stories?System.AssignedTo=williamhe%40microsoft.com
- [x] Tests are included and/or updated for code changes.
  - [In this test ](https://github.com/microsoft/Oryx/actions/runs/7389040933/job/20101085954#step:5:88)no stacking occurred, since constants.yaml had no changes.
  - This is the exit code we check when `build/constants.yaml` does not and does have a chance. Note the exit code is 0 and 1
    - ![image](https://github.com/microsoft/Oryx/assets/86327553/cadda04a-0d50-40be-82c2-2aa3cb20c6d0)
- [x] Proper license headers are included in each file.
