### PR TITLE
Only install .NET Monitor 9 on .NET 9 images

### DIFF
--- a/images/runtime/dotnetcore/9.0/bookworm.Dockerfile
+++ b/images/runtime/dotnetcore/9.0/bookworm.Dockerfile
@@ -6,7 +6,7 @@ RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-trace
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-dump
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-counters
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-gcdump
-RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor
+RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 9.*
 
 # Startup script generator
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-bookworm as startupCmdGen


### PR DESCRIPTION
The .NET 9 Oryx images are unconditionally installing the latest .NET Monitor version onto the image. This is opposed to the prior .NET Oryx images where they are range bound to the major version that corresponds with the .NET version. If this constraint is not added, when .NET Monitor releases a newer version that only works on a future version of .NET, image build failure will occur. This change is intended to mitigate that risk by applying the same range bound as the prior images have e.g. https://github.com/microsoft/Oryx/blob/main/images/runtime/dotnetcore/8.0/bookworm.Dockerfile#L9