### PR TITLE
Appending node modules bin to suffix instead of prefix in PATH

### DIFF
--- a/src/startupscriptgenerator/src/node/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/node/scriptgenerator.go
@@ -119,7 +119,7 @@ func (gen *NodeStartupScriptGenerator) GenerateEntrypointScript() string {
 		scriptBuilder.WriteString("export NODE_PATH=\"" + targetNodeModulesDir + "\":$NODE_PATH\n")
 		// NPM adds the current directory's node_modules/.bin folder to PATH before it runs, so commands in
 		// "npm start" can files there. Since we move node_modules, we have to add it to the path ourselves.
-		scriptBuilder.WriteString("export PATH=" + targetNodeModulesDir + "/.bin:$PATH\n")
+		scriptBuilder.WriteString("export PATH=" + "$PATH:" + targetNodeModulesDir + "/.bin\n")
 		// To avoid having older versions of packages available, we rename existing node_modules folder.
 		// We move the directory/link first to prevent node from start using it
 		scriptBuilder.WriteString("if [ -d node_modules ]; then\n")


### PR DESCRIPTION
## Context
For non node modules extraction based deployment, there was no updating of PATH env variable. Cx who had `yarn run start` command (taking example), their app will start since `yarn` used was that of which came with blessed image (even though the one in .bin was broken due to no preservation of symlink). 
Going ahead with node modules extraction based deployment involving customer building code locally, the PATH variable updated in this workflow will set preference to startup command script located at `.bin`, which is causing site failures (for customers who are not preserving symlinks in `.bin`), especially for those having `yarn` as startup. 
### **Screenshot to help understand better:**
<img width="939" height="847" alt="image" src="https://github.com/user-attachments/assets/8afc83de-4366-4da4-be5b-240becee0149" />

## Validation: 

<img width="1145" height="1106" alt="image" src="https://github.com/user-attachments/assets/89fc5255-d710-471a-a16d-47331433c79a" />

### Start:

<img width="478" height="521" alt="image" src="https://github.com/user-attachments/assets/cd84cc42-d7df-482a-85cf-7af779d72234" />



<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
