### PR TITLE
Using python -m venv for Venv Creation for UV Lock Scenarios

### DIFF
--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -186,6 +186,9 @@ install_python_packages_impl() {
     fi
 
     if [ "$CreateVenvWithPythonVenv" = "true" ]; then
+        if [[ "$CreateVenvCommand" == *"uv venv"* ]]; then
+            echo "Using Python's built-in venv for virtual environment creation"
+        fi
         CreateVenvCommand="$python -m $VIRTUALENVIRONMENTMODULE $VIRTUALENVIRONMENTNAME $VIRTUALENVIRONMENTOPTIONS"
     fi
     


### PR DESCRIPTION
Currently, for pyproject.toml and uv.lock combination-based python oryx build, venv created is using `uv venv`. Venv created in such fashion has python bin in it as a symlink ([Open Issue](https://github.com/astral-sh/uv/issues/6782)) which poses problems when transporting environments between build and runtime stages.

This PR fixes it by using `python -m venv` for venv creation instead. 

Note: `uv` is still used for package installation for these scenarios (`uv pip install`, `uv sync`) when appropriate. 