### PR TITLE
Ignore PROJECT variable for non .NET project files

### DIFF
--- a/src/Detector/DotNetCore/ProjectFileProviders/ExplicitProjectFileProvider.cs
+++ b/src/Detector/DotNetCore/ProjectFileProviders/ExplicitProjectFileProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Oryx.Detector.DotNetCore
             var projectFile = Path.Combine(context.SourceRepo.RootPath, projectFileWithRelativePath);
             if (context.SourceRepo.FileExists(projectFile) && this.IsValidDotNetProjectFile(projectFileWithRelativePath))
             {
-                this.logger.LogDebug($"Using the given .NET Core project file to build.");
+                this.logger.LogInformation($"Using the given .NET Core project file to build: '{projectFileWithRelativePath}'");
             }
             else
             {


### PR DESCRIPTION
In .NET detection, PROJECT environment variable is used to specify which project file to build, but this environment variable is very generic and may not contain valid .NET project files.

Now only honor PROJECT when it specifies valid .csproj or .fsproj files, otherwise ignore and fall back to auto-detection.

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
