### PR TITLE
Update the `COPY` command to fix how Azure Linux CA certificate bundle is copied

### DIFF
--- a/images/runtime/commonbase/Dockerfile
+++ b/images/runtime/commonbase/Dockerfile
@@ -39,7 +39,7 @@ RUN  rm -rf /var/lib/apt/lists/*
 # Copy Azure linux certs to a temporary location
 RUN mkdir -p /tmp/azurelinux-ca-certs && \
 	chmod 755 /tmp/azurelinux-ca-certs;
-COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem* /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
 
 COPY images/runtime/scripts/install-azurelinux-certs.sh /usr/local/bin/install-azurelinux-certs.sh
 

--- a/images/runtime/dotnetcore/10.0/noble.Dockerfile
+++ b/images/runtime/dotnetcore/10.0/noble.Dockerfile
@@ -104,7 +104,7 @@ RUN set -ex \
 # Copy Azure linux certs to a temporary location
 RUN mkdir -p /tmp/azurelinux-ca-certs && \
 	chmod 755 /tmp/azurelinux-ca-certs;
-COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem* /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
 
 COPY images/runtime/scripts/install-azurelinux-certs.sh /usr/local/bin/install-azurelinux-certs.sh
 

--- a/images/runtime/dotnetcore/8.0/bookworm.Dockerfile
+++ b/images/runtime/dotnetcore/8.0/bookworm.Dockerfile
@@ -98,7 +98,7 @@ RUN set -ex \
 # Copy Azure linux certs to a temporary location
 RUN mkdir -p /tmp/azurelinux-ca-certs && \
 	chmod 755 /tmp/azurelinux-ca-certs;
-COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem* /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
 
 COPY images/runtime/scripts/install-azurelinux-certs.sh /usr/local/bin/install-azurelinux-certs.sh
 

--- a/images/runtime/dotnetcore/8.0/bullseye.Dockerfile
+++ b/images/runtime/dotnetcore/8.0/bullseye.Dockerfile
@@ -98,7 +98,7 @@ RUN set -ex \
 # Copy Azure linux certs to a temporary location
 RUN mkdir -p /tmp/azurelinux-ca-certs && \
 	chmod 755 /tmp/azurelinux-ca-certs;
-COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem* /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
 
 COPY images/runtime/scripts/install-azurelinux-certs.sh /usr/local/bin/install-azurelinux-certs.sh
 

--- a/images/runtime/dotnetcore/9.0/bookworm.Dockerfile
+++ b/images/runtime/dotnetcore/9.0/bookworm.Dockerfile
@@ -100,7 +100,7 @@ RUN set -ex \
 # Copy Azure linux certs to a temporary location
 RUN mkdir -p /tmp/azurelinux-ca-certs && \
 	chmod 755 /tmp/azurelinux-ca-certs;
-COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem* /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY --from=azurelinux-core /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
 
 COPY images/runtime/scripts/install-azurelinux-certs.sh /usr/local/bin/install-azurelinux-certs.sh
 


### PR DESCRIPTION
This PR fixes how the Azure Linux CA certificate bundle is copied into the image. The change ensures that only the intended certificate file is copied, rather than using a wildcard (*) that could match multiple files.

The base image always includes a minimal CA certs package; this won't break the build regardless of whether the broader ca-certificates package installation step (which is conditional in the Dockerfile) is executed.