### PR TITLE
Implement GetFileSize in MemorySourceRepo test classes

### DIFF
--- a/tests/BuildScriptGenerator.Tests/MemorySourceRepo.cs
+++ b/tests/BuildScriptGenerator.Tests/MemorySourceRepo.cs
@@ -57,6 +57,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests
             return content.Split(new[] { '\r', '\n' });
         }
 
+        public long? GetFileSize(params string[] paths)
+        {
+            var path = Path.Combine(paths);
+            if (_pathsToFiles.TryGetValue(path, out var content))
+            {
+                return content?.Length;
+            }
+            return null;
+        }
+
         public string GetGitCommitId() => null;
     }
 }

--- a/tests/Detector.Tests/MemorySourceRepo.cs
+++ b/tests/Detector.Tests/MemorySourceRepo.cs
@@ -69,6 +69,16 @@ namespace Microsoft.Oryx.Detector.Tests
             return content.Split(new[] { '\r', '\n' });
         }
 
+        public long? GetFileSize(params string[] paths)
+        {
+            var path = Path.Combine(paths);
+            if (pathsToFiles.TryGetValue(path, out var content))
+            {
+                return content?.Length;
+            }
+            return null;
+        }
+
         public string GetGitCommitId() => null;
     }
 }


### PR DESCRIPTION
Add missing GetFileSize method to MemorySourceRepo test mocks to satisfy ISourceRepo interface requirement.

This PR [https://github.com/microsoft/Oryx/pull/2751](https://github.com/microsoft/Oryx/pull/2751) adds GetFileSize method to 
ISourceRepo, this is causing failures as this method isn't present in other ISourceRepo interface requirement.

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
