### PR TITLE
Search for checksum tag irrespective of case.

### DIFF
--- a/src/BuildScriptGenerator/ExternalSdkProvider.cs
+++ b/src/BuildScriptGenerator/ExternalSdkProvider.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         }
         catch (Exception ex)
         {
-          this.outputWriter.WriteLine($"Failed to get blob for platform {platformName}, blobName {blobName} from external provider. Exception : {ex}");
+          this.outputWriter.WriteLine($"Failed to get blob for platform {platformName}, blobName {blobName} from external provider. Exception : {ex.Message}");
           this.logger.LogError(ex, "Error requesting blob for platform {platformName} blobName {blobName} from external provider.", platformName, blobName);
           return false;
         }


### PR DESCRIPTION
This fixes the issue where the checksum tags for some of the older stacks starts with a 'c'. Made the search for checksum case insensitive.


![image](https://github.com/user-attachments/assets/25692b72-8143-4776-9867-a5936f2871b2)
