### PR TITLE
No Pubkey Error fix in Python bookworm images

### DIFF
--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -35,8 +35,8 @@ export ACCEPT_EULA=Y \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
 if [ "$debianFlavor" == "bookworm" ]; then \
-    curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list \ 
-    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+    curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 elif [ "$debianFlavor" == "bullseye" ]; then \
     curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 elif [ "$debianFlavor" == "buster" ]; then \

--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -35,7 +35,9 @@ export ACCEPT_EULA=Y \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
 if [ "$debianFlavor" == "bookworm" ]; then \
-    curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list
+    curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list \ 
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+
 elif [ "$debianFlavor" == "bullseye" ]; then \
     curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 elif [ "$debianFlavor" == "buster" ]; then \

--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -36,8 +36,7 @@ export ACCEPT_EULA=Y \
 
 if [ "$debianFlavor" == "bookworm" ]; then \
     curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list \ 
-    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-
+    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 elif [ "$debianFlavor" == "bullseye" ]; then \
     curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 elif [ "$debianFlavor" == "buster" ]; then \


### PR DESCRIPTION
The purpose of this PR is to fix the NO_PUBKEY EB3E94ADBE1229CF Error found in python bookworm images (and not in any other flavors). 

<img width="712" alt="error" src="https://github.com/microsoft/Oryx/assets/81869581/27c94853-1c52-4c40-82b7-beeaee3da46b">

```
W: GPG error: https://packages.microsoft.com/debian/12/prod bookworm InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY EB3E94ADBE1229CF
E: The repository 'https://packages.microsoft.com/debian/12/prod bookworm InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```


### Fix: 
Error seemed to be because of the way apt has changed the way it verifies its signature. 
Added the commands in install-dependency.sh file, created a custom image of python bookworm using Azure Devops pipeline and downloaded the artifact image to run locally to verify the working.

Check the pipeline and artifact produced here: [Pipeline](https://dev.azure.com/msazure/Antares/_build/results?buildId=97706980&view=results) 

<img width="814" alt="fixed" src="https://github.com/microsoft/Oryx/assets/81869581/9fd182b2-a435-495b-a305-620c0c0a6e8b">



 