### PR TITLE
Add Corepack and Pre-install Yarn for Node.js 18, 20, and 22 Images

### DIFF
--- a/images/runtime/build_runtime_images.sh
+++ b/images/runtime/build_runtime_images.sh
@@ -40,7 +40,7 @@ docker build -f ./images/runtime/commonbase/Dockerfile -t oryx_run_base_$debian_
 
 case $stack_name in
     "dotnet") 
-        curl -SL --output "DotNetCoreAgent.$DotNetCoreAgent_version.zip" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/appinsights-agent/DotNetCoreAgent.$DotNetCoreAgent_version.zip"
+        curl -SL --output "DotNetCoreAgent.$DotNetCoreAgent_version.zip" "https://oryxsdksdev.blob.core.windows.net/appinsights-agent/DotNetCoreAgent.$DotNetCoreAgent_version.zip"
        case $stack_version in
             "6.0")
                 docker build -f ./images/runtime/dotnetcore/6.0/$debian_flavor.Dockerfile -t dotnet6_image_$debian_flavor --build-arg NET_CORE_APP_60_SHA=$NET_CORE_APP_60_SHA --build-arg ASPNET_CORE_APP_60_SHA=$ASPNET_CORE_APP_60_SHA --build-arg NET_CORE_APP_60=$NET_CORE_APP_60 --build-arg ASPNET_CORE_APP_60=$ASPNET_CORE_APP_60 --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
@@ -66,19 +66,19 @@ case $stack_name in
         docker build -f ./images/runtime/commonbase/nodeRuntimeBase.Dockerfile -t oryx_node_run_base_$debian_flavor --build-arg BASE_IMAGE="docker.io/library/oryx_run_base_$debian_flavor" .
        case $stack_version in
             "18")
-                curl -SL --output "nodejs-$debian_flavor-$node18Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/nodejs/nodejs-$debian_flavor-$node18Version.tar.gz"
+                curl -SL --output "nodejs-$debian_flavor-$node18Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/nodejs/nodejs-$debian_flavor-$node18Version.tar.gz"
                 docker build -f ./images/runtime/node/18/$debian_flavor.Dockerfile -t node18_$debian_flavor --build-arg NODE18_VERSION=$node18Version --build-arg BASE_IMAGE="docker.io/library/oryx_node_run_base_$debian_flavor" --build-arg NPM_VERSION=$NPM_VERSION --build-arg PM2_VERSION=$PM2_VERSION --build-arg NODE_APP_INSIGHTS_SDK_VERSION=$NODE_APP_INSIGHTS_SDK_VERSION --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
                 rm -f ./nodejs-$debian_flavor-$node18Version.tar.gz
             ;;
 
             "20")
-                curl -SL --output "nodejs-$debian_flavor-$node20Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/nodejs/nodejs-$debian_flavor-$node20Version.tar.gz"
+                curl -SL --output "nodejs-$debian_flavor-$node20Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/nodejs/nodejs-$debian_flavor-$node20Version.tar.gz"
                 docker build -f ./images/runtime/node/20/$debian_flavor.Dockerfile -t node20_$debian_flavor --build-arg NODE20_VERSION=$node20Version --build-arg BASE_IMAGE="docker.io/library/oryx_node_run_base_$debian_flavor" --build-arg NPM_VERSION=$NPM_VERSION --build-arg PM2_VERSION=$PM2_VERSION --build-arg NODE_APP_INSIGHTS_SDK_VERSION=$NODE_APP_INSIGHTS_SDK_VERSION --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
                 rm -f ./nodejs-$debian_flavor-$node20Version.tar.gz
             ;;
 
             "22")
-                curl -SL --output "nodejs-$debian_flavor-$node22Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/nodejs/nodejs-$debian_flavor-$node22Version.tar.gz"
+                curl -SL --output "nodejs-$debian_flavor-$node22Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/nodejs/nodejs-$debian_flavor-$node22Version.tar.gz"
                 docker build -f ./images/runtime/node/22/$debian_flavor.Dockerfile -t node22_$debian_flavor --build-arg NODE22_VERSION=$node22Version --build-arg BASE_IMAGE="docker.io/library/oryx_node_run_base_$debian_flavor" --build-arg NPM_VERSION=$NPM_VERSION --build-arg PM2_VERSION=$PM2_VERSION --build-arg NODE_APP_INSIGHTS_SDK_VERSION=$NODE_APP_INSIGHTS_SDK_VERSION --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
                 rm -f ./nodejs-$debian_flavor-$node22Version.tar.gz
             ;;
