### PR TITLE
Acr SDK Distribution: Update logic for dotnet selection and handling default versions

### DIFF
--- a/build/tools/Automation/DotNet/DotNetAutomator.cs
+++ b/build/tools/Automation/DotNet/DotNetAutomator.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Oryx.Automation.DotNet
                 // Deserialize release metadata
                 var response = await this.httpService.GetDataAsync(DotNetConstants.ReleasesIndexJsonUrl);
                 var releaseNotes = JsonConvert.DeserializeObject<ReleaseNotes>(response);
-                return releaseNotes?.ReleaseIndexes ?? new List<ReleaseNote>();
+                return releaseNotes.ReleaseIndexes;
             }
             catch (JsonException ex)
             {

--- a/src/BuildScriptGenerator.Common/SdkStorageConstants.cs
+++ b/src/BuildScriptGenerator.Common/SdkStorageConstants.cs
@@ -29,11 +29,5 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Common
         public const string DefaultAcrSdkRegistryUrl = "https://oryxacr.azurecr.io";
         public const string AcrSdkRepositoryPrefix = "sdks";
         public const string AcrDefaultVersionTag = "default";
-        public const string AcrCatalogTag = "catalog";
-        public const string AcrVersionLabelName = "org.oryx.version";
-        public const string AcrPlatformLabelName = "org.oryx.platform";
-        public const string AcrOsFlavorLabelName = "org.oryx.os-flavor";
-        public const string AcrDotnetRuntimeVersionLabelName = "org.oryx.dotnet-runtime-version";
-        public const string AcrDotnetSdkVersionLabelName = "org.oryx.dotnet-sdk-version";
     }
 }

--- a/src/BuildScriptGenerator/AcrVersionProviderBase.cs
+++ b/src/BuildScriptGenerator/AcrVersionProviderBase.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 {
     /// <summary>
     /// Base class for ACR-based SDK version providers. Parallel to <see cref="SdkStorageVersionProviderBase"/>
-    /// but discovers versions via OCI Distribution API (tag listing + image config labels) instead of
+    /// but discovers versions via OCI Distribution API (tag listing) instead of
     /// Azure Blob Storage listing with XML metadata.
+    /// Default versions come from local per-flavor constants rather than ACR image labels.
     /// </summary>
     public class AcrVersionProviderBase
     {
@@ -42,11 +43,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         protected OciRegistryClient OciClient { get; }
 
         /// <summary>
-        /// Lists available versions for a platform from ACR tags.
-        /// Tags are in the format "{osFlavor}-{version}" (e.g. "bookworm-20.19.3").
-        /// Tags ending with "-default" or "-catalog" are excluded.
+        /// Lists available versions for a platform from ACR tags and resolves the default
+        /// version from the supplied per-flavor dictionary.
         /// </summary>
-        protected PlatformVersionInfo GetAvailableVersionsFromAcr(string platformName)
+        protected PlatformVersionInfo GetAvailableVersionsFromAcr(
+            string platformName,
+            Dictionary<string, string> defaultVersionPerFlavor)
         {
             var repository = $"{SdkStorageConstants.AcrSdkRepositoryPrefix}/{platformName}";
 
@@ -54,7 +56,14 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
             var allTags = this.GetTags(repository);
             var supportedVersions = this.FilterVersionTags(allTags);
-            var defaultVersion = this.GetDefaultVersion(repository);
+
+            string defaultVersion = null;
+            if (defaultVersionPerFlavor != null &&
+                !string.IsNullOrEmpty(this.debianFlavor) &&
+                defaultVersionPerFlavor.TryGetValue(this.debianFlavor, out var version))
+            {
+                defaultVersion = version;
+            }
 
             this.logger.LogDebug(
                 "Found {count} versions for {platformName} on ACR (default: {default}).",
@@ -83,23 +92,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             var prefix = $"{this.debianFlavor}-";
             return allTags
                 .Where(t => t.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                         && !t.EndsWith($"-{SdkStorageConstants.AcrDefaultVersionTag}", StringComparison.OrdinalIgnoreCase)
-                         && !t.EndsWith($"-{SdkStorageConstants.AcrCatalogTag}", StringComparison.OrdinalIgnoreCase))
+                         && !t.EndsWith($"-{SdkStorageConstants.AcrDefaultVersionTag}", StringComparison.OrdinalIgnoreCase))
                 .Select(t => t.Substring(prefix.Length))
                 .ToList();
-        }
-
-        private string GetDefaultVersion(string repository)
-        {
-            try
-            {
-                return this.OciClient.GetDefaultVersionAsync(repository, this.debianFlavor).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogWarning(ex, "Failed to get default version from ACR for {repository}.", repository);
-                return null;
-            }
         }
     }
 }

