### PR TITLE
Fix dotnet runtime resolution for external acr provider

### DIFF
--- a/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
@@ -287,11 +287,27 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
             // 3. Try Direct-ACR (direct OCI API calls)
             if (this.commonOptions.EnableAcrSdkProvider)
             {
-                var runtimeVersion = dotNetCorePlatformDetectorResult.PlatformVersion;
-                var result = this.TryInstallFromAcrSdkProvider(sdkVersion, runtimeVersion);
-                if (result != null)
+                // DirectACR needs the exact runtime version for the tag (e.g. "10.0.4", not "10.0").
+                // If ExternalACR handled version resolution, PlatformVersion may still be raw.
+                // Try to resolve it — the version map is lazily loaded and cached.
+                // If resolution fails, skip DirectACR entirely and let next provider handle it.
+                try
                 {
-                    return result;
+                    var runtimeVersion = this.GetMaxSatisfyingRuntimeVersionAndVerify(
+                        dotNetCorePlatformDetectorResult.PlatformVersion);
+                    dotNetCorePlatformDetectorResult.PlatformVersion = runtimeVersion;
+
+                    var result = this.TryInstallFromAcrSdkProvider(sdkVersion, runtimeVersion);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    this.logger.LogWarning(
+                        ex,
+                        "Could not resolve runtime version for DirectACR. Skipping to next provider.");
                 }
             }
 
@@ -314,17 +330,14 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
                     $"'{typeof(DotNetCorePlatformDetectorResult)}' but got '{detectorResult.GetType()}'.");
             }
 
-            // Resolve runtime version (same for all flows — ExternalAcrSdkProvider does not affect this).
-            var resolvedRuntimeVersion = this.GetRuntimeVersionUsingHierarchicalRules(
-                dotNetCorePlatformDetectorResult.PlatformVersion);
-            resolvedRuntimeVersion = this.GetMaxSatisfyingRuntimeVersionAndVerify(resolvedRuntimeVersion);
-            dotNetCorePlatformDetectorResult.PlatformVersion = resolvedRuntimeVersion;
-
-            // Resolve SDK version.
-            // External ACR provider dictates the SDK version directly — no runtime→SDK lookup needed.
-            // This is .NET-specific: other platforms have a single version,
-            // but .NET has separate runtime and SDK versions. The external host already knows
-            // which SDK companion image to use, so we trust its SDK version.
+            // When External ACR is enabled, try it first — it dictates the SDK version
+            // directly, without needing the runtime→SDK version map from blob/CDN.
+            // The runtime version is expected to come from the user (--platform-version / DOTNET_VERSION)
+            // or from .csproj detection (<TargetFramework>). We use it as-is without
+            // validation against a version map — the external host already ensures
+            // compatibility between the runtime and the SDK it provides.
+            // If the SDK fetch later falls back to DirectACR, the runtime version is
+            // resolved on demand at that point
             if (this.commonOptions.EnableExternalAcrSdkProvider)
             {
                 try
@@ -335,6 +348,10 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
                         this.logger.LogInformation(
                             "External ACR provider returned .NET SDK version {Version}. Using it directly.",
                             dictatedSdk);
+
+                        var resolvedRuntime = this.GetRuntimeVersionUsingHierarchicalRules(
+                            dotNetCorePlatformDetectorResult.PlatformVersion);
+                        dotNetCorePlatformDetectorResult.PlatformVersion = resolvedRuntime;
                         dotNetCorePlatformDetectorResult.SdkVersion = dictatedSdk;
                         return;
                     }
@@ -347,7 +364,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
                 }
             }
 
-            // Normal SDK resolution: look up from runtime→SDK version map.
+            // Normal path: resolve runtime version using the version map, then look up SDK.
+            var resolvedRuntimeVersion = this.GetRuntimeVersionUsingHierarchicalRules(
+                dotNetCorePlatformDetectorResult.PlatformVersion);
+            resolvedRuntimeVersion = this.GetMaxSatisfyingRuntimeVersionAndVerify(resolvedRuntimeVersion);
+            dotNetCorePlatformDetectorResult.PlatformVersion = resolvedRuntimeVersion;
+
             var versionMap = this.versionProvider.GetSupportedVersions();
             var sdkVersion = this.GetSdkVersion(context, dotNetCorePlatformDetectorResult.PlatformVersion, versionMap);
             dotNetCorePlatformDetectorResult.SdkVersion = sdkVersion;

