### PR TITLE
Checking for Activate Script inside bin of venv for Activation

### DIFF
--- a/src/startupscriptgenerator/src/python/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator.go
@@ -209,9 +209,9 @@ func (gen *PythonStartupScriptGenerator) getPackageSetupCommand() string {
 				scriptBuilder.WriteString("  echo WARNING: Could not find virtual environment directory '" + virtualEnvDir + "'.\n")
 			}
 		} else {
-			scriptBuilder.WriteString(fmt.Sprintf("echo 'if [ -f /%s/bin/activate ]; then . /%s/bin/activate; fi' >> ~/.bashrc\n", virtualEnvironmentName, virtualEnvironmentName))
-			compressedFile := gen.Manifest.CompressedVirtualEnvFile
 			virtualEnvDir := "/" + virtualEnvironmentName
+			scriptBuilder.WriteString(fmt.Sprintf("echo 'if [ -f %s/bin/activate ]; then . %s/bin/activate; fi' >> ~/.bashrc\n", virtualEnvDir, virtualEnvDir))
+			compressedFile := gen.Manifest.CompressedVirtualEnvFile
 			if strings.HasSuffix(compressedFile, ".zip") {
 				scriptBuilder.WriteString("echo Found virtual environment .zip archive.\n")
 				scriptBuilder.WriteString(
@@ -290,7 +290,7 @@ func (gen *PythonStartupScriptGenerator) getVenvHandlingScript(virtualEnvName st
 				scriptBuilder.WriteString(fmt.Sprintf(". %s/bin/activate\n", virtualEnvName))
 			}
 		} else {
-			scriptBuilder.WriteString(fmt.Sprintf("if [ -f /%s/bin/activate ]; then . /%s/bin/activate; fi\n", virtualEnvName, virtualEnvName))
+			scriptBuilder.WriteString(fmt.Sprintf("if [ -f %s/bin/activate ]; then . %s/bin/activate; fi\n", virtualEnvDir, virtualEnvDir))
 		}
 	}
 


### PR DESCRIPTION
With this PR, we conditionally check for activate script inside bin of venv to proceed ahead with its activation. 
Script generated which contains the PR changes: 
```
#!/bin/sh

echo 'export APP_PATH="/home/site/wwwroot"' >> ~/.bashrc
echo 'cd $APP_PATH' >> ~/.bashrc

# Enter the source directory to make sure the script runs where the user expects
cd /home/site/wwwroot

export APP_PATH="/home/site/wwwroot"
if [ -z "$HOST" ]; then
                export HOST=0.0.0.0
fi

if [ -z "$PORT" ]; then
                export PORT=80
fi

export PATH="/opt/python/3.13.11/bin:${PATH}"
echo 'export VIRTUALENVIRONMENT_PATH="/antenv"' >> ~/.bashrc
echo 'if [ -f /antenv/bin/activate ]; then . /antenv/bin/activate; fi' >> ~/.bashrc
echo Found virtual environment .tar.gz archive.
extractionCommand="tar -xzf antenv.tar.gz -C /antenv"
echo Removing existing virtual environment directory '/antenv'...
rm -fr /antenv
mkdir -p /antenv
echo Extracting to directory '/antenv'...
$extractionCommand
if [ -d antenv ]; then
    mv -f antenv _del_antenv || true
fi

if [ -d /antenv ]; then
    ln -sfn /antenv ./antenv
fi

echo "Done."
PYTHON_VERSION=$(python -c "import sys; print(str(sys.version_info.major) + '.' + str(sys.version_info.minor))")
echo Using packages from virtual environment 'antenv' located at '/antenv'.
export PYTHONPATH=$PYTHONPATH:"/antenv/lib/python$PYTHON_VERSION/site-packages"
echo "Updated PYTHONPATH to '$PYTHONPATH'"
if [ -f /antenv/bin/activate ]; then . /antenv/bin/activate; fi
```

Example: 
<img width="759" height="276" alt="image" src="https://github.com/user-attachments/assets/7d76ae74-f8c4-460d-b14b-e21d651e37d4" />
