### PR TITLE
ACR Sdk distribution: Cleanup startupscriptgenerator and fix image repo constants

### DIFF
--- a/src/BuildScriptGenerator.Common/SdkStorageConstants.cs
+++ b/src/BuildScriptGenerator.Common/SdkStorageConstants.cs
@@ -22,11 +22,23 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Common
         public const string LegacyDotnetRuntimeVersionMetadataName = "Runtime_version";
         public const string OsTypeMetadataName = "Os_type";
 
-        // ACR-based SDK distribution constants
+        // OCI image based SDK distribution constants
         public const string EnableExternalAcrSdkProviderKey = "ORYX_ENABLE_EXTERNAL_ACR_SDK_PROVIDER";
         public const string EnableAcrSdkProviderKey = "ORYX_ENABLE_ACR_SDK_PROVIDER";
         public const string AcrSdkRegistryUrlKeyName = "ORYX_ACR_SDK_REGISTRY_URL";
-        public const string DefaultAcrSdkRegistryUrl = "https://oryxacr.azurecr.io";
-        public const string AcrSdkRepositoryPrefix = "sdks";
+        public const string DefaultAcrSdkRegistryUrl = "https://mcr.microsoft.com";
+        public const string AcrSdkRepositoryPrefixKeyName = "ORYX_ACR_SDK_REPOSITORY_PREFIX";
+        public const string DefaultAcrSdkRepositoryPrefix = "oryx";
+
+        /// <summary>
+        /// Maps a platform name to its OCI SDK image repository path.
+        /// e.g. "nodejs" → "oryx/nodejs-sdk", "php" → "oryx/php-sdk".
+        /// Final image ref: mcr.microsoft.com/oryx/nodejs-sdk:bookworm-20.20.2
+        /// </summary>
+        public static string GetSdkImageRepository(string platformName, string prefix = null)
+        {
+            prefix = string.IsNullOrEmpty(prefix) ? DefaultAcrSdkRepositoryPrefix : prefix;
+            return $"{prefix}/{platformName}-sdk";
+        }
     }
 }

--- a/src/BuildScriptGenerator/AcrSdkProvider.cs
+++ b/src/BuildScriptGenerator/AcrSdkProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 debianFlavor = this.options.DebianFlavor ?? "bookworm";
             }
 
-            var repository = $"{SdkStorageConstants.AcrSdkRepositoryPrefix}/{platformName}";
+            var repository = SdkStorageConstants.GetSdkImageRepository(platformName, this.options.OryxAcrSdkRepositoryPrefix);
             var tag = $"{debianFlavor}-{version}";
             var blobName = $"{platformName}-{debianFlavor}-{version}.tar.gz";
 

--- a/src/BuildScriptGenerator/AcrVersionProviderBase.cs
+++ b/src/BuildScriptGenerator/AcrVersionProviderBase.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
     {
         private readonly ILogger logger;
         private readonly string debianFlavor;
+        private readonly string repositoryPrefix;
 
         public AcrVersionProviderBase(
             IOptions<BuildScriptGeneratorOptions> commonOptions,
@@ -32,6 +33,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             var options = commonOptions.Value;
             this.logger = loggerFactory.CreateLogger(this.GetType());
             this.debianFlavor = options.DebianFlavor;
+            this.repositoryPrefix = options.OryxAcrSdkRepositoryPrefix;
 
             var registryUrl = string.IsNullOrEmpty(options.OryxAcrSdkRegistryUrl)
                 ? SdkStorageConstants.DefaultAcrSdkRegistryUrl
@@ -50,7 +52,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
             string platformName,
             Dictionary<string, string> defaultVersionPerFlavor)
         {
-            var repository = $"{SdkStorageConstants.AcrSdkRepositoryPrefix}/{platformName}";
+            var repository = SdkStorageConstants.GetSdkImageRepository(platformName, this.repositoryPrefix);
 
             this.logger.LogDebug("Getting available versions for {platformName} from ACR repository {repository}.", platformName, repository);
 

--- a/src/BuildScriptGenerator/DotNetCore/VersionProviders/DotNetCoreAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/DotNetCore/VersionProviders/DotNetCoreAcrVersionProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
                 return;
             }
 
-            var repository = $"{SdkStorageConstants.AcrSdkRepositoryPrefix}/{DotNetCoreConstants.PlatformName}";
+            var repository = SdkStorageConstants.GetSdkImageRepository(DotNetCoreConstants.PlatformName, this.commonOptions.OryxAcrSdkRepositoryPrefix);
             var debianFlavor = this.commonOptions.DebianFlavor;
 
             this.GetVersionInfoFromTags(repository, debianFlavor);

--- a/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
+++ b/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
@@ -112,9 +112,15 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         public bool EnableAcrSdkProvider { get; set; }
 
         /// <summary>
-        /// Gets or sets the base URL of the ACR registry hosting SDK images.
-        /// e.g. "https://oryxsdks.azurecr.io"
+        /// Gets or sets the base URL of the OCI registry hosting SDK images.
+        /// e.g. "https://mcr.microsoft.com"
         /// </summary>
         public string OryxAcrSdkRegistryUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the repository prefix for SDK images in the OCI registry.
+        /// e.g. "oryx" produces images like {registry}/oryx/node-sdk:{tag}.
+        /// </summary>
+        public string OryxAcrSdkRepositoryPrefix { get; set; }
     }
 }