--- a/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCorePlatformTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCorePlatformTest.cs
@@ -172,13 +172,17 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
                 detector,
                 commonOptions: commonOptions,
                 sdkAlreadyInstalled: false,
-                acrSdkProvider: acrSdkProvider);
+                acrSdkProvider: acrSdkProvider,
+                supportedVersions: new Dictionary<string, string>
+                {
+                    { "3.1.32", "3.1.426" },
+                });
             var context = CreateContext();
             var detectorResult = new DotNetCorePlatformDetectorResult
             {
                 Platform = DotNetCoreConstants.PlatformName,
-                PlatformVersion = "3.1.2",
-                SdkVersion = "3.1.2",
+                PlatformVersion = "3.1.32",
+                SdkVersion = "3.1.426",
             };
 
             // Act
@@ -247,13 +251,17 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
                 sdkAlreadyInstalled: false,
                 externalAcrSdkProvider: externalAcrSdkProvider,
                 acrSdkProvider: acrSdkProvider,
-                externalSdkProvider: externalSdkProvider);
+                externalSdkProvider: externalSdkProvider,
+                supportedVersions: new Dictionary<string, string>
+                {
+                    { "3.1.32", "3.1.426" },
+                });
             var context = CreateContext();
             var detectorResult = new DotNetCorePlatformDetectorResult
             {
                 Platform = DotNetCoreConstants.PlatformName,
-                PlatformVersion = "3.1.2",
-                SdkVersion = "3.1.2",
+                PlatformVersion = "3.1.32",
+                SdkVersion = "3.1.426",
             };
 
             // Act
@@ -285,14 +293,14 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
                 acrSdkProvider: acrSdkProvider,
                 supportedVersions: new Dictionary<string, string>
                 {
-                    { "3.1.2", "3.1.2" },
+                    { "3.1.32", "3.1.426" },
                 });
             var context = CreateContext();
             var detectorResult = new DotNetCorePlatformDetectorResult
             {
                 Platform = DotNetCoreConstants.PlatformName,
-                PlatformVersion = "3.1.2",
-                SdkVersion = "3.1.2",
+                PlatformVersion = "3.1.32",
+                SdkVersion = "3.1.426",
             };
 
             // Act
@@ -302,9 +310,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
             Assert.NotNull(snippet);
             Assert.True(acrSdkProvider.RequestSdkFromAcrAsyncCalled);
             Assert.Equal(DotNetCoreConstants.PlatformName, acrSdkProvider.LastRequestedPlatformName);
-            Assert.Equal("3.1.2", acrSdkProvider.LastRequestedVersion);
+            Assert.Equal("3.1.426", acrSdkProvider.LastRequestedVersion);
             Assert.Equal(OsTypes.DebianBookworm, acrSdkProvider.LastRequestedDebianFlavor);
-            Assert.Equal("3.1.2", acrSdkProvider.LastRequestedRuntimeVersion);
+            Assert.Equal("3.1.32", acrSdkProvider.LastRequestedRuntimeVersion);
         }
 
         [Fact]
@@ -329,13 +337,17 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
                 sdkAlreadyInstalled: false,
                 externalAcrSdkProvider: externalAcrSdkProvider,
                 acrSdkProvider: acrSdkProvider,
-                externalSdkProvider: externalSdkProvider);
+                externalSdkProvider: externalSdkProvider,
+                supportedVersions: new Dictionary<string, string>
+                {
+                    { "3.1.32", "3.1.426" },
+                });
             var context = CreateContext();
             var detectorResult = new DotNetCorePlatformDetectorResult
             {
                 Platform = DotNetCoreConstants.PlatformName,
-                PlatformVersion = "3.1.2",
-                SdkVersion = "3.1.2",
+                PlatformVersion = "3.1.32",
+                SdkVersion = "3.1.426",
             };
 
             // Act
