### PR TITLE
Fix for issue #2557

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -100,9 +100,9 @@ fi
         printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
         pip install poetry
         echo "Running poetry install..."
-        InstallPoetryCommand="poetry install --no-dev"
+        InstallPoetryCommand="poetry install --without dev"
         printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( poetry install --no-dev; exit ${PIPESTATUS[0]} ) 2>&1)
+        output=$( ( poetry install --without dev; exit ${PIPESTATUS[0]} ) 2>&1)
         pythonBuildExitCode=${PIPESTATUS[0]}
         set -e
         echo "${output}"
@@ -171,9 +171,9 @@ fi
         pip install poetry
         START_TIME=$SECONDS
         echo "Running poetry install..."
-        InstallPoetryCommand="poetry install --no-dev"
+        InstallPoetryCommand="poetry install --without dev"
         printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( poetry install --no-dev; exit ${PIPESTATUS[0]} ) 2>&1 )
+        output=$( ( poetry install --without dev; exit ${PIPESTATUS[0]} ) 2>&1 )
         pythonBuildExitCode=${PIPESTATUS[0]}
         ELAPSED_TIME=$(($SECONDS - $START_TIME))
         echo "Done in $ELAPSED_TIME sec(s)."


### PR DESCRIPTION
python 2.0 has removed --no-dev and we need to use `--without dev` instead

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
