### PR TITLE
Added dotnet-monitor version for dotnet 10

### DIFF
--- a/images/runtime/dotnetcore/10.0/noble.Dockerfile
+++ b/images/runtime/dotnetcore/10.0/noble.Dockerfile
@@ -6,7 +6,7 @@ RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-trace
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-dump
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-counters
 RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-gcdump
-RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 10.*
+RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 10.0.0-rc.1.25460.1
 
 # Startup script generator
 FROM mcr.microsoft.com/oss/go/microsoft/golang:1.25.1-bookworm as startupCmdGen


### PR DESCRIPTION
`RUN dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 10.0.0-rc.1.25460.1`

https://github.com/dotnet/dotnet-monitor/releases

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
