### PR TITLE
Fix bash syntax error caused by empty else block

### DIFF
--- a/src/BuildScriptGenerator/BaseBashBuildScript.sh.tpl
+++ b/src/BuildScriptGenerator/BaseBashBuildScript.sh.tpl
@@ -191,6 +191,7 @@ then
 			echo "Direct compression with gzip done in $ELAPSED_TIME sec(s)."
 		fi
 	else
+		echo "Using standard output preparation..."
 		{{ ## When compressing destination directory is chosen, we want to copy the source content to a temporary 
 		destination directory first, compress the content there and then copy that content to the final destination 
 		directory ## }}


### PR DESCRIPTION
This PR adds log statement to prevent empty else block when template conditions evaluate to false, which causes bash syntax error.

Without this change:
In dotnet deployments, all statements were evaluated to false and caused syntax error and Oryx build is failing
<img width="1517" height="76" alt="image" src="https://github.com/user-attachments/assets/78c80ec1-c85e-4b89-8b99-4bd214dcb5d8" />

<img width="822" height="117" alt="image" src="https://github.com/user-attachments/assets/8f0dccd0-0237-4d0a-8a36-4d5092893b6f" />

With this change:
<img width="562" height="101" alt="image" src="https://github.com/user-attachments/assets/fdd1a528-9d2a-4494-a472-a9bdde9e8119" />


- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