--- a/src/BuildScriptGenerator/DotNetCore/DotnetCoreConstants.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCoreConstants.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license.
 // --------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 {
     public static class DotNetCoreConstants
@@ -57,5 +59,18 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
         public const string InstallBlazorWebAssemblyAOTWorkloadCommand = "dotnet workload install wasm-tools";
 
         public static readonly string DefaultDotNetCoreSdkVersionsInstallDir = $"/opt/{PlatformName}";
+
+        /// <summary>
+        /// Default .NET major.minor runtime version per OS flavor, matching platforms/dotnet/versions/*/defaultVersion.txt.
+        /// </summary>
+        public static readonly Dictionary<string, string> DefaultVersionPerFlavor = new Dictionary<string, string>
+        {
+            { "bookworm", "8.0" },
+            { "bullseye", "6.0" },
+            { "buster", "6.0" },
+            { "focal-scm", "6.0" },
+            { "noble", "10.0" },
+            { "stretch", "6.0" },
+        };
     }
 }

--- a/src/BuildScriptGenerator/DotNetCore/VersionProviders/DotNetCoreAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/VersionProviders/DotNetCoreAcrVersionProvider.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Oryx.BuildScriptGenerator.Common;
@@ -17,8 +16,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
     /// <summary>
     /// ACR-based version provider for .NET SDKs.
     /// Unlike other platforms, .NET requires a runtime→SDK version mapping.
-    /// This provider uses a catalog tag containing a JSON mapping, and falls back
-    /// to per-tag config label inspection.
+    /// This provider extracts the mapping directly from image tags, which encode
+    /// both versions in the format "{osFlavor}-{sdkVersion}_{runtimeVersion}"
+    /// (e.g. "noble-10.0.201_10.0.5").
     /// </summary>
     public class DotNetCoreAcrVersionProvider : AcrVersionProviderBase, IDotNetCoreVersionProvider
     {
@@ -59,128 +59,56 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             var repository = $"{SdkStorageConstants.AcrSdkRepositoryPrefix}/{DotNetCoreConstants.PlatformName}";
             var debianFlavor = this.commonOptions.DebianFlavor;
 
-            // Try catalog tag first — single HTTP round-trip for the full runtime→SDK mapping
-            if (!this.TryGetVersionInfoFromCatalog(repository, debianFlavor))
-            {
-                // Fallback: inspect individual tag configs (more HTTP calls)
-                this.GetVersionInfoFromTags(repository, debianFlavor);
-            }
+            this.GetVersionInfoFromTags(repository, debianFlavor);
         }
 