--- a/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
             options.EnableExternalAcrSdkProvider = !options.EnableMultiPlatformBuild && this.GetBooleanValue(SettingsKeys.EnableExternalAcrSdkProvider);
             options.EnableAcrSdkProvider = this.GetBooleanValue(SettingsKeys.EnableAcrSdkProvider);
             options.OryxAcrSdkRegistryUrl = this.GetStringValue(SettingsKeys.OryxAcrSdkRegistryUrl);
+            options.OryxAcrSdkRepositoryPrefix = this.GetStringValue(SettingsKeys.OryxAcrSdkRepositoryPrefix);
 
             var dynamicInstallRootDir = this.GetStringValue(SettingsKeys.DynamicInstallRootDir);
 

--- a/src/BuildScriptGeneratorCli/SettingsKeys.cs
+++ b/src/BuildScriptGeneratorCli/SettingsKeys.cs
@@ -78,5 +78,6 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
         public const string EnableExternalAcrSdkProvider = "ORYX_ENABLE_EXTERNAL_ACR_SDK_PROVIDER";
         public const string EnableAcrSdkProvider = "ORYX_ENABLE_ACR_SDK_PROVIDER";
         public const string OryxAcrSdkRegistryUrl = "ORYX_ACR_SDK_REGISTRY_URL";
+        public const string OryxAcrSdkRepositoryPrefix = "ORYX_ACR_SDK_REPOSITORY_PREFIX";
     }
 }

--- a/src/startupscriptgenerator/src/common/consts/sdk_storage_constants.go
+++ b/src/startupscriptgenerator/src/common/consts/sdk_storage_constants.go
@@ -18,10 +18,3 @@ const LegacySdkVersionMetadataName string = "Version"
 const DotnetRuntimeVersionMetadataName string = "Dotnet_runtime_version"
 const LegacyDotnetRuntimeVersionMetadataName string = "Runtime_version"
 const OsTypeMetadataName string = "Os_type"
-
-// ACR-based SDK distribution constants
-const EnableExternalAcrSdkProviderKey string = "ORYX_ENABLE_EXTERNAL_ACR_SDK_PROVIDER"
-const EnableAcrSdkProviderKey string = "ORYX_ENABLE_ACR_SDK_PROVIDER"
-const AcrSdkRegistryUrlKeyName string = "ORYX_ACR_SDK_REGISTRY_URL"
-const DefaultAcrSdkRegistryUrl string = "https://oryxacr.azurecr.io"
-const AcrSdkRepositoryPrefix string = "sdks"

--- a/src/startupscriptgenerator/src/common/setupEnvironment.go
+++ b/src/startupscriptgenerator/src/common/setupEnvironment.go
@@ -38,14 +38,6 @@ func GetSetupScript(platformName string, version string, installationDir string)
 		return ""
 	}
 
