### PR TITLE
Install uv and poetry in Python SDKs

### DIFF
--- a/platforms/python/prereqs/build.sh
+++ b/platforms/python/prereqs/build.sh
@@ -110,6 +110,15 @@ then
         --disable-pip-version-check \
         --no-cache-dir \
         --no-warn-script-location
+
+    # Install uv and poetry
+    echo "Installing uv and poetry..."
+    /opt/python/$PYTHON_VERSION/bin/python3 -m pip install uv poetry \
+        --disable-pip-version-check \
+        --no-cache-dir \
+        --no-warn-script-location
+    echo "uv and poetry installed successfully"
+
     rm -rf /configure* /config.* /*.txt /*.md /*.rst /*.toml /*.m4 /tmpFiles
     rm -rf /LICENSE /install-sh /Makefile* /pyconfig* /python.tar* /python-* /libpython3.* /setup.py
     rm -rf /Python /PCbuild /Grammar /python /Objects /Parser /Misc /Tools /Programs /Modules /Include /Mac /Doc /PC /Lib 
@@ -128,6 +137,16 @@ else
         --no-cache-dir \
         --no-warn-script-location \
         pip==$PIP_VERSION
+    
+    # Install uv and poetry
+    echo "Installing uv and poetry..."
+    LD_LIBRARY_PATH=/usr/src/python \
+    /usr/src/python/python -m pip install uv poetry \
+        --prefix $INSTALLATION_PREFIX \
+        --disable-pip-version-check \
+        --no-cache-dir \
+        --no-warn-script-location
+    echo "uv and poetry installed successfully"
 fi
 
 # Currently only for version '2' of Python, the alias 'python' exists in the 'bin'


### PR DESCRIPTION
This PR adds support for installing both `uv` and `poetry` in the SDK

Tested this by building SDK locally 
Old SDK:
<img width="1448" height="226" alt="image" src="https://github.com/user-attachments/assets/37f24a6a-0ea0-4e96-8d15-3ef8520d54e1" />
Poetry and uv are not present

After this change:
<img width="1437" height="345" alt="image" src="https://github.com/user-attachments/assets/298fa41a-1147-4638-b631-9fcd63d36569" />
poetry and uv are present

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