-        private bool TryGetVersionInfoFromCatalog(string repository, string debianFlavor)
-        {
-            try
-            {
-                var catalogTag = $"{debianFlavor}-{SdkStorageConstants.AcrCatalogTag}";
-                this.logger.LogDebug("Trying .NET catalog tag {tag} from ACR", catalogTag);
-
-                var manifest = this.OciClient.GetManifestAsync(repository, catalogTag).GetAwaiter().GetResult();
-                var configDigest = manifest.Config?.Digest;
-                if (string.IsNullOrEmpty(configDigest))
-                {
-                    return false;
-                }
-
-                var config = this.OciClient.GetImageConfigAsync(repository, configDigest).GetAwaiter().GetResult();
-                if (config?.Config?.Labels == null ||
-                    !config.Config.Labels.TryGetValue("org.oryx.dotnet-version-map", out var mapJson))
-                {
-                    return false;
-                }
-
-                var catalog = JsonSerializer.Deserialize<DotNetCatalog>(mapJson);
-                if (catalog?.Mappings == null)
-                {
-                    return false;
-                }
-
-                this.versionMap = new Dictionary<string, string>(catalog.Mappings, StringComparer.OrdinalIgnoreCase);
-                this.defaultRuntimeVersion = catalog.DefaultRuntimeVersion;
-                this.logger.LogDebug("Got .NET version map from catalog tag with {count} entries.", this.versionMap.Count);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogDebug(ex, "Catalog tag not available, falling back to per-tag inspection.");
-                return false;
-            }
-        }
-
+        /// <summary>
+        /// Parses the runtime→SDK version mapping from ACR tags.
+        /// Tags follow the format "{osFlavor}-{sdkVersion}_{runtimeVersion}".
+        /// Tags ending with "-default" are excluded from the version list.
+        /// </summary>
         private void GetVersionInfoFromTags(string repository, string debianFlavor)
         {
-            this.logger.LogDebug("Getting .NET version info from individual ACR tags.");
+            this.logger.LogDebug("Getting .NET version info from ACR tags for repository {repository}.", repository);
 
             var allTags = this.OciClient.GetAllTagsAsync(repository).GetAwaiter().GetResult();
 
             var prefix = $"{debianFlavor}-";
-            var versionTags = allTags
-                .Where(t => t.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                         && !t.EndsWith($"-{SdkStorageConstants.AcrDefaultVersionTag}", StringComparison.OrdinalIgnoreCase)
-                         && !t.EndsWith($"-{SdkStorageConstants.AcrCatalogTag}", StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
             var supportedVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var tag in versionTags)
+            foreach (var tag in allTags)
             {
-                this.TryExtractDotNetVersionFromTag(repository, tag, supportedVersions);
+                if (!tag.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                    || tag.EndsWith($"-{SdkStorageConstants.AcrDefaultVersionTag}", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Strip the osFlavor prefix to get "{sdkVersion}_{runtimeVersion}"
+                var versionPart = tag.Substring(prefix.Length);
+                var separatorIndex = versionPart.IndexOf('_');
+                if (separatorIndex <= 0 || separatorIndex >= versionPart.Length - 1)
+                {
+                    this.logger.LogDebug("Skipping tag '{tag}' — does not match expected format.", tag);
+                    continue;
+                }
+
+                var sdkVersion = versionPart.Substring(0, separatorIndex);
+                var runtimeVersion = versionPart.Substring(separatorIndex + 1);
+
+                supportedVersions[runtimeVersion] = sdkVersion;
             }
 
             this.versionMap = supportedVersions;
-            this.defaultRuntimeVersion = this.GetDefaultRuntimeVersionFromAcr(repository, debianFlavor);
-        }
 
-        private void TryExtractDotNetVersionFromTag(
-            string repository,
-            string tag,
-            Dictionary<string, string> supportedVersions)
-        {
-            try
-            {
-                var manifest = this.OciClient.GetManifestAsync(repository, tag).GetAwaiter().GetResult();
-                var configDigest = manifest.Config?.Digest;
-                if (string.IsNullOrEmpty(configDigest))
-                {
-                    return;
-                }
+            DotNetCoreConstants.DefaultVersionPerFlavor.TryGetValue(
+                debianFlavor ?? string.Empty, out var defaultVersion);
+            this.defaultRuntimeVersion = defaultVersion;
 
-                var config = this.OciClient.GetImageConfigAsync(repository, configDigest).GetAwaiter().GetResult();
-                var labels = config?.Config?.Labels;
-                if (labels == null)
-                {
-                    return;
-                }
-
-                if (labels.TryGetValue(SdkStorageConstants.AcrDotnetRuntimeVersionLabelName, out var runtimeVersion) &&
-                    labels.TryGetValue(SdkStorageConstants.AcrDotnetSdkVersionLabelName, out var sdkVersion))
-                {
-                    supportedVersions[runtimeVersion] = sdkVersion;
-                }
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogWarning(ex, "Failed to inspect config for tag {tag}.", tag);
-            }
-        }
-
-        private string GetDefaultRuntimeVersionFromAcr(string repository, string debianFlavor)
-        {
-            try
-            {
-                return this.OciClient.GetDefaultVersionAsync(repository, debianFlavor).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogWarning(ex, "Failed to get default .NET runtime version from ACR.");
-                return null;
-            }
-        }
-
-        private class DotNetCatalog
-        {
-            public Dictionary<string, string> Mappings { get; set; }
-
-            public string DefaultRuntimeVersion { get; set; }
+            this.logger.LogDebug(
+                "Found {count} .NET runtime→SDK mappings from tags (default runtime: {default}).",
+                supportedVersions.Count,
+                this.defaultRuntimeVersion ?? "none");
         }
     }
 }

--- a/src/BuildScriptGenerator/Helpers/OciRegistryClient.cs
+++ b/src/BuildScriptGenerator/Helpers/OciRegistryClient.cs
@@ -143,62 +143,6 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         }
 
         /// <summary>
