### PR TITLE
Fix UV support in Oryx

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -49,7 +49,7 @@ fi
         echo "Installing uv..."
         InstallUv="python -m pip install uv"
         printf %s " , $InstallUv" >> "$COMMAND_MANIFEST_FILE"
-        python -m pip install uv
+        $python -m pip install uv
         CreateVenvCommand="uv venv --link-mode=copy --system-site-packages $VIRTUALENVIRONMENTNAME"
     else
         if [ -e "$REQUIREMENTS_TXT_FILE" ]; then
@@ -76,9 +76,9 @@ fi
     then
         set +e
         echo "Running pip install..."
-        InstallCommand="python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE | ts $TS_FMT"
+        InstallCommand="$python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE | ts $TS_FMT"
         printf %s " , $InstallCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
+        output=$( ( $python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
         pipInstallExitCode=${PIPESTATUS[0]}
 
         set -e
@@ -145,7 +145,7 @@ fi
     fi
 
     # For virtual environment, we use the actual 'python' alias that as setup by the venv,
-    python_bin=python
+    python_bin=$python
 {{ else }}
     moreInformation="More information: https://aka.ms/troubleshoot-python"
     if [ -e "$REQUIREMENTS_TXT_FILE" ]
@@ -201,7 +201,7 @@ fi
             echo "Installing uv..."
             InstallUv="python -m pip install uv"
             printf %s " , $InstallUv" >> "$COMMAND_MANIFEST_FILE"
-            python -m pip install uv
+            $python -m pip install uv
             
             set +e
             SITE_PACKAGES_PATH="{{ PackagesDirectory }}"


### PR DESCRIPTION
The build was relying on `python` executable to be always available but in the new images, `python3` is available. This was already being handled with variables in the script but was missed in some spots. This PR fixes this issue.

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.


