### PR TITLE
remove --no-build flag from uv pip installation

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -60,7 +60,7 @@ install_via_uv() {
     echo "Running uv pip install..."
     
     # Build the command with --no-build to only use pre-built wheels
-    local base_cmd="uv pip install --cache-dir $UV_PIP_CACHE_DIR --no-build --compile-bytecode"
+    local base_cmd="uv pip install --cache-dir $UV_PIP_CACHE_DIR --compile-bytecode"
     
     # Add find-links if PYTHON_PRELOADED_WHEELS_DIR is set
     if [ -n "$PYTHON_PRELOADED_WHEELS_DIR" ]; then


### PR DESCRIPTION
In uv pip installation, we have added --no-build flag.
And because of this so many deployments are falling back so removing it.

Tested the changes manually in stage-0.
