### PR TITLE
Fixing Python Package Installation

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -169,7 +169,7 @@ fi
     fi
 
     # For virtual environment, we use the actual 'python' alias that as setup by the venv,
-    python_bin=$python
+    python_bin=python
 {{ else }}
     moreInformation="More information: https://aka.ms/troubleshoot-python"
     if [ -e "$REQUIREMENTS_TXT_FILE" ]


### PR DESCRIPTION
This PR fixes the python package installation, which got changed in recent PRs.

With $python, packages are installed in local instead of venv.

Without fix:
<img width="763" height="49" alt="image" src="https://github.com/user-attachments/assets/626619ef-cd6e-43a5-9829-128b1ca03eb4" />

With fix:
<img width="1558" height="156" alt="image" src="https://github.com/user-attachments/assets/78f68df4-f519-4316-a74e-737b674f244a" />
