### PR TITLE
ACR SDK distribution: Refactor direct acr sdk fetching logic

### DIFF
--- a/src/BuildScriptGenerator.Common/SdkStorageConstants.cs
+++ b/src/BuildScriptGenerator.Common/SdkStorageConstants.cs
@@ -28,6 +28,5 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Common
         public const string AcrSdkRegistryUrlKeyName = "ORYX_ACR_SDK_REGISTRY_URL";
         public const string DefaultAcrSdkRegistryUrl = "https://oryxacr.azurecr.io";
         public const string AcrSdkRepositoryPrefix = "sdks";
-        public const string AcrDefaultVersionTag = "default";
     }
 }

--- a/src/BuildScriptGenerator/AcrSdkProvider.cs
+++ b/src/BuildScriptGenerator/AcrSdkProvider.cs
@@ -14,21 +14,16 @@ using Microsoft.Oryx.BuildScriptGenerator.Common;
 namespace Microsoft.Oryx.BuildScriptGenerator
 {
     /// <summary>
-    /// ACR-based SDK provider that fetches SDK tarballs directly from an OCI-compliant
-    /// container registry using the OCI Distribution API. SDK images are single-layer
-    /// <c>FROM scratch</c> images where the layer IS the SDK tarball.
+    /// Fetches SDK tarballs directly from an OCI container registry.
+    /// SDK images are single-layer <c>FROM scratch</c> images where
+    /// the layer IS the SDK tarball.
     /// </summary>
     /// <remarks>
-    /// This provider makes direct HTTP calls to the registry — no Unix socket, no external
-    /// intermediary. See <see cref="ExternalAcrSdkProvider"/> for the socket-based variant.
+    /// Makes direct HTTP calls to the registry (no Unix socket).
+    /// See <see cref="ExternalAcrSdkProvider"/> for the socket-based variant.
     /// </remarks>
     public class AcrSdkProvider : IAcrSdkProvider
     {
-        /// <summary>
-        /// The directory where SDKs are cached (same as the blob-based provider).
-        /// </summary>
-        public const string SdksCacheDir = "/var/OryxSdks";
-
         private readonly ILogger<AcrSdkProvider> logger;
         private readonly IStandardOutputWriter outputWriter;
         private readonly BuildScriptGeneratorOptions options;
@@ -53,7 +48,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         }
 
         /// <inheritdoc/>
-        public async Task<bool> RequestSdkFromAcrAsync(string platformName, string version, string debianFlavor)
+        public async Task<string> RequestSdkFromAcrAsync(string platformName, string version, string debianFlavor)
         {
             if (string.IsNullOrEmpty(platformName))
             {
@@ -81,16 +76,18 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             this.outputWriter.WriteLine(
                 $"Requesting SDK from ACR: {repository}:{tag}");
 
-            // Check if the file is already cached locally
-            var expectedFilePath = Path.Combine(SdksCacheDir, platformName, blobName);
-            if (File.Exists(expectedFilePath))
+            // Download to the writable dynamic install directory, NOT /var/OryxSdks (read-only external mount).
+            var downloadDir = Path.Combine(this.options.DynamicInstallRootDir, platformName);
+            var tarballPath = Path.Combine(downloadDir, blobName);
+
+            if (File.Exists(tarballPath))
             {
                 this.logger.LogInformation(
-                    "SDK already cached at {FilePath}, skipping ACR pull.",
-                    expectedFilePath);
+                    "SDK tarball already downloaded at {FilePath}, skipping ACR pull.",
+                    tarballPath);
                 this.outputWriter.WriteLine(
-                    $"SDK already cached at {expectedFilePath}");
-                return true;
+                    $"SDK tarball already downloaded at {tarballPath}");
+                return tarballPath;
             }
 
             try
@@ -105,17 +102,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                         "No layer found in manifest for {Repository}:{Tag}",
                         repository,
                         tag);
-                    return false;
+                    return null;
                 }
 
                 // 2. Download the layer blob (the SDK tarball) and verify its SHA256 digest
