### PR TITLE
Fixing Setup.py Based Installation

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -85,9 +85,9 @@ fi
         printf %s " , $InstallSetuptoolsPipCommand" >> "$COMMAND_MANIFEST_FILE"
         pip install setuptools
         echo "Running python setup.py install..."
-        InstallCommand="$python setup.py install --user| ts $TS_FMT"
+        InstallCommand="pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary | ts $TS_FMT"
         printf %s " , $InstallCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( $python setup.py install --user| ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
+        output=$( ( pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
         pythonBuildExitCode=${PIPESTATUS[0]}
         set -e
         echo "${output}"
@@ -158,10 +158,10 @@ fi
         InstallSetuptoolsPipCommand="pip install setuptools"
         printf %s " , $InstallSetuptoolsPipCommand" >> "$COMMAND_MANIFEST_FILE"
         pip install setuptools
-        echo "Running python setup.py install..."
-        InstallCommand="$python setup.py install --user| ts $TS_FMT"
+        echo "Running pip install..."
+        InstallCommand="$python -m pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary --target="{{ PackagesDirectory }}" {{ PipUpgradeFlag }} | ts $TS_FMT"
         printf %s " , $InstallCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( $python setup.py install --user| ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
+        output=$( ( $python -m pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary --target="{{ PackagesDirectory }}" {{ PipUpgradeFlag }} | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
         pythonBuildExitCode=${PIPESTATUS[0]}
         set -e
         echo "${output}"


### PR DESCRIPTION
This PR fix the workflow of installing packages based on setup.py file. 
1. Installs setuptools package if setup.py is detected (common package to be in setup.py file)
2. Updated installation command 

Testing:
- Manual Testing with a sample setup.py based project

Installation looks correct: 
<img width="1659" height="861" alt="image" src="https://github.com/user-attachments/assets/571da435-50b1-4a9f-8508-fc933a19965b" />

Runtime looks to be loading the packages correctly:
<img width="1528" height="405" alt="image" src="https://github.com/user-attachments/assets/ce55e194-c753-4732-91c4-d8d7fcac8a95" />

