### PR TITLE
fix: deprecated poetry flag

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -100,9 +100,9 @@ fi
         printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
         pip install poetry
         echo "Running poetry install..."
-        InstallPoetryCommand="poetry install --no-dev"
+        InstallPoetryCommand="poetry install --only"
         printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( poetry install --no-dev; exit ${PIPESTATUS[0]} ) 2>&1)
+        output=$( ( poetry install --only; exit ${PIPESTATUS[0]} ) 2>&1)
         pythonBuildExitCode=${PIPESTATUS[0]}
         set -e
         echo "${output}"


### PR DESCRIPTION
This issue close #2019

Currently flag --no-dev in poetry is deprecated and the new flag option is --only. this PR change the poetry command to use --only