### PR TITLE
Update poetry flag | Unpin poetry version

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -125,6 +125,7 @@ fi
 
             set +e
             echo "Running pip install poetry..."
+            START_TIME=$SECONDS
             InstallPipCommand="pip install poetry"
             printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
             pip install poetry
@@ -154,6 +155,8 @@ fi
                 fi
             fi
 
+            ELAPSED_TIME=$(($SECONDS - $START_TIME))
+            echo "Done in $ELAPSED_TIME sec(s)."
             set -e
             echo "${output}"
         fi
@@ -241,6 +244,7 @@ fi
 
             set +e
             echo "Running pip install poetry..."
+            START_TIME=$SECONDS
             InstallPipCommand="pip install poetry"
             printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
             pip install poetry
@@ -270,6 +274,8 @@ fi
                 fi
             fi
 
+            ELAPSED_TIME=$(($SECONDS - $START_TIME))
+            echo "Done in $ELAPSED_TIME sec(s)."
             set -e
             echo "${output}"
         fi


### PR DESCRIPTION
This PR unpins the poetry version

- Latest poetry versions have deprecated the --no-dev flag, which has been replaced with --only main
- When installation fails using the latest poetry version with the --only main flag, the system automatically falls back to poetry version 1.8.5 with the legacy --no-dev flag

Testing:
Built the GitHub Actions image

**Testing --only main:** Deployed a Python application containing pyproject.toml. The system automatically installed the latest poetry version and successfully used the --only main flag.

<img width="1160" height="206" alt="image" src="https://github.com/user-attachments/assets/7554530a-ccb5-4c8d-ab80-f7be9273d2d4" />

---------------
<img width="849" height="427" alt="image" src="https://github.com/user-attachments/assets/23fa4e67-95e8-4141-89f8-5d149e3151bd" />

Deployment completed successfully

**Testing --no-dev fallback:** Intentionally provided an invalid flag and built the GitHub Actions image. During Python app deployment, the system detected the failure and automatically reverted to poetry 1.8.5 with the --no-dev option.

<img width="1134" height="211" alt="image" src="https://github.com/user-attachments/assets/93dfb58a-b789-4914-891b-8c568a6acaaa" />

The initial poetry installation failed due to the invalid flag (poetry install --invalid-main-flag), triggering the fallback mechanism

<img width="1628" height="170" alt="image" src="https://github.com/user-attachments/assets/eae0039e-7645-46b4-9058-67d56fcbb0b2" />

<img width="958" height="432" alt="image" src="https://github.com/user-attachments/assets/e97cc212-bad0-4a07-8f3f-92122e9f829e" />

The deployment is successful


--------------------------------------------------------------------------------------------------------------------------------------------

**Comparing --no-dev --without dev --only main flags:**
Created a python project with pyproject.toml with multiple dependency groups, the output of --only main and --no-dev are same - both of them just downloaded production dependencies, whereas --without dev downloaded everything except for dev dependencies

<img width="1219" height="561" alt="image" src="https://github.com/user-attachments/assets/2853e8ba-f273-4dfe-abc3-bfab5977fe8f" />


In older Poetry versions, the simple dependencies/dev-dependencies model made --no-dev equivalent to installing only production dependencies. However, with modern Poetry's flexible dependency groups (which can include lint, docs, test, etc.), --without dev installs everything except the dev group but still includes other optional groups, while --only main more accurately replicates the original --no-dev behavior by installing only the core production dependencies.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
