### PR TITLE
Fix oryx build failures by updating Azure.Identity NuGet and address security vulnerability

### DIFF
--- a/src/BuildScriptGenerator.Common/BuildScriptGenerator.Common.csproj
+++ b/src/BuildScriptGenerator.Common/BuildScriptGenerator.Common.csproj
@@ -16,7 +16,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\CommonFiles\AssemblyVersion.proj" />
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />


### PR DESCRIPTION
Ref: https://github.com/devcontainers/images/actions/runs/8912840852/job/24477114284#step:3:18361

Oryx build is failing for the `universal` image with the following error 👇  This is blocking a newer release of the image. 

![image](https://github.com/microsoft/Oryx/assets/24955913/da0ac029-0726-4c5f-b430-5b4567e73159)

This PR fixes oryx build, as well as patches the security vulnerability.