### PR TITLE
Add dotnet, php composer versions to constants file

### DIFF
--- a/images/constants.yml
+++ b/images/constants.yml
@@ -58,6 +58,9 @@ variables:
   NET_CORE_APP_90: 9.0.14
   NET_CORE_APP_90_SHA: db0db0b9e709ffe463dead94fb4e77b9b0c7086bbaa78a78aa6b5366bef77ba3c33899a81c3c1aef3c11027a1e6cdebf4a7ad30532bdc193f0decc71972e5dda
   NET_CORE_APP_100: "10.0.4"
+  DOTNET_SDK_80: 8.0.419
+  DOTNET_SDK_90: 9.0.312
+  DOTNET_SDK_100: 10.0.200
   node18Version: 18.20.8
   node20Version: 20.20.0
   node22Version: 22.22.0
@@ -72,6 +75,7 @@ variables:
   php84Version_SHA: f66f8f48db34e9e29f7bfd6901178e9cf4a1b163e6e497716dfcb8f88bcfae30
   php85Version: 8.5.1
   php85Version_SHA: 3f5bf99ce81201f526d25e288eddb2cfa111d068950d1e9a869530054ff98815
+  phpComposerVersion: 2.6.2
   python39Version: 3.9.24
   python310Version: 3.10.20
   python311Version: 3.11.15


### PR DESCRIPTION
This PR updates the constants file to include dotnet SDK and PHP Composer versions, as these are referenced during SDK image generation

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