@@ -109,7 +109,7 @@ case $stack_name in
     "python")
         case $stack_version in
             "3.8")
-                curl -SL --output "python-$debian_flavor-$python38Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/python/python-$debian_flavor-$python38Version.tar.gz"
+                curl -SL --output "python-$debian_flavor-$python38Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/python/python-$debian_flavor-$python38Version.tar.gz"
                 docker build -f ./images/runtime/python/template.Dockerfile -t python38_image_$debian_flavor --build-arg PYTHON_FULL_VERSION=$python38Version --build-arg PYTHON_VERSION=3.8 --build-arg PYTHON_MAJOR_VERSION=3 --build-arg DEBIAN_FLAVOR=$debian_flavor --build-arg BASE_IMAGE="docker.io/library/oryx_run_base_$debian_flavor" --build-arg SDK_STORAGE_BASE_URL_VALUE=$SDK_STORAGE_BASE_URL_VALUE .
                 rm -f ./python-$debian_flavor-$python38Version.tar.gz
             ;;

--- a/images/runtime/build_runtime_images.sh
+++ b/images/runtime/build_runtime_images.sh
@@ -40,7 +40,7 @@ docker build -f ./images/runtime/commonbase/Dockerfile -t oryx_run_base_$debian_
 
 case $stack_name in
     "dotnet") 
-        curl -SL --output "DotNetCoreAgent.$DotNetCoreAgent_version.zip" "https://oryxsdksdev.blob.core.windows.net/appinsights-agent/DotNetCoreAgent.$DotNetCoreAgent_version.zip"
+        curl -SL --output "DotNetCoreAgent.$DotNetCoreAgent_version.zip" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/appinsights-agent/DotNetCoreAgent.$DotNetCoreAgent_version.zip"
        case $stack_version in
             "6.0")
                 docker build -f ./images/runtime/dotnetcore/6.0/$debian_flavor.Dockerfile -t dotnet6_image_$debian_flavor --build-arg NET_CORE_APP_60_SHA=$NET_CORE_APP_60_SHA --build-arg ASPNET_CORE_APP_60_SHA=$ASPNET_CORE_APP_60_SHA --build-arg NET_CORE_APP_60=$NET_CORE_APP_60 --build-arg ASPNET_CORE_APP_60=$ASPNET_CORE_APP_60 --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
@@ -66,19 +66,19 @@ case $stack_name in
         docker build -f ./images/runtime/commonbase/nodeRuntimeBase.Dockerfile -t oryx_node_run_base_$debian_flavor --build-arg BASE_IMAGE="docker.io/library/oryx_run_base_$debian_flavor" .
        case $stack_version in
             "18")
-                curl -SL --output "nodejs-$debian_flavor-$node18Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/nodejs/nodejs-$debian_flavor-$node18Version.tar.gz"
+                curl -SL --output "nodejs-$debian_flavor-$node18Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/nodejs/nodejs-$debian_flavor-$node18Version.tar.gz"
                 docker build -f ./images/runtime/node/18/$debian_flavor.Dockerfile -t node18_$debian_flavor --build-arg NODE18_VERSION=$node18Version --build-arg BASE_IMAGE="docker.io/library/oryx_node_run_base_$debian_flavor" --build-arg NPM_VERSION=$NPM_VERSION --build-arg PM2_VERSION=$PM2_VERSION --build-arg NODE_APP_INSIGHTS_SDK_VERSION=$NODE_APP_INSIGHTS_SDK_VERSION --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
                 rm -f ./nodejs-$debian_flavor-$node18Version.tar.gz
             ;;
 
             "20")
