### PR TITLE
Python Bookworm Image Fixes

### DIFF
--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -56,7 +56,8 @@ if [ "$debianFlavor" != "bookworm" ]; then \
     ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.4.1-1 \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.2.2.1-1
 elif [ "$debianFlavor" == "bookworm" ]; then \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.3.3.1-1
+    ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.6.1-1 \
+    && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.3.3.1-1
 fi
 
 ACCEPT_EULA=Y apt-get install -y mssql-tools18 \

--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -55,7 +55,7 @@ apt-get update \
 if [ "$debianFlavor" != "bookworm" ]; then \
     ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.4.1-1 \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.2.2.1-1
-elif [ "$debianFlavor" == "bookworm" ]; then \
+else
     ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.6.1-1 \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.3.3.1-1
 fi

--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -36,6 +36,7 @@ export ACCEPT_EULA=Y \
 
 if [ "$debianFlavor" == "bookworm" ]; then \
     curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 elif [ "$debianFlavor" == "bullseye" ]; then \
     curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 elif [ "$debianFlavor" == "buster" ]; then \
@@ -50,14 +51,17 @@ apt-get update \
         apt-transport-https \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
     && locale-gen \
-    && ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.4.1-1 \
-    && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.2.2.1-1 \
     && ACCEPT_EULA=Y apt-get install -y mssql-tools18 \
     && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
     && source ~/.bashrc \
     && apt-get install -y --no-install-recommends \
         unixodbc-dev \
         libgssapi-krb5-2
+
+if [ "$debianFlavor" != "bookworm" ]; then \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.4.1-1 \
+    && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.2.2.1-1
+fi
 
 mkdir -p /etc/unixODBC
 cat >/etc/unixODBC/odbcinst.ini <<EOL

--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -50,18 +50,21 @@ apt-get update \
         locales \
         apt-transport-https \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
-    && locale-gen \
-    && ACCEPT_EULA=Y apt-get install -y mssql-tools18 \
+    && locale-gen 
+
+if [ "$debianFlavor" != "bookworm" ]; then \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.4.1-1 \
+    && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.2.2.1-1
+elif [ "$debianFlavor" == "bookworm" ]; then \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.3.3.1-1
+fi
+
+ACCEPT_EULA=Y apt-get install -y mssql-tools18 \
     && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
     && source ~/.bashrc \
     && apt-get install -y --no-install-recommends \
         unixodbc-dev \
         libgssapi-krb5-2
-
-if [ "$debianFlavor" != "bookworm" ]; then \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.4.1-1 \
-    && ACCEPT_EULA=Y apt-get install -y msodbcsql18=18.2.2.1-1
-fi
 
 mkdir -p /etc/unixODBC
 cat >/etc/unixODBC/odbcinst.ini <<EOL


### PR DESCRIPTION
The purpose of this PR is to fix the following which existed in the Python Bookworm Images: 

- NO_PUBKEY EB3E94ADBE1229CF error (Since Debian 12 has changed its way to verify signatures) 
- Pinned versions for MSODBCSQL17 and MSODBCSQL18 (Since the current listed version did not exist for Bookworm). 


Link for the Python Bookworm artifacts generated and report: [Pipeline](https://dev.azure.com/msazure/Antares/_build/results?buildId=97808625&view=results)