-	// Check if ACR SDK provider is enabled (external or direct)
-	enableExternalAcrSdkProvider := os.Getenv(consts.EnableExternalAcrSdkProviderKey)
-	enableAcrSdkProvider := os.Getenv(consts.EnableAcrSdkProviderKey)
-	if strings.EqualFold(enableExternalAcrSdkProvider, "true") || enableExternalAcrSdkProvider == "1" ||
-		strings.EqualFold(enableAcrSdkProvider, "true") || enableAcrSdkProvider == "1" {
-		return GetAcrSetupScript(platformName, version, installationDir, sentinelFilePath)
-	}
-
 	sdkStorageBaseUrl := os.Getenv(consts.SdkStorageBaseUrlKeyName)
 	if sdkStorageBaseUrl == "" {
 		panic("Environment variable " + consts.SdkStorageBaseUrlKeyName + " is required.")
@@ -65,7 +57,7 @@ func GetSetupScript(platformName string, version string, installationDir string)
 	scriptBuilder.WriteString(fmt.Sprintf("cd %s\n", installationDir))
 	if debianFlavor == "" || debianFlavor == consts.DebianStretch {
 		scriptBuilder.WriteString(
-			fmt.Sprintf("curl --fail -D headers.txt -SL \"%s/%s/%s-%s.tar.gz%s\" --output %s\n",
+			fmt.Sprintf("curl -D headers.txt -SL \"%s/%s/%s-%s.tar.gz%s\" --output %s\n",
 				sdkStorageBaseUrl,
 				platformName,
 				platformName,
@@ -74,7 +66,7 @@ func GetSetupScript(platformName string, version string, installationDir string)
 				tarFile))
 	} else {
 		scriptBuilder.WriteString(
-			fmt.Sprintf("curl --fail -D headers.txt -SL \"%s/%s/%s-%s-%s.tar.gz%s\" --output %s\n",
+			fmt.Sprintf("curl -D headers.txt -SL \"%s/%s/%s-%s-%s.tar.gz%s\" --output %s\n",
 				sdkStorageBaseUrl,
 				platformName,
 				platformName,
@@ -99,85 +91,6 @@ func GetSetupScript(platformName string, version string, installationDir string)
 	scriptBuilder.WriteString(fmt.Sprintf("rm -f %s\n", tarFile))
 	scriptBuilder.WriteString(fmt.Sprintf("echo Done. Installed at '%s'\n", installationDir))
 	scriptBuilder.WriteString(fmt.Sprintf("rm -f %s\n", tarFile))
-	scriptBuilder.WriteString(fmt.Sprintf("echo > %s\n", sentinelFilePath))
-	scriptBuilder.WriteString("echo\n")
-	return scriptBuilder.String()
-}
-
-// GetAcrSetupScript generates a bash script to download an SDK from ACR using the OCI Distribution API.
-// The script uses curl to fetch the manifest, extract the layer digest, download the blob,
-// verify its SHA256 checksum, and extract the tarball.
-func GetAcrSetupScript(platformName string, version string, installationDir string, sentinelFilePath string) string {
-	acrRegistryUrl := os.Getenv(consts.AcrSdkRegistryUrlKeyName)
-	if acrRegistryUrl == "" {
-		acrRegistryUrl = consts.DefaultAcrSdkRegistryUrl
-	}
-
-	// Enforce HTTPS
-	if !strings.HasPrefix(acrRegistryUrl, "https://") {
-		panic(fmt.Sprintf("ACR registry URL must use HTTPS: '%s'", acrRegistryUrl))
-	}
-
-	// Remove trailing slash
-	acrRegistryUrl = strings.TrimRight(acrRegistryUrl, "/")
-
-	debianFlavor := os.Getenv(consts.DebianFlavor)
-	if debianFlavor == "" {
-		debianFlavor = "bookworm"
-	}
-
-	repository := fmt.Sprintf("%s/%s", consts.AcrSdkRepositoryPrefix, platformName)
-	tag := fmt.Sprintf("%s-%s", debianFlavor, version)
-
-	scriptBuilder := strings.Builder{}
-	scriptBuilder.WriteString("#!/bin/sh\n")
-	scriptBuilder.WriteString("set -e\n")
-	scriptBuilder.WriteString("echo\n")
-	scriptBuilder.WriteString(
-		fmt.Sprintf("echo Downloading '%s' version '%s' from ACR to '%s'...\n", platformName, version, installationDir))
-	scriptBuilder.WriteString(fmt.Sprintf("mkdir -p %s\n", installationDir))
-	scriptBuilder.WriteString(fmt.Sprintf("cd %s\n", installationDir))
-
-	// Fetch the OCI manifest (--fail ensures HTTP errors are not silently treated as content)
-	manifestUrl := fmt.Sprintf("%s/v2/%s/manifests/%s", acrRegistryUrl, repository, tag)
-	scriptBuilder.WriteString(fmt.Sprintf(
-		"echo Fetching OCI manifest from ACR for %s:%s...\n", repository, tag))
-	scriptBuilder.WriteString(fmt.Sprintf(
-		"MANIFEST=$(curl --fail -sSL -H 'Accept: application/vnd.oci.image.manifest.v1+json' '%s')\n", manifestUrl))
-
-	// Extract the layer digest (first/only layer in a FROM scratch image)
-	scriptBuilder.WriteString(
-		"LAYER_DIGEST=$(echo \"$MANIFEST\" | grep -o '\"digest\":\"sha256:[a-f0-9]*\"' | tail -1 | cut -d'\"' -f4)\n")
-	scriptBuilder.WriteString("if [ -z \"$LAYER_DIGEST\" ]; then\n")
-	scriptBuilder.WriteString("  echo 'ERROR: Could not extract layer digest from ACR manifest.'\n")
-	scriptBuilder.WriteString("  exit 1\n")
-	scriptBuilder.WriteString("fi\n")
-	scriptBuilder.WriteString("echo \"Layer digest: $LAYER_DIGEST\"\n")
-
-	// Extract expected SHA256 from digest
-	scriptBuilder.WriteString("EXPECTED_SHA256=$(echo \"$LAYER_DIGEST\" | cut -d':' -f2)\n")
-
-	// Download the layer blob
-	blobUrl := fmt.Sprintf("%s/v2/%s/blobs/", acrRegistryUrl, repository)
-	scriptBuilder.WriteString("echo Downloading SDK blob from ACR...\n")
-	scriptBuilder.WriteString(fmt.Sprintf(
-		"curl --fail -sSL '%s'\"$LAYER_DIGEST\" --output sdk.tar.gz\n", blobUrl))
-
-	// Verify SHA256 checksum
-	scriptBuilder.WriteString("echo Verifying SHA256 checksum...\n")
-	scriptBuilder.WriteString("ACTUAL_SHA256=$(sha256sum sdk.tar.gz | cut -d' ' -f1)\n")
-	scriptBuilder.WriteString("if [ \"$ACTUAL_SHA256\" != \"$EXPECTED_SHA256\" ]; then\n")
-	scriptBuilder.WriteString("  echo \"ERROR: SHA256 checksum mismatch. Expected: $EXPECTED_SHA256, Got: $ACTUAL_SHA256\"\n")
-	scriptBuilder.WriteString("  rm -f sdk.tar.gz\n")
-	scriptBuilder.WriteString("  exit 1\n")
-	scriptBuilder.WriteString("fi\n")
-	scriptBuilder.WriteString("echo Checksum verified.\n")
-
-	// Extract and clean up
-	scriptBuilder.WriteString("echo Extracting contents...\n")
-	scriptBuilder.WriteString("tar -xzf sdk.tar.gz -C .\n")
-	scriptBuilder.WriteString("rm -f sdk.tar.gz\n")
-	scriptBuilder.WriteString(fmt.Sprintf("echo Done. Installed at '%s' (from ACR)\n", installationDir))
 	scriptBuilder.WriteString(fmt.Sprintf("echo > %s\n", sentinelFilePath))
 	scriptBuilder.WriteString("echo\n")
 	return scriptBuilder.String()


### PR DESCRIPTION
This pull request refactors and simplifies how SDKs are fetched and referenced from container registries, It introduces new configuration options for repository prefixes, updates default registry URLs, and removes the Go implementation for fetching SDKs from ACR, consolidating SDK download logic.