-                curl -SL --output "nodejs-$debian_flavor-$node20Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/nodejs/nodejs-$debian_flavor-$node20Version.tar.gz"
+                curl -SL --output "nodejs-$debian_flavor-$node20Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/nodejs/nodejs-$debian_flavor-$node20Version.tar.gz"
                 docker build -f ./images/runtime/node/20/$debian_flavor.Dockerfile -t node20_$debian_flavor --build-arg NODE20_VERSION=$node20Version --build-arg BASE_IMAGE="docker.io/library/oryx_node_run_base_$debian_flavor" --build-arg NPM_VERSION=$NPM_VERSION --build-arg PM2_VERSION=$PM2_VERSION --build-arg NODE_APP_INSIGHTS_SDK_VERSION=$NODE_APP_INSIGHTS_SDK_VERSION --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
                 rm -f ./nodejs-$debian_flavor-$node20Version.tar.gz
             ;;
 
             "22")
-                curl -SL --output "nodejs-$debian_flavor-$node22Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/nodejs/nodejs-$debian_flavor-$node22Version.tar.gz"
+                curl -SL --output "nodejs-$debian_flavor-$node22Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/nodejs/nodejs-$debian_flavor-$node22Version.tar.gz"
                 docker build -f ./images/runtime/node/22/$debian_flavor.Dockerfile -t node22_$debian_flavor --build-arg NODE22_VERSION=$node22Version --build-arg BASE_IMAGE="docker.io/library/oryx_node_run_base_$debian_flavor" --build-arg NPM_VERSION=$NPM_VERSION --build-arg PM2_VERSION=$PM2_VERSION --build-arg NODE_APP_INSIGHTS_SDK_VERSION=$NODE_APP_INSIGHTS_SDK_VERSION --build-arg USER_DOTNET_AI_VERSION=$USER_DOTNET_AI_VERSION --build-arg AI_CONNECTION_STRING=$AI_CONNECTION_STRING .
                 rm -f ./nodejs-$debian_flavor-$node22Version.tar.gz
             ;;
@@ -109,7 +109,7 @@ case $stack_name in
     "python")
         case $stack_version in
             "3.8")
-                curl -SL --output "python-$debian_flavor-$python38Version.tar.gz" "https://oryxsdksdev.blob.core.windows.net/python/python-$debian_flavor-$python38Version.tar.gz"
+                curl -SL --output "python-$debian_flavor-$python38Version.tar.gz" "https://oryxsdksdev-h4a7b3fscnhggycc.b02.azurefd.net/python/python-$debian_flavor-$python38Version.tar.gz"
                 docker build -f ./images/runtime/python/template.Dockerfile -t python38_image_$debian_flavor --build-arg PYTHON_FULL_VERSION=$python38Version --build-arg PYTHON_VERSION=3.8 --build-arg PYTHON_MAJOR_VERSION=3 --build-arg DEBIAN_FLAVOR=$debian_flavor --build-arg BASE_IMAGE="docker.io/library/oryx_run_base_$debian_flavor" --build-arg SDK_STORAGE_BASE_URL_VALUE=$SDK_STORAGE_BASE_URL_VALUE .
                 rm -f ./python-$debian_flavor-$python38Version.tar.gz
             ;;

--- a/images/runtime/commonbase/nodeRuntimeBase.Dockerfile
+++ b/images/runtime/commonbase/nodeRuntimeBase.Dockerfile
@@ -14,14 +14,3 @@ RUN apt-get update \
 # Gpg keys listed at https://github.com/nodejs/node
 RUN ${IMAGES_DIR}/receiveGpgKeys.sh \
     6A010C5166006599AA17F08146C2130DFD2497F5
-
-ARG YARN_VERSION
-ENV YARN_VERSION ${YARN_VERSION}
-
-COPY images/yarn-v${YARN_VERSION}.tar.gz .
-
-RUN mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz

--- a/images/runtime/node/18/bullseye.Dockerfile
+++ b/images/runtime/node/18/bullseye.Dockerfile
@@ -51,6 +51,10 @@ RUN npm install -g npm@${NPM_VERSION}
 RUN PM2_VERSION=${PM2_VERSION} NODE_APP_INSIGHTS_SDK_VERSION=${NODE_APP_INSIGHTS_SDK_VERSION} ${IMAGES_DIR}/runtime/node/installDependencies.sh 
 RUN rm -rf /tmp/oryx
 
+ARG YARN_VERSION="1.22.15"
+# Enable Corepack to manage Yarn and other package managers, Also Pre-cache and activate the specified Yarn version
+RUN corepack enable && corepack prepare yarn@${YARN_VERSION} --activate
+
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_CONNECTION_STRING
 ENV ORYX_AI_CONNECTION_STRING=${AI_CONNECTION_STRING}