-        /// Fetches the image config blob (contains Labels) for the given repository and digest.
-        /// </summary>
-        public async Task<OciImageConfig> GetImageConfigAsync(string repository, string configDigest)
-        {
-            var url = $"{this.registryUrl}/v2/{repository}/blobs/{configDigest}";
-            using (var response = await this.httpClient.GetAsync(url))
-            {
-                if (!response.IsSuccessStatusCode)
-                {
-                    throw new HttpRequestException(
-                        $"Failed to fetch config for '{repository}' (HTTP {(int)response.StatusCode}).");
-                }
-
-                using (var stream = await response.Content.ReadAsStreamAsync())
-                {
-                    return await JsonSerializer.DeserializeAsync<OciImageConfig>(stream);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets the default version for a platform from the "-default" tag's image config labels.
-        /// </summary>
-        public async Task<string> GetDefaultVersionAsync(string repository, string osFlavor)
-        {
-            var tag = $"{osFlavor}-default";
-            this.logger.LogDebug("Fetching default version from {repository}:{tag}", repository, tag);
-
-            try
-            {
-                var manifest = await this.GetManifestAsync(repository, tag);
-                var configDigest = manifest.Config?.Digest;
-                if (string.IsNullOrEmpty(configDigest))
-                {
-                    this.logger.LogWarning("No config digest found in manifest for {repository}:{tag}", repository, tag);
-                    return null;
-                }
-
-                var config = await this.GetImageConfigAsync(repository, configDigest);
-                if (config?.Config?.Labels != null &&
-                    config.Config.Labels.TryGetValue(Common.SdkStorageConstants.AcrVersionLabelName, out var version))
-                {
-                    return version;
-                }
-
-                this.logger.LogWarning("Version label not found in config for {repository}:{tag}", repository, tag);
-                return null;
-            }
-            catch (Exception ex)
-            {
-                this.logger.LogError(ex, "Failed to get default version from {repository}:{tag}", repository, tag);
-                throw;
-            }
-        }
-
-        /// <summary>
         /// Downloads a layer blob (the SDK tarball) to disk and verifies its SHA256 digest.
         /// The digest in the manifest IS the content hash — no separate checksum metadata needed.
         /// Uses single-pass streaming: the SHA256 hash is computed incrementally as bytes are

--- a/src/BuildScriptGenerator/Node/NodeConstants.cs
+++ b/src/BuildScriptGenerator/Node/NodeConstants.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license.
 // --------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Oryx.BuildScriptGenerator.Node
 {
     public static class NodeConstants
@@ -51,5 +53,18 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
         public const string InstalledNodeVersionsDir = "/opt/nodejs/";
         public const string NodeVersion = "NODE_VERSION";
         public const string LegacyZipNodeModules = "ENABLE_NODE_MODULES_ZIP";
+
+        /// <summary>
+        /// Default Node major version per OS flavor, matching platforms/nodejs/versions/*/defaultVersion.txt.
+        /// </summary>
+        public static readonly Dictionary<string, string> DefaultVersionPerFlavor = new Dictionary<string, string>
+        {
+            { "bookworm", "20" },
+            { "bullseye", "16" },
+            { "buster", "16" },
+            { "focal-scm", "16" },
+            { "noble", "24" },
+            { "stretch", "16" },
+        };
     }
 }

--- a/src/BuildScriptGenerator/Node/VersionProviders/NodeAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/Node/VersionProviders/NodeAcrVersionProvider.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
         public virtual PlatformVersionInfo GetVersionInfo()
         {
             return this.platformVersionInfo
-                ??= this.GetAvailableVersionsFromAcr(platformName: "nodejs");
+                ??= this.GetAvailableVersionsFromAcr(
+                    platformName: "nodejs",
+                    defaultVersionPerFlavor: NodeConstants.DefaultVersionPerFlavor);
         }
     }
 }

