### PR TITLE
Zipped Antenv Fixes and Improved Bashrc

### DIFF
--- a/src/startupscriptgenerator/src/python/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator.go
@@ -221,8 +221,8 @@ func (gen *PythonStartupScriptGenerator) getPackageSetupCommand() string {
 			scriptBuilder.WriteString("$extractionCommand\n")
 			venvSubScript := gen.getHandleVenvPresentInRootScript(virtualEnvDir, virtualEnvironmentName)
 			scriptBuilder.WriteString(venvSubScript)
-			venvSubScript := gen.getVenvHandlingScript(virtualEnvironmentName, virtualEnvDir)
-			scriptBuilder.WriteString(venvSubScript)
+			venvHandlingScript := gen.getVenvHandlingScript(virtualEnvironmentName, virtualEnvDir)
+			scriptBuilder.WriteString(venvHandlingScript)
 		}
 	}
 


### PR DESCRIPTION
This PR fixes some bashrc experience where we do not show error if antenv is not available for sourcing. 
Moreover, this PR brings major changes in startup script if venv is present in project directory in zipped format. 

If antenv is already present in the wwwroot, it shifts it to _del_antenv. _del_antenv is safe to delete. Reason of this shift is to have a antenv symlink there instead which will be pointing to /antenv, where the extracted antenv will be present. 

<img width="1975" height="764" alt="image" src="https://github.com/user-attachments/assets/da403229-1285-400c-9f4f-95d8817b6f13" />

Updated Startup Script (for zipped antenv scenario)
```
#!/bin/sh

echo 'export APP_PATH="/home/site/wwwroot"' >> ~/.bashrc
echo 'cd $APP_PATH' >> ~/.bashrc

# Enter the source directory to make sure the script runs where the user expects
cd /home/site/wwwroot

export APP_PATH="/home/site/wwwroot"
if [ -z "$HOST" ]; then
                export HOST=0.0.0.0
fi

if [ -z "$PORT" ]; then
                export PORT=80
fi

export PATH="/opt/python/3.13.5/bin:${PATH}"
echo 'export VIRTUALENVIRONMENT_PATH="/antenv"' >> ~/.bashrc
echo '. /antenv/bin/activate' >> ~/.bashrc
echo Found virtual environment .tar.gz archive.
extractionCommand="tar -xzf antenv.tar.gz -C /antenv"
echo Removing existing virtual environment directory '/antenv'...
rm -fr /antenv
mkdir -p /antenv
echo Extracting to directory '/antenv'...
$extractionCommand
if [ -d antenv ]; then
    mv -f antenv _del_antenv || true
fi

if [ -d /antenv ]; then
    ln -sfn /antenv ./antenv
fi

echo "Done."
PYTHON_VERSION=$(python -c "import sys; print(str(sys.version_info.major) + '.' + str(sys.version_info.minor))")
echo Using packages from virtual environment 'antenv' located at '/antenv'.
export PYTHONPATH=$PYTHONPATH:"/antenv/lib/python$PYTHON_VERSION/site-packages"
echo "Updated PYTHONPATH to '$PYTHONPATH'"
. /antenv/bin/activate
GUNICORN_CMD_ARGS="--timeout 600 --access-logfile '-' --error-logfile '-' -c /opt/startup/gunicorn.conf.py --workers=5 --chdir=/home/site/wwwroot" gunicorn web.wsgi
```


<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
