### PR TITLE
Fix php composer version resolution flow

### DIFF
--- a/src/BuildScriptGenerator/Php/PhpPlatform.cs
+++ b/src/BuildScriptGenerator/Php/PhpPlatform.cs
@@ -617,20 +617,9 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
 
             string ResolvePhpComposerVersion(string detectedVersion)
             {
-                // If external ACR provider is enabled, resolve version from the composer version provider.
-                // Note: Unlike PHP, Composer versions are hardcoded locally in PhpVersions.ComposerVersionsPerDebianFlavor
-                // rather than fetched from the external host. The provider still uses the same pattern for consistency.
-                if (this.commonOptions.EnableExternalAcrSdkProvider)
-                {
-                    var acrVersionInfo = this.phpComposerVersionProvider.GetVersionInfo();
-                    if (acrVersionInfo?.DefaultVersion != null)
-                    {
-                        this.logger.LogDebug("External ACR SDK provider is enabled and returned version {version} for PHP Composer.", acrVersionInfo.DefaultVersion);
-                        return acrVersionInfo.DefaultVersion;
-                    }
-                }
-
-                // Explicitly specified version by user wins over detected version
+                // Explicitly specified version by user wins over detected version and any provider default.
+                // This is an exception only for php-composer to allow users to override the composer version
+                // even when external acr provider is enabled
                 if (!string.IsNullOrEmpty(this.phpScriptGeneratorOptions.PhpComposerVersion))
                 {
                     return this.phpScriptGeneratorOptions.PhpComposerVersion;
@@ -646,6 +635,19 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
                 if (!string.IsNullOrEmpty(this.phpScriptGeneratorOptions.PhpComposerDefaultVersion))
                 {
                     return this.phpScriptGeneratorOptions.PhpComposerDefaultVersion;
+                }
+
+                // If external ACR provider is enabled, fall back to the default from the composer version provider.
+                // Note: Unlike PHP, Composer versions are hardcoded locally in PhpVersions.ComposerVersionsPerDebianFlavor
+                // rather than fetched from the external host. The provider still uses the same pattern for consistency.
+                if (this.commonOptions.EnableExternalAcrSdkProvider)
+                {
+                    var acrVersionInfo = this.phpComposerVersionProvider.GetVersionInfo();
+                    if (acrVersionInfo?.DefaultVersion != null)
+                    {
+                        this.logger.LogDebug("External ACR SDK provider is enabled and returned version {version} for PHP Composer.", acrVersionInfo.DefaultVersion);
+                        return acrVersionInfo.DefaultVersion;
+                    }
                 }
 
                 // Fallback to default version detection

--- a/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
@@ -915,6 +915,41 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
             Assert.Equal(versionProviderDefault, result.PlatformVersion);
         }
 
+        [Fact]
+        public void Detect_UserSpecifiedComposerVersion_WinsOverExternalAcrProviderDefault()
+        {
+            // Arrange
+            var userSpecifiedComposerVersion = "2.5.8";
+            var acrProviderDefaultComposerVersion = "2.0.0";
+            var repo = new MemorySourceRepo();
+            repo.AddFile("{}", PhpConstants.ComposerFileName);
+            repo.AddFile("<?php echo true; ?>", "foo.php");
+            var context = CreateContext(repo);
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                EnableExternalAcrSdkProvider = true,
+            };
+            var phpScriptGeneratorOptions = new PhpScriptGeneratorOptions
+            {
+                PhpComposerVersion = userSpecifiedComposerVersion,
+            };
+            var platform = CreatePhpPlatform(
+                supportedPhpVersions: new[] { "7.3.5" },
+                defaultVersion: "7.3.5",
+                detectedVersion: "7.3.5",
+                supportedPhpComposerVersions: new[] { userSpecifiedComposerVersion, acrProviderDefaultComposerVersion },
+                defaultComposerVersion: acrProviderDefaultComposerVersion,
+                commonOptions: commonOptions,
+                phpScriptGeneratorOptions: phpScriptGeneratorOptions);
+
+            // Act
+            var result = platform.Detect(context) as PhpPlatformDetectorResult;
+
+            // Assert - user-specified PHP_COMPOSER_VERSION must win over the ACR provider default
+            Assert.NotNull(result);
+            Assert.Equal(userSpecifiedComposerVersion, result.PhpComposerVersion);
+        }
+
         [Theory]
         [InlineData(null, "7.4.30", null, "7.4.30")]
         [InlineData(null, "7.4.30", "7.3.1", "7.4.30")]


### PR DESCRIPTION
This pull request updates the logic for resolving the PHP Composer version in the build script generator to ensure that a user-specified Composer version always takes precedence over the external ACR provider default, even when the provider is enabled. Additionally, a new test is added to verify this behavior.

