### PR TITLE
Add log for primary/backup storage URL during build

### DIFF
--- a/src/BuildScriptGenerator/DefaultPlatformsInformationProvider.cs
+++ b/src/BuildScriptGenerator/DefaultPlatformsInformationProvider.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         {
             var platformInfos = new List<PlatformInfo>();
 
+            this.outputWriter.WriteLine($"Primary SDK Storage URL: {this.commonOptions.OryxSdkStorageBaseUrl}");
+            this.outputWriter.WriteLine($"Backup SDK Storage URL: {this.commonOptions.OryxSdkStorageBackupBaseUrl}");
+
             // Try detecting ALL platforms since in some scenarios this is required.
             // For example, in case of a multi-platform app like ASP.NET Core + NodeJs, we might need to dynamically
             // install both these platforms' sdks before actually using any of their commands. So even though a user


### PR DESCRIPTION
Adding logging to print the primary and backup storage URLs being used during the build process.

![image](https://github.com/user-attachments/assets/ac4bac45-e123-48d5-b616-11930e4f4c48)
