### PR TITLE
Removing link mode copy flag from uv

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -53,7 +53,7 @@ install_via_uv() {
     
     # Build the command
     # Note: uv uses its own cache mechanism, not pip's cache-dir
-    local base_cmd="uv pip install --link-mode=copy"
+    local base_cmd="uv pip install"
     
     # Add find-links if PYTHON_PRELOADED_WHEELS_DIR is set
     if [ -n "$PYTHON_PRELOADED_WHEELS_DIR" ]; then


### PR DESCRIPTION
This PR removes the --link-mode copy flag from uv pip install.