### PR TITLE
Update build pack to mcr latest

### DIFF
--- a/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBookworm.Dockerfile
+++ b/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBookworm.Dockerfile
@@ -1,3 +1,2 @@
-# https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-# DisableDockerDetector "Need to determine correct way of handling hashes in mirror registry"
-FROM buildpack-deps:bookworm@sha256:af1d6cabbfa6bb5e8897a4fba5442451b77aecc090f35508a45d087a0a69eec2
+# For ref - https://mcr.microsoft.com/en-us/product/mirror/docker/library/buildpack-deps/tags
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm

--- a/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBookworm.Dockerfile
+++ b/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBookworm.Dockerfile
@@ -1,2 +1,4 @@
 # For ref - https://mcr.microsoft.com/en-us/product/mirror/docker/library/buildpack-deps/tags
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bookworm
+# Debian version - 12.5
+# Release date of this image - 10th April 2024
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff838f535d6e3bace9ab7eefa360d648ba529f9aa57fdd709335f8ef0516cdde

--- a/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBullseye.Dockerfile
+++ b/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBullseye.Dockerfile
@@ -1,3 +1,2 @@
-# https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-# DisableDockerDetector "Need to determine correct way of handling hashes in mirror registry"
-FROM buildpack-deps:bullseye-scm@sha256:c776f9f4b32b6d3fa36b400434510ccd17a218bb27944b1781e9f823ba39881b
+# For ref - https://mcr.microsoft.com/en-us/product/mirror/docker/library/buildpack-deps/tags
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye

--- a/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBullseye.Dockerfile
+++ b/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBullseye.Dockerfile
@@ -1,2 +1,4 @@
 # For ref - https://mcr.microsoft.com/en-us/product/mirror/docker/library/buildpack-deps/tags
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:bullseye
+# Debian Version - 11.9
+# Release date of this image - 10th April 2024
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:25c86292946cce832340fe808ac47e5a845b68c488f177a47ff44fd59040397d

--- a/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBuster.Dockerfile
+++ b/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBuster.Dockerfile
@@ -1,3 +1,2 @@
-# https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-# DisableDockerDetector "Need to determine correct way of handling hashes in mirror registry"
-FROM buildpack-deps:buster@sha256:a254f0d1ab14e6f05992f64e71cbc6f22ab8a657b0e962bb8d0c7a1a3b2ed6d0
+# For ref - https://mcr.microsoft.com/en-us/product/mirror/docker/library/buildpack-deps/tags
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:buster

--- a/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBuster.Dockerfile
+++ b/images/build/Dockerfiles/gitHubRunners.BuildPackDepsBuster.Dockerfile
@@ -1,2 +1,4 @@
 # For ref - https://mcr.microsoft.com/en-us/product/mirror/docker/library/buildpack-deps/tags
-FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps:buster
+# Debian version - 10.13
+# Release date of this image - 10th April 2024
+FROM mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:be7137ba47bdf421d3950abe1200322631e8db11b468cd6f0ebf3d687e556c90


### PR DESCRIPTION
The base images for all build images are hard coded and pulled from public docker hub.
Changing those to mcr latest.

**New images**
bookworm
debian version - 12.5
mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff838f535d6e3bace9ab7eefa360d648ba529f9aa57fdd709335f8ef0516cdde

bullseye
debian version - 11.9
mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:25c86292946cce832340fe808ac47e5a845b68c488f177a47ff44fd59040397d

buster
mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:be7137ba47bdf421d3950abe1200322631e8db11b468cd6f0ebf3d687e556c90
debian version - 10.13


**Old Images**
bookworm
debian version - 12.1
buildpack-deps:bookworm@sha256:af1d6cabbfa6bb5e8897a4fba5442451b77aecc090f35508a45d087a0a69eec2

bullseye
debian version - 11.3
buildpack-deps:bullseye-scm@sha256:c776f9f4b32b6d3fa36b400434510ccd17a218bb27944b1781e9f823ba39881b

buster
debian version - 10.10
buildpack-deps:buster@sha256:a254f0d1ab14e6f05992f64e71cbc6f22ab8a657b0e962bb8d0c7a1a3b2ed6d0
