### PR TITLE
Implement automatic fallback from zstd to gzip

### DIFF
--- a/src/BuildScriptGenerator/BaseBashBuildScript.sh.tpl
+++ b/src/BuildScriptGenerator/BaseBashBuildScript.sh.tpl
@@ -176,7 +176,6 @@ then
 			else
 				echo "WARNING: Direct compression with zstd failed: $output, exit code: $compressionExitCode"
 				echo "Falling back to gzip compression."
-				BASE_START_TIME=$SECONDS
 			fi
 		fi
 
@@ -184,6 +183,7 @@ then
 			if [ -f "$DESTINATION_DIR/output.tar.zst" ]; then
 				rm -f "$DESTINATION_DIR/output.tar.zst" 2>/dev/null || true
 			fi
+			BASE_START_TIME=$SECONDS
 			echo "Using gzip for compression"
 			tar -zcf "$DESTINATION_DIR/output.tar.gz" $excludedDirectories .
 			ELAPSED_TIME=$(($SECONDS - $BASE_START_TIME))
@@ -297,10 +297,10 @@ then
 			if [ -f "$DESTINATION_DIR/output.tar.zst" ]; then
 				rm -f "$DESTINATION_DIR/output.tar.zst" 2>/dev/null || true
 			fi
+			BASE_START_TIME=$SECONDS
 			echo "Using gzip for compression"
-			GZIP_START_TIME=$SECONDS
 			tar -zcf "$DESTINATION_DIR/output.tar.gz" .
-			ELAPSED_TIME=$(($SECONDS - $GZIP_START_TIME))
+			ELAPSED_TIME=$(($SECONDS - $BASE_START_TIME))
 			echo "Copied the compressed output to '$DESTINATION_DIR'"
 			echo "Compression with gzip done in $ELAPSED_TIME sec(s)."
 		fi


### PR DESCRIPTION
This PR adds error handling and automatic fallback mechanism for tar compression in oryx build. When zstd compression fails, the build will now automatically fall back to gzip compression instead of failing completely.

testing:
Created a Kudu Image which doesn't have zstd installed to trigger compression failure
<img width="731" height="250" alt="image" src="https://github.com/user-attachments/assets/75c275e1-8e54-4767-9f9a-09db8bdd636c" />
 compression with zstd failed, it switched to gzip and compression is successful with gzip

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