@@ -380,8 +392,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
             // Act
             platform.ResolveVersions(context, detectorResult);
 
-            // Assert - ExternalACR dictates SDK version, overriding normal map lookup
+            // Assert - ExternalACR dictates SDK version, overriding normal map lookup.
+            // PlatformVersion is only processed by hierarchical rules (not fully resolved
+            // against the version map), so it stays as the detected value.
             Assert.Equal("3.1.415", detectorResult.SdkVersion);
+            Assert.Equal("3.1", detectorResult.PlatformVersion);
         }
 
         [Fact]
@@ -416,8 +431,10 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
             // Act
             platform.ResolveVersions(context, detectorResult);
 
-            // Assert - Falls back to normal version map
+            // Assert - Falls back to normal version map.
+            // PlatformVersion is fully resolved (hierarchical rules + version map).
             Assert.Equal("3.1.302", detectorResult.SdkVersion);
+            Assert.Equal("3.1.2", detectorResult.PlatformVersion);
         }
 
         private BuildScriptGeneratorContext CreateContext(ISourceRepo sourceRepo = null)


### PR DESCRIPTION
This pull request refines the version resolution logic for .NET Core platform detection and installation, especially when using ACR (Azure Container Registry) providers. It clarifies how runtime and SDK versions are resolved depending on which provider is enabled, and updates the test suite to ensure the new logic is validated. The main focus is to ensure that version mapping and fallback behaviors are correct and transparent.

**.NET Core version resolution logic:**

* When the External ACR SDK provider is enabled, the SDK version is taken directly from the provider, and the runtime version is only minimally processed (not fully resolved against the version map). [[1]](diffhunk://#diff-a5bdaee0d5527530b84ab42d5fc872408cdf7d3fbd416c31b13ac50dd3ced562L317-R340) [[2]](diffhunk://#diff-a5bdaee0d5527530b84ab42d5fc872408cdf7d3fbd416c31b13ac50dd3ced562R351-R354)
* For Direct ACR, the runtime version is resolved on demand using the version map to ensure the tag is exact (e.g., "10.0.4" instead of "10.0"). If resolution fails, the process skips Direct ACR and falls back to the next provider.
* If neither ACR provider is available or successful, the normal version resolution path is followed: the runtime version is fully resolved using hierarchical rules and the version map, then the SDK version is determined.

**Test updates:**

* Unit tests have been updated to use more realistic version pairs (e.g., "3.1.32" for runtime and "3.1.426" for SDK) and to verify that the correct versions are passed to providers and set in results. [[1]](diffhunk://#diff-2f0ababf2f961f228d92a7e380b2a0fd460e70a1f65cf694fb3b0dbec51af7c1L175-R185) [[2]](diffhunk://#diff-2f0ababf2f961f228d92a7e380b2a0fd460e70a1f65cf694fb3b0dbec51af7c1L250-R264) [[3]](diffhunk://#diff-2f0ababf2f961f228d92a7e380b2a0fd460e70a1f65cf694fb3b0dbec51af7c1L288-R303) [[4]](diffhunk://#diff-2f0ababf2f961f228d92a7e380b2a0fd460e70a1f65cf694fb3b0dbec51af7c1L305-R315) [[5]](diffhunk://#diff-2f0ababf2f961f228d92a7e380b2a0fd460e70a1f65cf694fb3b0dbec51af7c1L332-R350)
* Tests now assert the expected behavior for version resolution and fallback, including the distinction between hierarchical-only and fully resolved runtime versions, depending on the provider path taken. [[1]](diffhunk://#diff-2f0ababf2f961f228d92a7e380b2a0fd460e70a1f65cf694fb3b0dbec51af7c1L383-R399) [[2]](diffhunk://#diff-2f0ababf2f961f228d92a7e380b2a0fd460e70a1f65cf694fb3b0dbec51af7c1L419-R437)