### PR TITLE
Refactor metadata fetching in ExternalSdkProvider to handle pagination

### DIFF
--- a/src/BuildScriptGenerator/ExternalSdkProvider.cs
+++ b/src/BuildScriptGenerator/ExternalSdkProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
         return xdoc;
       }
-      catch (Exception ex)
+      catch (Exception ex) when (!(ex is InvalidOperationException))
       {
         this.outputWriter.WriteLine($"Error getting metadata for platform {platformName} from external provider: {ex.Message}");
         throw new InvalidOperationException($"Error getting metadata for platform {platformName} from external provider.", ex);


### PR DESCRIPTION
## PR Checklist
- [x] Change Description
- [x] Tests

### Change Description

This PR refactors the logic for fetching platform metadata from the external SDK provider to better support paginated results. The main changes include extracting the metadata page fetching logic into a new helper method and updating the main method to handle pagination by iteratively requesting all pages and aggregating results.

**Pagination support and code refactoring:**

* Refactored the `GetPlatformMetaDataAsync` method to handle paginated metadata results by iteratively requesting pages using the `NextMarker` value and aggregating all blobs into a single `XDocument`.
* Extracted the logic for fetching a single metadata page into a new private helper method `FetchMetadataPageAsync`, improving code readability and reusability.
### Tests
- Before
<img width="452" height="266" alt="image" src="https://github.com/user-attachments/assets/e0ed9983-2477-4f3c-a583-96ebc1f40be6" />
<img width="1472" height="250" alt="image" src="https://github.com/user-attachments/assets/e06ca388-b748-4304-a25f-2f7b662d3e8e" />

- With fix
<img width="480" height="183" alt="image" src="https://github.com/user-attachments/assets/f412137d-2c9b-4793-a90d-45e7c4db374f" />
<img width="1372" height="704" alt="image" src="https://github.com/user-attachments/assets/48d57a4c-e6ff-4420-aa99-2d488daa151f" />