-                var platformDir = Path.Combine(SdksCacheDir, platformName);
-                Directory.CreateDirectory(platformDir);
+                Directory.CreateDirectory(downloadDir);
 
                 var success = await this.ociClient.DownloadLayerBlobAsync(
                     repository,
                     layerDigest,
-                    expectedFilePath);
+                    tarballPath);
 
                 if (success)
                 {
@@ -123,10 +119,10 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                         "Successfully pulled SDK from ACR: {Repository}:{Tag} → {FilePath}",
                         repository,
                         tag,
-                        expectedFilePath);
+                        tarballPath);
                     this.outputWriter.WriteLine(
                         $"Successfully pulled SDK from ACR: {platformName} {version}");
-                    return true;
+                    return tarballPath;
                 }
                 else
                 {
@@ -136,7 +132,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                         tag);
                     this.outputWriter.WriteLine(
                         $"Failed to pull SDK from ACR (digest mismatch): {platformName} {version}");
-                    return false;
+                    return null;
                 }
             }
             catch (Exception ex)
@@ -148,7 +144,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                     tag);
                 this.outputWriter.WriteLine(
                     $"Error pulling SDK from ACR: {platformName} {version}: {ex.Message}");
-                return false;
+                return null;
             }
         }
     }

--- a/src/BuildScriptGenerator/AcrVersionProviderBase.cs
+++ b/src/BuildScriptGenerator/AcrVersionProviderBase.cs
@@ -91,8 +91,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         {
             var prefix = $"{this.debianFlavor}-";
             return allTags
-                .Where(t => t.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                         && !t.EndsWith($"-{SdkStorageConstants.AcrDefaultVersionTag}", StringComparison.OrdinalIgnoreCase))
+                .Where(t => t.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 .Select(t => t.Substring(prefix.Length))
                 .ToList();
         }

--- a/src/BuildScriptGenerator/Contracts/IAcrSdkProvider.cs
+++ b/src/BuildScriptGenerator/Contracts/IAcrSdkProvider.cs
@@ -8,23 +8,26 @@ using System.Threading.Tasks;
 namespace Microsoft.Oryx.BuildScriptGenerator
 {
     /// <summary>
-    /// Pulls SDK tarballs directly from an OCI-compliant container registry (ACR)
-    /// using the OCI Distribution API. SDK images are single-layer <c>FROM scratch</c>
-    /// images where the layer IS the SDK tarball.
+    /// Fetches SDK tarballs directly from an OCI container registry.
+    /// SDK images are single-layer <c>FROM scratch</c> images where
+    /// the layer IS the SDK tarball.
     /// </summary>
     /// <remarks>
     /// Gated by the <c>ORYX_ENABLE_ACR_SDK_PROVIDER</c> feature flag.
-    /// This is an alternative to <see cref="IExternalSdkProvider"/> (blob storage via socket).
+    /// Alternative to <see cref="IExternalSdkProvider"/> (blob storage via socket).
     /// </remarks>
     public interface IAcrSdkProvider
     {
         /// <summary>
-        /// Pulls an SDK image from the ACR registry and saves the SDK tarball to the local cache.
+        /// Pulls an SDK image from the registry and saves the tarball to
+        /// the dynamic install directory (writable by Oryx).
         /// </summary>
         /// <param name="platformName">The platform name (e.g., "nodejs", "python", "dotnet", "php").</param>
         /// <param name="version">The SDK version (e.g., "20.19.3").</param>
         /// <param name="debianFlavor">The Debian flavor (e.g., "bookworm", "bullseye").</param>
-        /// <returns>True if the SDK was successfully pulled and cached.</returns>
-        Task<bool> RequestSdkFromAcrAsync(string platformName, string version, string debianFlavor);
+        /// <returns>
+        /// The absolute path to the downloaded tarball, or <c>null</c> if the pull failed.
+        /// </returns>
+        Task<string> RequestSdkFromAcrAsync(string platformName, string version, string debianFlavor);
     }
 }

--- a/src/BuildScriptGenerator/Contracts/IExternalSdkProvider.cs
+++ b/src/BuildScriptGenerator/Contracts/IExternalSdkProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
     /// <summary>
     /// The directory where SDKs are cached by the external provider.
     /// </summary>
-    public const string ExternalSdksStorageDir = "/var/OryxSdksCache";
+    public const string ExternalSdksStorageDir = "/var/OryxSdks";
 
     /// <summary>
     /// Gets all metadata for a specific platform from the external SDK provider.

--- a/src/BuildScriptGenerator/DotNetCore/DotNetCorePlatformInstaller.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotNetCorePlatformInstaller.cs
@@ -19,9 +19,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
         {
         }
 
-        public virtual string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+        public virtual string GetInstallerScriptSnippet(
+            string version,
+            bool skipSdkBinaryDownload = false,
+            string localSdkTarballPath = null)
         {
-            return this.GetInstallerScriptSnippet(DotNetCoreConstants.PlatformName, version, skipSdkBinaryDownload: skipSdkBinaryDownload);
+            return this.GetInstallerScriptSnippet(
+                DotNetCoreConstants.PlatformName,
+                version,
+                skipSdkBinaryDownload: skipSdkBinaryDownload,
+                localSdkTarballPath: localSdkTarballPath);
         }
 
         public virtual bool IsVersionAlreadyInstalled(string version)

--- a/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
@@ -371,13 +371,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 
             try
             {
-                if (this.acrSdkProvider.RequestSdkFromAcrAsync(
-                    this.Name, sdkVersion, this.commonOptions.DebianFlavor).Result)
+                var tarballPath = this.acrSdkProvider.RequestSdkFromAcrAsync(
+                    this.Name, sdkVersion, this.commonOptions.DebianFlavor).Result;
+
+                if (!string.IsNullOrEmpty(tarballPath))
                 {
                     this.logger.LogDebug(
-                        "DotNetCore SDK version {version} is fetched successfully using ACR SDK provider. Skipping platform binary download.",
-                        sdkVersion);
-                    return this.platformInstaller.GetInstallerScriptSnippet(sdkVersion, skipSdkBinaryDownload: true);
+                        "DotNetCore SDK version {version} is fetched successfully using ACR SDK provider. Tarball at {tarballPath}.",
+                        sdkVersion,
+                        tarballPath);
+                    return this.platformInstaller.GetInstallerScriptSnippet(sdkVersion, localSdkTarballPath: tarballPath);
                 }
 
                 this.logger.LogDebug(

--- a/src/BuildScriptGenerator/DotNetCore/VersionProviders/DotNetCoreAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/VersionProviders/DotNetCoreAcrVersionProvider.cs
@@ -78,8 +78,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 
             foreach (var tag in allTags)
             {
-                if (!tag.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                    || tag.EndsWith($"-{SdkStorageConstants.AcrDefaultVersionTag}", StringComparison.OrdinalIgnoreCase))
+                if (!tag.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/src/BuildScriptGenerator/ExternalAcrSdkProvider.cs
+++ b/src/BuildScriptGenerator/ExternalAcrSdkProvider.cs
@@ -12,8 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Oryx.BuildScriptGenerator.Common;
-using Microsoft.Oryx.Common.Extensions;
 
 namespace Microsoft.Oryx.BuildScriptGenerator
 {
@@ -22,7 +20,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
     /// This is the ACR equivalent of <see cref="ExternalSdkProvider"/> (blob storage via socket).
     /// </summary>
     /// <remarks>
-    /// Flow: Oryx → Unix socket → external host (LWASv2 OryxSdkImageProxy) → ACR.
+    /// Flow: Oryx → Unix socket → external host → ACR.
     /// Connects to a dedicated ACR SDK socket and sends <c>Action=pull-sdk</c> so the
     /// external host routes to the ACR image-pull logic.
     /// Version discovery is handled by <see cref="ExternalAcrVersionProviderBase"/>.
@@ -36,12 +34,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
         /// <summary>
         /// The directory where ACR-based SDKs are cached.
-        /// Must match the mount path used by the external host (LWASv2 OryxAcrSdks volume).
+        /// Must match the mount path used by the external host.
         /// </summary>
         public const string ExternalAcrSdksStorageDir = "/var/OryxAcrSdks";
 
-        private const string SocketPath = "/var/sdk-image-sockets/oryx-pull-sdk-image.socket";
-        private const int MaxTimeoutForSocketOperationInSeconds = 120;
+        private const string SocketPath = "/var/sockets/oryx-pull-sdk-image.socket";
+        private const int MaxTimeoutForSocketOperationInSeconds = 100;
 
         private readonly ILogger<ExternalAcrSdkProvider> logger;
         private readonly IStandardOutputWriter outputWriter;
@@ -72,7 +70,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
 
             if (string.IsNullOrEmpty(debianFlavor))
             {
-                debianFlavor = this.options.DebianFlavor ?? "bookworm";
+                throw new ArgumentException("Debian flavor cannot be null or empty.", nameof(debianFlavor));
             }
 
             this.logger.LogInformation(
@@ -90,6 +88,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 {
                     Action = "pull-sdk",
                     PlatformName = platformName,
+                    Version = version,
+                    DebianFlavor = debianFlavor,
                 };
 
                 var responseFilename = await this.SendRequestAsync(request);
@@ -137,9 +137,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             try
             {
                 this.logger.LogInformation(
-                    "Sending ACR request via socket: Action={Action}, PlatformName={PlatformName}",
+                    "Sending ACR request via socket: Action={Action}, PlatformName={PlatformName}, Version={Version}, DebianFlavor={DebianFlavor}",
                     request.Action,
-                    request.PlatformName);
+                    request.PlatformName,
+                    request.Version,
+                    request.DebianFlavor);
 
                 using (var cts = new CancellationTokenSource(
                     TimeSpan.FromSeconds(MaxTimeoutForSocketOperationInSeconds)))
@@ -196,6 +198,10 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             public string Action { get; set; }
 
             public string PlatformName { get; set; }
+
+            public string Version { get; set; }
+
+            public string DebianFlavor { get; set; }
         }
     }
 }

--- a/src/BuildScriptGenerator/ExternalAcrVersionProviderBase.cs
+++ b/src/BuildScriptGenerator/ExternalAcrVersionProviderBase.cs
@@ -16,15 +16,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator
     /// <summary>
     /// Base class for version providers that resolve the companion SDK version for a platform
     /// via a Unix socket to the external host.
+    /// The external host dictates the SDK version to use for each platform.
     /// </summary>
     /// <remarks>
-    /// Flow: Oryx → Unix socket → external host (LWASv2 OryxSdkImageProxy) → single SDK version response.
+    /// Flow: Oryx → Unix socket → external host → single SDK version response.
     /// Connects to the dedicated ACR SDK socket and sends <c>Action=get-version</c>.
     /// SDK pulling is handled separately by <see cref="ExternalAcrSdkProvider"/>.
     /// </remarks>
     public class ExternalAcrVersionProviderBase
     {
-        private const string SocketPath = "/var/sdk-image-sockets/oryx-pull-sdk-image.socket";
+        private const string SocketPath = "/var/sockets/oryx-pull-sdk-image.socket";
         private const int MaxTimeoutForSocketOperationInSeconds = 120;
 
         private readonly ILogger logger;

--- a/src/BuildScriptGenerator/Node/NodePlatform.cs
+++ b/src/BuildScriptGenerator/Node/NodePlatform.cs
@@ -710,13 +710,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
 
             try
             {
-                if (this.acrSdkProvider.RequestSdkFromAcrAsync(
-                    this.Name, version, this.commonOptions.DebianFlavor).Result)
+                var tarballPath = this.acrSdkProvider.RequestSdkFromAcrAsync(
+                    this.Name, version, this.commonOptions.DebianFlavor).Result;
+
+                if (!string.IsNullOrEmpty(tarballPath))
                 {
                     this.logger.LogDebug(
-                        "Node version {version} is fetched successfully using ACR SDK provider. Skipping platform binary download.",
-                        version);
-                    return this.platformInstaller.GetInstallerScriptSnippet(version, skipSdkBinaryDownload: true);
+                        "Node version {version} is fetched successfully using ACR SDK provider. Tarball at {tarballPath}.",
+                        version,
+                        tarballPath);
+                    return this.platformInstaller.GetInstallerScriptSnippet(version, localSdkTarballPath: tarballPath);
                 }
 
                 this.logger.LogDebug(

--- a/src/BuildScriptGenerator/Node/NodePlatformInstaller.cs
+++ b/src/BuildScriptGenerator/Node/NodePlatformInstaller.cs
@@ -19,9 +19,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
         {
         }
 
-        public virtual string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+        public virtual string GetInstallerScriptSnippet(
+            string version,
+            bool skipSdkBinaryDownload = false,
+            string localSdkTarballPath = null)
         {
-            return this.GetInstallerScriptSnippet(NodeConstants.PlatformName, version, skipSdkBinaryDownload: skipSdkBinaryDownload);
+            return this.GetInstallerScriptSnippet(
+                NodeConstants.PlatformName,
+                version,
+                skipSdkBinaryDownload: skipSdkBinaryDownload,
+                localSdkTarballPath: localSdkTarballPath);
         }
 
         public virtual bool IsVersionAlreadyInstalled(string version)

--- a/src/BuildScriptGenerator/Php/PhpComposerInstaller.cs
+++ b/src/BuildScriptGenerator/Php/PhpComposerInstaller.cs
@@ -22,9 +22,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
         {
         }
 
-        public virtual string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+        public virtual string GetInstallerScriptSnippet(
+            string version,
+            bool skipSdkBinaryDownload = false,
+            string localSdkTarballPath = null)
         {
-            return this.GetInstallerScriptSnippet(platformName: "php-composer", version, skipSdkBinaryDownload: skipSdkBinaryDownload);
+            return this.GetInstallerScriptSnippet(
+                platformName: "php-composer",
+                version,
+                skipSdkBinaryDownload: skipSdkBinaryDownload,
+                localSdkTarballPath: localSdkTarballPath);
         }
 
         public virtual bool IsVersionAlreadyInstalled(string version)

--- a/src/BuildScriptGenerator/Php/PhpPlatform.cs
+++ b/src/BuildScriptGenerator/Php/PhpPlatform.cs
@@ -423,11 +423,13 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
 
             try
             {
-                if (this.acrSdkProvider.RequestSdkFromAcrAsync(
-                    "php", phpVersion, this.commonOptions.DebianFlavor).Result)
+                var tarballPath = this.acrSdkProvider.RequestSdkFromAcrAsync(
+                    "php", phpVersion, this.commonOptions.DebianFlavor).Result;
+
+                if (!string.IsNullOrEmpty(tarballPath))
                 {
-                    this.logger.LogDebug("PHP version {version} is fetched successfully using ACR SDK provider. Skipping platform binary download.", phpVersion);
-                    scriptBuilder.AppendLine(this.phpInstaller.GetInstallerScriptSnippet(phpVersion, skipSdkBinaryDownload: true));
+                    this.logger.LogDebug("PHP version {version} is fetched successfully using ACR SDK provider. Tarball at {tarballPath}.", phpVersion, tarballPath);
+                    scriptBuilder.AppendLine(this.phpInstaller.GetInstallerScriptSnippet(phpVersion, localSdkTarballPath: tarballPath));
                     return;
                 }
 
@@ -458,11 +460,13 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
 
             try
             {
-                if (this.acrSdkProvider.RequestSdkFromAcrAsync(
-                    "php-composer", phpComposerVersion, this.commonOptions.DebianFlavor).Result)
+                var tarballPath = this.acrSdkProvider.RequestSdkFromAcrAsync(
+                    "php-composer", phpComposerVersion, this.commonOptions.DebianFlavor).Result;
+
+                if (!string.IsNullOrEmpty(tarballPath))
                 {
-                    this.logger.LogDebug("PHP Composer version {version} is fetched successfully using ACR SDK provider. Skipping platform binary download.", phpComposerVersion);
-                    scriptBuilder.AppendLine(this.phpComposerInstaller.GetInstallerScriptSnippet(phpComposerVersion, skipSdkBinaryDownload: true));
+                    this.logger.LogDebug("PHP Composer version {version} is fetched successfully using ACR SDK provider. Tarball at {tarballPath}.", phpComposerVersion, tarballPath);
+                    scriptBuilder.AppendLine(this.phpComposerInstaller.GetInstallerScriptSnippet(phpComposerVersion, localSdkTarballPath: tarballPath));
                     return;
                 }
 

--- a/src/BuildScriptGenerator/Php/PhpPlatformInstaller.cs
+++ b/src/BuildScriptGenerator/Php/PhpPlatformInstaller.cs
@@ -22,9 +22,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
         {
         }
 
-        public virtual string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+        public virtual string GetInstallerScriptSnippet(
+            string version,
+            bool skipSdkBinaryDownload = false,
+            string localSdkTarballPath = null)
         {
-            return this.GetInstallerScriptSnippet(PhpConstants.PlatformName, version, skipSdkBinaryDownload: skipSdkBinaryDownload);
+            return this.GetInstallerScriptSnippet(
+                PhpConstants.PlatformName,
+                version,
+                skipSdkBinaryDownload: skipSdkBinaryDownload,
+                localSdkTarballPath: localSdkTarballPath);
         }
 
         public virtual bool IsVersionAlreadyInstalled(string version)

--- a/src/BuildScriptGenerator/PlatformInstallerBase.cs
+++ b/src/BuildScriptGenerator/PlatformInstallerBase.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             string platformName,
             string version,
             string directoryToInstall = null,
-            bool skipSdkBinaryDownload = false)
+            bool skipSdkBinaryDownload = false,
+            string localSdkTarballPath = null)
         {
             var sdkStorageBaseUrl = this.GetPlatformBinariesStorageBaseUrl();
             var sdkStorageBackupBaseUrl = this.GetPlatformBinariesBackupStorageBaseUrl();
@@ -153,6 +154,15 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                         .AppendLine($"tar -xzf {tarFilePath} -C .")
                         .AppendLine($"rm -f {tarFileName}")
                         .AppendLine($"echo \"Successfully extracted {platformName} version {version} from external sdk provider cache...\"");
+                }
+            else if (!string.IsNullOrEmpty(localSdkTarballPath))
+                {
+                    // ACR direct provider already downloaded the tarball to a writable location.
+                    // Extract from that local path and clean up.
+                    snippet.AppendLine($"echo \"Extracting SDK from locally downloaded tarball: {localSdkTarballPath}...\"")
+                        .AppendLine($"tar -xzf {localSdkTarballPath} -C .")
+                        .AppendLine($"rm -f {localSdkTarballPath}")
+                        .AppendLine($"echo \"Successfully extracted {platformName} version {version} from local tarball.\"");
                 }
             else
                 {

--- a/src/BuildScriptGenerator/Python/PythonPlatform.cs
+++ b/src/BuildScriptGenerator/Python/PythonPlatform.cs
@@ -607,12 +607,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
 
             try
             {
-                if (this.acrSdkProvider.RequestSdkFromAcrAsync(this.Name, version, this.commonOptions.DebianFlavor).Result)
+                var tarballPath = this.acrSdkProvider.RequestSdkFromAcrAsync(
+                    this.Name, version, this.commonOptions.DebianFlavor).Result;
+
+                if (!string.IsNullOrEmpty(tarballPath))
                 {
                     this.logger.LogDebug(
-                        "Python version {version} is fetched successfully using ACR SDK provider. Skipping platform binary download.",
-                        version);
-                    return this.platformInstaller.GetInstallerScriptSnippet(version, skipSdkBinaryDownload: true);
+                        "Python version {version} is fetched successfully using ACR SDK provider. Tarball at {tarballPath}.",
+                        version,
+                        tarballPath);
+                    return this.platformInstaller.GetInstallerScriptSnippet(version, localSdkTarballPath: tarballPath);
                 }
 
                 this.logger.LogDebug(

--- a/src/BuildScriptGenerator/Python/PythonPlatformInstaller.cs
+++ b/src/BuildScriptGenerator/Python/PythonPlatformInstaller.cs
@@ -19,9 +19,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         {
         }
 
-        public virtual string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+        public virtual string GetInstallerScriptSnippet(
+            string version,
+            bool skipSdkBinaryDownload = false,
+            string localSdkTarballPath = null)
         {
-            return this.GetInstallerScriptSnippet(PythonConstants.PlatformName, version, skipSdkBinaryDownload: skipSdkBinaryDownload);
+            return this.GetInstallerScriptSnippet(
+                PythonConstants.PlatformName,
+                version,
+                skipSdkBinaryDownload: skipSdkBinaryDownload,
+                localSdkTarballPath: localSdkTarballPath);
         }
 
         public virtual bool IsVersionAlreadyInstalled(string version)

--- a/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
                 return _isVersionAlreadyInstalled;
             }
 
-            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false, string localSdkTarballPath = null)
             {
                 return _installerScript;
             }

--- a/tests/BuildScriptGenerator.Tests/Node/NodePlatformTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Node/NodePlatformTest.cs
@@ -1146,7 +1146,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Node
                 return _sdkIsAlreadyInstalled;
             }
 
-            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false, string localSdkTarballPath = null)
             {
                 if (skipSdkBinaryDownload)
                 {

--- a/tests/BuildScriptGenerator.Tests/Node/NodeVersionProviderTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Node/NodeVersionProviderTest.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Node
                 onDiskProvider,
                 storageProvider,
                 externalProvider,
-                new NodeExternalAcrVersionProvider(commonOptions, NullLoggerFactory.Instance),
+                new NodeExternalAcrVersionProvider(NullLoggerFactory.Instance),
                 new NodeAcrVersionProvider(commonOptions, new TestHttpClientFactory(), NullLoggerFactory.Instance),
                 NullLogger<NodeVersionProvider>.Instance);
             return (versionProvider, onDiskProvider, storageProvider, externalProvider);

--- a/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
@@ -657,7 +657,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
                 return _isVersionAlreadyInstalled;
             }
 
-            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false, string localSdkTarballPath = null)
             {
                 if (skipSdkBinaryDownload)
                 {
@@ -686,7 +686,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
                 return _isVersionAlreadyInstalled;
             }
 
-            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false, string localSdkTarballPath = null)
             {
                 if (skipSdkBinaryDownload)
                 {

--- a/tests/BuildScriptGenerator.Tests/Php/PhpVersionProviderTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Php/PhpVersionProviderTest.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
                 onDiskProvider,
                 storageProvider,
                 externalProvider,
-                new PhpExternalAcrVersionProvider(commonOptions, NullLoggerFactory.Instance),
+                new PhpExternalAcrVersionProvider(NullLoggerFactory.Instance),
                 new PhpAcrVersionProvider(commonOptions, new TestHttpClientFactory(), NullLoggerFactory.Instance),
                 NullLogger<PhpVersionProvider>.Instance);
             return (versionProvider, onDiskProvider, storageProvider, externalProvider);

--- a/tests/BuildScriptGenerator.Tests/Python/PythonPlatformTests.cs
+++ b/tests/BuildScriptGenerator.Tests/Python/PythonPlatformTests.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Python
                 return _isVersionAlreadyInstalled;
             }
 
-            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false)
+            public override string GetInstallerScriptSnippet(string version, bool skipSdkBinaryDownload = false, string localSdkTarballPath = null)
             {
                 if (skipSdkBinaryDownload)
                 {

--- a/tests/BuildScriptGenerator.Tests/Python/PythonVersionProviderTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Python/PythonVersionProviderTest.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Python
                 onDiskProvider,
                 storageProvider,
                 externalProvider,
-                new PythonExternalAcrVersionProvider(commonOptions, NullLoggerFactory.Instance),
+                new PythonExternalAcrVersionProvider(NullLoggerFactory.Instance),
                 new PythonAcrVersionProvider(commonOptions, new TestHttpClientFactory(), NullLoggerFactory.Instance),
                 NullLogger<PythonVersionProvider>.Instance);
             return (versionProvider, onDiskProvider, storageProvider, externalProvider);

--- a/tests/Oryx.Tests.Common/TestAcrSdkProvider.cs
+++ b/tests/Oryx.Tests.Common/TestAcrSdkProvider.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Oryx.Tests.Common
 {
     public class TestAcrSdkProvider : IAcrSdkProvider
     {
-        public Task<bool> RequestSdkFromAcrAsync(string platformName, string version, string debianFlavor)
+        public Task<string> RequestSdkFromAcrAsync(string platformName, string version, string debianFlavor)
         {
-            return Task.FromResult(false);
+            return Task.FromResult<string>(null);
         }
     }
 }

--- a/tests/Oryx.Tests.Common/TestExternalSdkProvider.cs
+++ b/tests/Oryx.Tests.Common/TestExternalSdkProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Oryx.Tests.Common
 {
     public class TestExternalSdkProvider : IExternalSdkProvider
     {
-        public const string ExternalSdksStorageDir = "/var/OryxSdksCache";
+        public const string ExternalSdksStorageDir = "/var/OryxSdks";
 
         public Task<XDocument> GetPlatformMetaDataAsync(string platformName)
         {


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the SDK acquisition logic from Azure Container Registry (ACR) and external providers, focusing on clarity, correctness, and flexibility. The most significant changes involve updating the contract and implementation for fetching SDK tarballs, improving installer interfaces, and cleaning up legacy or confusing code paths.