--- a/images/runtime/node/20/bookworm.Dockerfile
+++ b/images/runtime/node/20/bookworm.Dockerfile
@@ -53,6 +53,10 @@ RUN npm install -g npm@${NPM_VERSION}
 RUN PM2_VERSION=${PM2_VERSION} NODE_APP_INSIGHTS_SDK_VERSION=${NODE_APP_INSIGHTS_SDK_VERSION} ${IMAGES_DIR}/runtime/node/installDependencies.sh
 RUN rm -rf /tmp/oryx
 
+ARG YARN_VERSION="1.22.15"
+# Enable Corepack to manage Yarn and other package managers, Also Pre-cache and activate the specified Yarn version
+RUN corepack enable && corepack prepare yarn@${YARN_VERSION} --activate
+
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_CONNECTION_STRING
 ENV ORYX_AI_CONNECTION_STRING=${AI_CONNECTION_STRING}

--- a/images/runtime/node/20/bullseye.Dockerfile
+++ b/images/runtime/node/20/bullseye.Dockerfile
@@ -52,6 +52,10 @@ RUN npm install -g npm@${NPM_VERSION}
 RUN NPM_VERSION=${NPM_VERSION} PM2_VERSION=${PM2_VERSION} NODE_APP_INSIGHTS_SDK_VERSION=${NODE_APP_INSIGHTS_SDK_VERSION} ${IMAGES_DIR}/runtime/node/installDependencies.sh 
 RUN rm -rf /tmp/oryx
 
+ARG YARN_VERSION="1.22.15"
+# Enable Corepack to manage Yarn and other package managers, Also Pre-cache and activate the specified Yarn version
+RUN corepack enable && corepack prepare yarn@${YARN_VERSION} --activate
+
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_CONNECTION_STRING
 ENV ORYX_AI_CONNECTION_STRING=${AI_CONNECTION_STRING}

--- a/images/runtime/node/22/bookworm.Dockerfile
+++ b/images/runtime/node/22/bookworm.Dockerfile
@@ -53,6 +53,11 @@ RUN npm install -g npm@${NPM_VERSION}
 RUN PM2_VERSION=${PM2_VERSION} NODE_APP_INSIGHTS_SDK_VERSION=${NODE_APP_INSIGHTS_SDK_VERSION} ${IMAGES_DIR}/runtime/node/installDependencies.sh
 RUN rm -rf /tmp/oryx
 
+#stable is an alias for the latest stable release.
+ARG YARN_VERSION="stable"
+# Enable Corepack to manage Yarn and other package managers, Also Pre-cache and activate the specified Yarn version
+RUN corepack enable && corepack prepare yarn@${YARN_VERSION} --activate
+
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_CONNECTION_STRING
 ENV ORYX_AI_CONNECTION_STRING=${AI_CONNECTION_STRING}

--- a/images/runtime/node/22/bullseye.Dockerfile
+++ b/images/runtime/node/22/bullseye.Dockerfile
@@ -52,6 +52,11 @@ RUN npm install -g npm@${NPM_VERSION}
 RUN PM2_VERSION=${PM2_VERSION} NODE_APP_INSIGHTS_SDK_VERSION=${NODE_APP_INSIGHTS_SDK_VERSION} ${IMAGES_DIR}/runtime/node/installDependencies.sh 
 RUN rm -rf /tmp/oryx
 
+#stable is an alias for the latest stable release.
+ARG YARN_VERSION="stable"
+# Enable Corepack to manage Yarn and other package managers, Also Pre-cache and activate the specified Yarn version
+RUN corepack enable && corepack prepare yarn@${YARN_VERSION} --activate
+
 # Bake Application Insights key from pipeline variable into final image
 ARG AI_CONNECTION_STRING
 ENV ORYX_AI_CONNECTION_STRING=${AI_CONNECTION_STRING}


### PR DESCRIPTION
Corepack has been installed, and Yarn version 1.22.15 has been pre-installed for Node.js 18 and 20 images using Corepack. For node 22 latest stable yarn version is being used.

If a customer specifies a different Yarn version in the packageManager field of their package.json, Corepack will automatically install and use that specified version.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