--- a/src/BuildScriptGenerator/Php/PhpConstants.cs
+++ b/src/BuildScriptGenerator/Php/PhpConstants.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license.
 // --------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Oryx.BuildScriptGenerator.Php
 {
     public static class PhpConstants
@@ -15,5 +17,31 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
         public const string DefaultPhpRuntimeVersion = Common.PhpVersions.Php73Version;
         public const string InstalledPhpVersionsDir = "/opt/php/"; // TODO: consolidate with Dockerfile to yaml?
         public const string InstalledPhpComposerVersionDir = "/opt/php-composer/";
+
+        /// <summary>
+        /// Default PHP major.minor version per OS flavor, matching platforms/php/versions/*/defaultVersion.txt.
+        /// </summary>
+        public static readonly Dictionary<string, string> DefaultVersionPerFlavor = new Dictionary<string, string>
+        {
+            { "bookworm", "8.3" },
+            { "bullseye", "8.0" },
+            { "buster", "8.0" },
+            { "focal-scm", "8.0" },
+            { "noble", "8.5" },
+            { "stretch", "8.0" },
+        };
+
+        /// <summary>
+        /// Default PHP Composer major version per OS flavor, matching platforms/php/composer/versions/*/defaultVersion.txt.
+        /// </summary>
+        public static readonly Dictionary<string, string> ComposerDefaultVersionPerFlavor = new Dictionary<string, string>
+        {
+            { "bookworm", "2" },
+            { "bullseye", "2" },
+            { "buster", "2" },
+            { "focal-scm", "2" },
+            { "noble", "2" },
+            { "stretch", "2" },
+        };
     }
 }

--- a/src/BuildScriptGenerator/Php/VersionProviders/PhpAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/Php/VersionProviders/PhpAcrVersionProvider.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
         public virtual PlatformVersionInfo GetVersionInfo()
         {
             return this.platformVersionInfo
-                ??= this.GetAvailableVersionsFromAcr(platformName: ToolNameConstants.PhpName);
+                ??= this.GetAvailableVersionsFromAcr(
+                    platformName: ToolNameConstants.PhpName,
+                    defaultVersionPerFlavor: PhpConstants.DefaultVersionPerFlavor);
         }
     }
 }

--- a/src/BuildScriptGenerator/Php/VersionProviders/PhpComposerAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/Php/VersionProviders/PhpComposerAcrVersionProvider.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
         public virtual PlatformVersionInfo GetVersionInfo()
         {
             return this.platformVersionInfo
-                ??= this.GetAvailableVersionsFromAcr(platformName: "php-composer");
+                ??= this.GetAvailableVersionsFromAcr(
+                    platformName: "php-composer",
+                    defaultVersionPerFlavor: PhpConstants.ComposerDefaultVersionPerFlavor);
         }
     }
 }

--- a/src/BuildScriptGenerator/Python/PythonConstants.cs
+++ b/src/BuildScriptGenerator/Python/PythonConstants.cs
@@ -3,6 +3,8 @@
 // Licensed under the MIT license.
 // --------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.Oryx.BuildScriptGenerator.Python
 {
     public static class PythonConstants
@@ -20,5 +22,18 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         public const string DefaultTargetPackageDirectory = "__oryx_packages__";
         public const string SetupDotPyFileName = "setup.py";
         public const string CondaExecutablePath = "/opt/conda/condabin/conda";
+
+        /// <summary>
+        /// Default Python major.minor version per OS flavor, matching platforms/python/versions/*/defaultVersion.txt.
+        /// </summary>
+        public static readonly Dictionary<string, string> DefaultVersionPerFlavor = new Dictionary<string, string>
+        {
+            { "bookworm", "3.8" },
+            { "bullseye", "3.8" },
+            { "buster", "3.8" },
+            { "focal-scm", "3.8" },
+            { "noble", "3.14" },
+            { "stretch", "3.8" },
+        };
     }
 }

--- a/src/BuildScriptGenerator/Python/VersionProviders/PythonAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/Python/VersionProviders/PythonAcrVersionProvider.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         public virtual PlatformVersionInfo GetVersionInfo()
         {
             return this.platformVersionInfo
-                ??= this.GetAvailableVersionsFromAcr(platformName: ToolNameConstants.PythonName);
+                ??= this.GetAvailableVersionsFromAcr(
+                    platformName: ToolNameConstants.PythonName,
+                    defaultVersionPerFlavor: Python.PythonConstants.DefaultVersionPerFlavor);
         }
     }
 }


### PR DESCRIPTION
This pull request updates how default SDK/runtime versions are determined for .NET, Node.js, and PHP platforms when using ACR (Azure Container Registry) as the version source. Instead of reading default versions from ACR image labels or catalog tags, the logic now uses local per-OS-flavor constants. Additionally, the .NET ACR version provider is refactored to extract runtime→SDK mappings directly from tag names, simplifying and speeding up version discovery. Several unused constants and methods related to ACR image labels are removed as part of this cleanup.