### PR TITLE
Include pyproject.toml in dependency file not found message

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -2,7 +2,7 @@ set -e
 # TODO: refactor redundant code. Work-item: 1476457
 
 declare -r TS_FMT='[%T%z] '
-declare -r REQS_NOT_FOUND_MSG='Could not find setup.py, requirements.txt, or pyproject.toml; Not running pip install. More information: https://aka.ms/requirements-not-found'
+declare -r REQS_NOT_FOUND_MSG='Could not find requirements.txt, pyproject.toml, or setup.py; Not installing dependencies. More information: https://aka.ms/requirements-not-found'
 echo "Python Version: $python"
 PIP_CACHE_DIR=/usr/local/share/pip-cache
 


### PR DESCRIPTION
Updated error message to include pyproject.toml alongside setup.py and requirements.txt when dependency files are not found.

- [x] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [x] Proper license headers are included in each file.
