### PR TITLE
Add FastAPI framework support to Oryx

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -45,3 +45,23 @@ jobs:
 
       - name: Run BuildServer.Tests
         run: dotnet test tests/BuildServer.Tests/BuildServer.Tests.csproj --no-build --configuration Release --verbosity normal
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Run Startup Script Generator Tests
+        run: |
+          cd src/startupscriptgenerator/src
+          GOROOT=$(go env GOROOT)
+          cp -r common "$GOROOT/src/common"
+          for dir in */; do
+            if [ -f "$dir/go.mod" ]; then
+              echo "Building and testing $dir..."
+              cd "$dir"
+              go mod tidy
+              go test -v ./...
+              cd ..
+            fi
+          done

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -52,16 +52,18 @@ jobs:
           go-version: '1.25.7'
 
       - name: Run Startup Script Generator Tests
+        env:
+          GOTOOLCHAIN: local
         run: |
           cd src/startupscriptgenerator/src
           COMMON_DIR=$(pwd)/common
+          GOROOT_DIR=$(go env GOROOT)
+          cp -r "$COMMON_DIR" "$GOROOT_DIR/src/common"
           for dir in */; do
             if [ -f "$dir/go.mod" ]; then
               echo "Building and testing $dir..."
               cd "$dir"
               go mod tidy
-              EFFECTIVE_GOROOT=$(go env GOROOT)
-              cp -r "$COMMON_DIR" "$EFFECTIVE_GOROOT/src/common"
               go test -v ./...
               cd ..
             fi

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -49,21 +49,22 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.7'
+          go-version: '1.26'
 
       - name: Run Startup Script Generator Tests
         env:
           GOTOOLCHAIN: local
         run: |
           cd src/startupscriptgenerator/src
-          COMMON_DIR=$(pwd)/common
           GOROOT_DIR=$(go env GOROOT)
-          cp -r "$COMMON_DIR" "$GOROOT_DIR/src/common"
+          cp -r "$(pwd)/common" "$GOROOT_DIR/src/common"
           for dir in */; do
+            if [ "$dir" = "common/" ]; then
+              continue
+            fi
             if [ -f "$dir/go.mod" ]; then
-              echo "Building and testing $dir..."
+              echo "Testing $dir..."
               cd "$dir"
-              go mod tidy
               go test -v ./...
               cd ..
             fi

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -49,18 +49,19 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
 
       - name: Run Startup Script Generator Tests
         run: |
           cd src/startupscriptgenerator/src
-          GOROOT=$(go env GOROOT)
-          cp -r common "$GOROOT/src/common"
+          COMMON_DIR=$(pwd)/common
           for dir in */; do
             if [ -f "$dir/go.mod" ]; then
               echo "Building and testing $dir..."
               cd "$dir"
               go mod tidy
+              EFFECTIVE_GOROOT=$(go env GOROOT)
+              cp -r "$COMMON_DIR" "$EFFECTIVE_GOROOT/src/common"
               go test -v ./...
               cd ..
             fi

--- a/build/constants.yaml
+++ b/build/constants.yaml
@@ -25,6 +25,7 @@
     python-gunicorn-config-path-env-var-name: PYTHON_USE_GUNICORN_CONFIG_FROM_PATH
     python-gunicorn-custom-worker-num: PYTHON_GUNICORN_CUSTOM_WORKER_NUM
     python-gunicorn-custom-thread-num: PYTHON_GUNICORN_CUSTOM_THREAD_NUM
+    python-disable-fastapi-detection-env-var-name: DISABLE_FASTAPI_DETECTION
     nginx-conf-file: NGINX_CONF_FILE
   outputs:
   - type: csharp

--- a/images/runtime/python/noble.Dockerfile
+++ b/images/runtime/python/noble.Dockerfile
@@ -78,7 +78,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/oryx

--- a/images/runtime/python/noble.Dockerfile
+++ b/images/runtime/python/noble.Dockerfile
@@ -78,7 +78,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/oryx

--- a/images/runtime/python/noble.Dockerfile
+++ b/images/runtime/python/noble.Dockerfile
@@ -78,7 +78,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/oryx

--- a/images/runtime/python/noble.Dockerfile
+++ b/images/runtime/python/noble.Dockerfile
@@ -78,7 +78,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker==0.4.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/oryx

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -16,27 +16,10 @@ ENV BUILD_NUMBER=${BUILD_NUMBER}
 ENV PATH_CA_CERTIFICATE="/etc/ssl/certs/ca-certificate.crt"
 RUN chmod +x build.sh && ./build.sh python /opt/startupcmdgen/startupcmdgen
 
-# Build Python SDK from source in a disposable stage
-FROM ${BASE_IMAGE} AS pythonSdkBuilder
-ARG DEBIAN_FLAVOR
-ARG PYTHON_FULL_VERSION
-ARG PYTHON_VERSION
-ENV PYTHON_VERSION=${PYTHON_FULL_VERSION}
-COPY platforms/python/prereqs/build.sh /tmp/build.sh
-COPY platforms/python/versions/${DEBIAN_FLAVOR}/versionsToBuild.txt /tmp/versionsToBuild.txt
-COPY images/receiveGpgKeys.sh /tmp/receiveGpgKeys.sh
-RUN chmod +x /tmp/build.sh /tmp/receiveGpgKeys.sh
-RUN set -e \
-    && mkdir -p /usr/src/python && cd /usr/src/python \
-    && VERSION_LINE=$(grep "^${PYTHON_VERSION}," /tmp/versionsToBuild.txt) \
-    && export GPG_KEY=$(echo "$VERSION_LINE" | cut -d',' -f2 | tr -d ' ') \
-    && export PYTHON_SHA256=$(echo "$VERSION_LINE" | cut -d',' -f3 | tr -d ' ') \
-    && export OS_FLAVOR=${DEBIAN_FLAVOR} \
-    && /tmp/build.sh
-
 FROM ${BASE_IMAGE} as main
 
 ARG IMAGES_DIR=/tmp/oryx/images
+ARG BUILD_DIR=/tmp/oryx/build
 ARG SDK_STORAGE_BASE_URL_VALUE
 
 ARG DEBIAN_FLAVOR
@@ -52,15 +35,34 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ADD images ${IMAGES_DIR}
+ADD build ${BUILD_DIR}
 RUN find ${IMAGES_DIR} -type f -iname "*.sh" -exec chmod +x {} \;
+RUN find ${BUILD_DIR} -type f -iname "*.sh" -exec chmod +x {} \;
 
 ARG PYTHON_FULL_VERSION
 ARG PYTHON_VERSION
 ARG PYTHON_MAJOR_VERSION
 
 ENV PYTHON_VERSION ${PYTHON_FULL_VERSION}
+RUN true
+# COPY build/__pythonVersions.sh ${BUILD_DIR}
+# RUN true
+COPY platforms/__common.sh /tmp/
+RUN true
+COPY platforms/python/prereqs/build.sh /tmp/
+RUN true
+COPY platforms/python/versions/${DEBIAN_FLAVOR}/versionsToBuild.txt /tmp/
+RUN true
+COPY images/receiveGpgKeys.sh /tmp/receiveGpgKeys.sh
+RUN true
 
-COPY --from=pythonSdkBuilder /opt/python/${PYTHON_FULL_VERSION} /opt/python/${PYTHON_FULL_VERSION}
+RUN chmod +x /tmp/receiveGpgKeys.sh
+RUN chmod +x /tmp/build.sh
+
+RUN --mount=type=secret,id=oryx_sdk_storage_account_access_token \
+    set -e \
+    && export ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN_PATH="/run/secrets/oryx_sdk_storage_account_access_token" \
+    && ${BUILD_DIR}/buildPythonSdkByVersion.sh $PYTHON_VERSION $DEBIAN_FLAVOR
 
 RUN set -ex \
  && cd /opt/python/ \
@@ -89,7 +91,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker==0.4.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     if [ "${PYTHON_VERSION}" != "3.12" ] && [ "${PYTHON_VERSION}" != "3.7" ]; then pip install --index-url $(cat /run/secrets/pip_index_url) orjson==3.10.7; fi && \
     if [ "${PYTHON_VERSION}" = "3.7" ] || [ "${PYTHON_VERSION}" = "3.8" ]; then curl -LO http://ftp.de.debian.org/debian/pool/main/libf/libffi/libffi6_3.2.1-9_amd64.deb \
     && dpkg -i libffi6_3.2.1-9_amd64.deb \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -102,7 +102,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     if [ "${PYTHON_VERSION}" != "3.12" ] && [ "${PYTHON_VERSION}" != "3.7" ]; then pip install --index-url $(cat /run/secrets/pip_index_url) orjson==3.10.7; fi && \
     if [ "${PYTHON_VERSION}" = "3.7" ] || [ "${PYTHON_VERSION}" = "3.8" ]; then curl -LO http://ftp.de.debian.org/debian/pool/main/libf/libffi/libffi6_3.2.1-9_amd64.deb \
     && dpkg -i libffi6_3.2.1-9_amd64.deb \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -91,7 +91,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker==0.4.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     if [ "${PYTHON_VERSION}" != "3.12" ] && [ "${PYTHON_VERSION}" != "3.7" ]; then pip install --index-url $(cat /run/secrets/pip_index_url) orjson==3.10.7; fi && \
     if [ "${PYTHON_VERSION}" = "3.7" ] || [ "${PYTHON_VERSION}" = "3.8" ]; then curl -LO http://ftp.de.debian.org/debian/pool/main/libf/libffi/libffi6_3.2.1-9_amd64.deb \
     && dpkg -i libffi6_3.2.1-9_amd64.deb \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -89,7 +89,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker==0.4.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     if [ "${PYTHON_VERSION}" != "3.12" ] && [ "${PYTHON_VERSION}" != "3.7" ]; then pip install --index-url $(cat /run/secrets/pip_index_url) orjson==3.10.7; fi && \
     if [ "${PYTHON_VERSION}" = "3.7" ] || [ "${PYTHON_VERSION}" = "3.8" ]; then curl -LO http://ftp.de.debian.org/debian/pool/main/libf/libffi/libffi6_3.2.1-9_amd64.deb \
     && dpkg -i libffi6_3.2.1-9_amd64.deb \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -91,7 +91,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     if [ "${PYTHON_VERSION}" != "3.12" ] && [ "${PYTHON_VERSION}" != "3.7" ]; then pip install --index-url $(cat /run/secrets/pip_index_url) orjson==3.10.7; fi && \
     if [ "${PYTHON_VERSION}" = "3.7" ] || [ "${PYTHON_VERSION}" = "3.8" ]; then curl -LO http://ftp.de.debian.org/debian/pool/main/libf/libffi/libffi6_3.2.1-9_amd64.deb \
     && dpkg -i libffi6_3.2.1-9_amd64.deb \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -91,7 +91,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     if [ "${PYTHON_VERSION}" != "3.12" ] && [ "${PYTHON_VERSION}" != "3.7" ]; then pip install --index-url $(cat /run/secrets/pip_index_url) orjson==3.10.7; fi && \
     if [ "${PYTHON_VERSION}" = "3.7" ] || [ "${PYTHON_VERSION}" = "3.8" ]; then curl -LO http://ftp.de.debian.org/debian/pool/main/libf/libffi/libffi6_3.2.1-9_amd64.deb \
     && dpkg -i libffi6_3.2.1-9_amd64.deb \

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -16,10 +16,27 @@ ENV BUILD_NUMBER=${BUILD_NUMBER}
 ENV PATH_CA_CERTIFICATE="/etc/ssl/certs/ca-certificate.crt"
 RUN chmod +x build.sh && ./build.sh python /opt/startupcmdgen/startupcmdgen
 
+# Build Python SDK from source in a disposable stage
+FROM ${BASE_IMAGE} AS pythonSdkBuilder
+ARG DEBIAN_FLAVOR
+ARG PYTHON_FULL_VERSION
+ARG PYTHON_VERSION
+ENV PYTHON_VERSION=${PYTHON_FULL_VERSION}
+COPY platforms/python/prereqs/build.sh /tmp/build.sh
+COPY platforms/python/versions/${DEBIAN_FLAVOR}/versionsToBuild.txt /tmp/versionsToBuild.txt
+COPY images/receiveGpgKeys.sh /tmp/receiveGpgKeys.sh
+RUN chmod +x /tmp/build.sh /tmp/receiveGpgKeys.sh
+RUN set -e \
+    && mkdir -p /usr/src/python && cd /usr/src/python \
+    && VERSION_LINE=$(grep "^${PYTHON_VERSION}," /tmp/versionsToBuild.txt) \
+    && export GPG_KEY=$(echo "$VERSION_LINE" | cut -d',' -f2 | tr -d ' ') \
+    && export PYTHON_SHA256=$(echo "$VERSION_LINE" | cut -d',' -f3 | tr -d ' ') \
+    && export OS_FLAVOR=${DEBIAN_FLAVOR} \
+    && /tmp/build.sh
+
 FROM ${BASE_IMAGE} as main
 
 ARG IMAGES_DIR=/tmp/oryx/images
-ARG BUILD_DIR=/tmp/oryx/build
 ARG SDK_STORAGE_BASE_URL_VALUE
 
 ARG DEBIAN_FLAVOR
@@ -35,34 +52,15 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ADD images ${IMAGES_DIR}
-ADD build ${BUILD_DIR}
 RUN find ${IMAGES_DIR} -type f -iname "*.sh" -exec chmod +x {} \;
-RUN find ${BUILD_DIR} -type f -iname "*.sh" -exec chmod +x {} \;
 
 ARG PYTHON_FULL_VERSION
 ARG PYTHON_VERSION
 ARG PYTHON_MAJOR_VERSION
 
 ENV PYTHON_VERSION ${PYTHON_FULL_VERSION}
-RUN true
-# COPY build/__pythonVersions.sh ${BUILD_DIR}
-# RUN true
-COPY platforms/__common.sh /tmp/
-RUN true
-COPY platforms/python/prereqs/build.sh /tmp/
-RUN true
-COPY platforms/python/versions/${DEBIAN_FLAVOR}/versionsToBuild.txt /tmp/
-RUN true
-COPY images/receiveGpgKeys.sh /tmp/receiveGpgKeys.sh
-RUN true
 
-RUN chmod +x /tmp/receiveGpgKeys.sh
-RUN chmod +x /tmp/build.sh
-
-RUN --mount=type=secret,id=oryx_sdk_storage_account_access_token \
-    set -e \
-    && export ORYX_SDK_STORAGE_ACCOUNT_ACCESS_TOKEN_PATH="/run/secrets/oryx_sdk_storage_account_access_token" \
-    && ${BUILD_DIR}/buildPythonSdkByVersion.sh $PYTHON_VERSION $DEBIAN_FLAVOR
+COPY --from=pythonSdkBuilder /opt/python/${PYTHON_FULL_VERSION} /opt/python/${PYTHON_FULL_VERSION}
 
 RUN set -ex \
  && cd /opt/python/ \
@@ -91,7 +89,7 @@ LABEL io.buildpacks.stack.id="oryx.stacks.skeleton"
 RUN ${IMAGES_DIR}/runtime/python/install-dependencies.sh
 RUN --mount=type=secret,id=pip_index_url,target=/run/secrets/pip_index_url \
     pip install --index-url $(cat /run/secrets/pip_index_url) --upgrade pip && \
-    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
+    pip install --index-url $(cat /run/secrets/pip_index_url) gunicorn uvicorn==0.46.0 uvicorn-worker==0.4.0 debugpy viztracer==0.15.6 vizplugins==0.1.3 && \
     if [ "${PYTHON_VERSION}" != "3.12" ] && [ "${PYTHON_VERSION}" != "3.7" ]; then pip install --index-url $(cat /run/secrets/pip_index_url) orjson==3.10.7; fi && \
     if [ "${PYTHON_VERSION}" = "3.7" ] || [ "${PYTHON_VERSION}" = "3.8" ]; then curl -LO http://ftp.de.debian.org/debian/pool/main/libf/libffi/libffi6_3.2.1-9_amd64.deb \
     && dpkg -i libffi6_3.2.1-9_amd64.deb \

--- a/src/startupscriptgenerator/src/common/consts/ext_var_names.go
+++ b/src/startupscriptgenerator/src/common/consts/ext_var_names.go
@@ -27,4 +27,5 @@ const PythonEnableGunicornMultiWorkersEnvVarName string = "PYTHON_ENABLE_GUNICOR
 const PythonGunicornConfigPathEnvVarName string = "PYTHON_USE_GUNICORN_CONFIG_FROM_PATH"
 const PythonGunicornCustomWorkerNum string = "PYTHON_GUNICORN_CUSTOM_WORKER_NUM"
 const PythonGunicornCustomThreadNum string = "PYTHON_GUNICORN_CUSTOM_THREAD_NUM"
+const PythonDisableFastAPIDetectionEnvVarName string = "DISABLE_FASTAPI_DETECTION"
 const NginxConfFile string = "NGINX_CONF_FILE"

--- a/src/startupscriptgenerator/src/node/scriptgenerator_test.go
+++ b/src/startupscriptgenerator/src/node/scriptgenerator_test.go
@@ -132,7 +132,7 @@ func ExampleNodeStartupScriptGenerator_getStartupCommandFromJsFile_simpleNodeCom
 	// node a/b/c.js
 }
 
-func ExampleNodeStartupScriptGenerator_getConfigJsCommand_returnsEmptyString_WhenUsePm2IsFalse(t *testing.T) {
+func TestNodeStartupScriptGenerator_getConfigJsCommand_returnsEmptyString_WhenUsePm2IsFalse(t *testing.T) {
 	gen := &NodeStartupScriptGenerator{
 		UsePm2: false,
 	}
@@ -140,7 +140,7 @@ func ExampleNodeStartupScriptGenerator_getConfigJsCommand_returnsEmptyString_Whe
 	assert.Empty(t, command)
 }
 
-func ExampleNodeStartupScriptGenerator_getConfigYamlCommand_returnsEmptyString_WhenUsePm2IsFalse(t *testing.T) {
+func TestNodeStartupScriptGenerator_getConfigYamlCommand_returnsEmptyString_WhenUsePm2IsFalse(t *testing.T) {
 	gen := &NodeStartupScriptGenerator{
 		UsePm2: false,
 	}

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -199,7 +199,7 @@ func (detector *fastAPIDetector) detect() bool {
 
 		hasImport := strings.Contains(contentStr, "from fastapi") ||
 			strings.Contains(contentStr, "import fastapi")
-		hasFlask := strings.Contains(contentStr, "flask")
+		hasFlask := strings.Contains(contentStr, "from flask")
 
 		if hasImport && !hasFlask {
 			logger.LogInformation("Detected FastAPI app in '%s'.", file)

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -176,8 +176,7 @@ func (detector *fastAPIDetector) detect() bool {
 
 		contentStr := string(content)
 		if strings.Contains(contentStr, "from fastapi import") ||
-			strings.Contains(contentStr, "from fastapi\nimport") ||
-			strings.Contains(contentStr, "FastAPI()") {
+			strings.Contains(contentStr, "FastAPI(") {
 			logger.LogInformation("Detected FastAPI app in '%s'.", file)
 			detector.mainFile = file
 			return true

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -154,8 +154,8 @@ func (detector *fastAPIDetector) Name() string {
 }
 
 // Checks if the app is based on FastAPI:
-// Returns true if there's a Python file in the app's root that imports FastAPI.
-// Looks for 'from fastapi import' or 'FastAPI()' in common entry point files.
+// Returns true if a common entrypoint file both imports the fastapi package
+// AND creates a FastAPI application instance.
 func (detector *fastAPIDetector) detect() bool {
 	logger := common.GetLogger("python.frameworks.fastAPIDetector.detect")
 	defer logger.Shutdown()
@@ -175,8 +175,15 @@ func (detector *fastAPIDetector) detect() bool {
 		}
 
 		contentStr := string(content)
-		if strings.Contains(contentStr, "from fastapi import") ||
-			strings.Contains(contentStr, "FastAPI(") {
+
+		// Condition A: file imports the fastapi package
+		hasImport := strings.Contains(contentStr, "from fastapi") ||
+			strings.Contains(contentStr, "import fastapi")
+
+		// Condition B: file creates a FastAPI app instance
+		hasAppCreation := strings.Contains(contentStr, "FastAPI(")
+
+		if hasImport && hasAppCreation {
 			logger.LogInformation("Detected FastAPI app in '%s'.", file)
 			detector.mainFile = file
 			return true

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"common"
+	"common/consts"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -36,7 +37,7 @@ type fastAPIDetector struct {
 	mainFile	string
 }
 
-func DetectFramework(appPath string, venvName string) PyAppFramework {
+func DetectFramework(appPath string, venvName string, pythonVersion string) PyAppFramework {
 	var detector PyAppFramework
 
 	detector = &djangoDetector{ appPath: appPath, venvName: venvName }
@@ -44,9 +45,12 @@ func DetectFramework(appPath string, venvName string) PyAppFramework {
 		return detector
 	}
 
-	detector = &fastAPIDetector{ appPath: appPath }
-	if detector.detect() {
-		return detector
+	if isPythonVersionAtLeast(pythonVersion, 3, 14) &&
+		!common.GetBooleanEnvironmentVariable(consts.PythonDisableFastAPIDetectionEnvVarName) {
+		detector = &fastAPIDetector{ appPath: appPath }
+		if detector.detect() {
+			return detector
+		}
 	}
 
 	detector = &flaskDetector{ appPath: appPath }
@@ -55,6 +59,23 @@ func DetectFramework(appPath string, venvName string) PyAppFramework {
 	}
 
 	return nil
+}
+
+// isPythonVersionAtLeast checks whether the given version string (e.g. "3.14.1")
+// is at least major.minor.
+func isPythonVersionAtLeast(version string, major int, minor int) bool {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	var maj, min int
+	if _, err := fmt.Sscan(parts[0], &maj); err != nil {
+		return false
+	}
+	if _, err := fmt.Sscan(parts[1], &min); err != nil {
+		return false
+	}
+	return maj > major || (maj == major && min >= minor)
 }
 
 func (detector *djangoDetector) Name() string {

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -7,9 +7,10 @@ package main
 
 import (
 	"common"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"fmt"
+	"strings"
 )
 
 type PyAppFramework interface {
@@ -30,10 +31,20 @@ type flaskDetector struct {
 	mainFile	string
 }
 
+type fastAPIDetector struct {
+	appPath		string
+	mainFile	string
+}
+
 func DetectFramework(appPath string, venvName string) PyAppFramework {
 	var detector PyAppFramework
 
 	detector = &djangoDetector{ appPath: appPath, venvName: venvName }
+	if detector.detect() {
+		return detector
+	}
+
+	detector = &fastAPIDetector{ appPath: appPath }
 	if detector.detect() {
 		return detector
 	}
@@ -136,4 +147,54 @@ func (detector *flaskDetector) GetDebuggableModule() string {
 
 	// Default is 127.0.0.1:5000 (https://flask.palletsprojects.com/en/1.1.x/api/#flask.Flask.run)
 	return fmt.Sprintf("flask run --host $HOST --port $PORT")
+}
+
+func (detector *fastAPIDetector) Name() string {
+	return "FastAPI"
+}
+
+// Checks if the app is based on FastAPI:
+// Returns true if there's a Python file in the app's root that imports FastAPI.
+// Looks for 'from fastapi import' or 'FastAPI()' in common entry point files.
+func (detector *fastAPIDetector) detect() bool {
+	logger := common.GetLogger("python.frameworks.fastAPIDetector.detect")
+	defer logger.Shutdown()
+
+	filesToSearch := []string{"main.py", "app.py", "application.py", "server.py"}
+
+	for _, file := range filesToSearch {
+		fullPath := filepath.Join(detector.appPath, file)
+		if !common.FileExists(fullPath) {
+			continue
+		}
+
+		content, err := ioutil.ReadFile(fullPath)
+		if err != nil {
+			logger.LogError("Failed to read file '%s': %s", fullPath, err.Error())
+			continue
+		}
+
+		contentStr := string(content)
+		if strings.Contains(contentStr, "from fastapi import") ||
+			strings.Contains(contentStr, "from fastapi\nimport") ||
+			strings.Contains(contentStr, "FastAPI()") {
+			logger.LogInformation("Detected FastAPI app in '%s'.", file)
+			detector.mainFile = file
+			return true
+		}
+	}
+
+	return false
+}
+
+// Returns the gunicorn module argument with uvicorn worker class for ASGI support.
+func (detector *fastAPIDetector) GetGunicornModuleArg() string {
+	module := detector.mainFile[0 : len(detector.mainFile) - 3] // Remove the '.py' from the end
+	return "-k uvicorn.workers.UvicornWorker " + module + ":app"
+}
+
+func (detector *fastAPIDetector) GetDebuggableModule() string {
+	module := detector.mainFile[0 : len(detector.mainFile) - 3] // Remove the '.py' from the end
+	// Use uvicorn directly for debugging since it supports --reload
+	return fmt.Sprintf("uvicorn %s:app --host $HOST --port $PORT", module)
 }

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -189,7 +189,7 @@ func (detector *fastAPIDetector) detect() bool {
 // Returns the gunicorn module argument with uvicorn worker class for ASGI support.
 func (detector *fastAPIDetector) GetGunicornModuleArg() string {
 	module := detector.mainFile[0 : len(detector.mainFile) - 3] // Remove the '.py' from the end
-	return "-k uvicorn.workers.UvicornWorker " + module + ":app"
+	return "-k uvicorn_worker.UvicornWorker " + module + ":app"
 }
 
 func (detector *fastAPIDetector) GetDebuggableModule() string {

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -176,14 +176,11 @@ func (detector *fastAPIDetector) detect() bool {
 
 		contentStr := string(content)
 
-		// Condition A: file imports the fastapi package
 		hasImport := strings.Contains(contentStr, "from fastapi") ||
 			strings.Contains(contentStr, "import fastapi")
+		hasFlask := strings.Contains(contentStr, "flask")
 
-		// Condition B: file creates a FastAPI app instance
-		hasAppCreation := strings.Contains(contentStr, "FastAPI(")
-
-		if hasImport && hasAppCreation {
+		if hasImport && !hasFlask {
 			logger.LogInformation("Detected FastAPI app in '%s'.", file)
 			detector.mainFile = file
 			return true

--- a/src/startupscriptgenerator/src/python/frameworks.go
+++ b/src/startupscriptgenerator/src/python/frameworks.go
@@ -160,7 +160,7 @@ func (detector *fastAPIDetector) detect() bool {
 	logger := common.GetLogger("python.frameworks.fastAPIDetector.detect")
 	defer logger.Shutdown()
 
-	filesToSearch := []string{"main.py", "app.py", "application.py", "server.py"}
+	filesToSearch := []string{"main.py", "app.py", "application.py", "server.py", "asgi.py", "api.py", "index.py", "run.py"}
 
 	for _, file := range filesToSearch {
 		fullPath := filepath.Join(detector.appPath, file)

--- a/src/startupscriptgenerator/src/python/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator.go
@@ -379,8 +379,8 @@ func (gen *PythonStartupScriptGenerator) buildDebugPyCommandForModule(moduleAndA
 		cdcmd = fmt.Sprintf("cd %s && ", appDir)
 	}
 
-	pycmd := fmt.Sprintf("%spython -m debugpy --listen %s:%s %s -m %s",
-		cdcmd, DefaultHost, gen.DebugPort, waitarg, moduleAndArgs)
+	pycmd := fmt.Sprintf("python -m debugpy --listen %s:%s %s -m %s",
+		DefaultHost, gen.DebugPort, waitarg, moduleAndArgs)
 
 	return cdcmd + pycmd
 }

--- a/src/startupscriptgenerator/src/python/scriptgenerator.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator.go
@@ -117,7 +117,7 @@ func (gen *PythonStartupScriptGenerator) GenerateEntrypointScript() string {
 		logger.LogInformation("Permission added: %t", isPermissionAdded)
 		command = common.ExtendPathForCommand(command, gen.getAppPath())
 	} else {
-		var appFw PyAppFramework = DetectFramework(gen.getAppPath(), gen.VirtualEnvName)
+		var appFw PyAppFramework = DetectFramework(gen.getAppPath(), gen.VirtualEnvName, pythonVersion)
 
 		if appFw != nil {
 			println("Detected an app based on " + appFw.Name())

--- a/src/startupscriptgenerator/src/python/scriptgenerator_test.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator_test.go
@@ -6,6 +6,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,7 +27,7 @@ func Test_ExamplePythonStartupScriptGenerator_buildGunicornCommandForModule_only
 	assert.Equal(t, expected, actual)
 }
 
-func ExamplePythonStartupScriptGenerator_buildGunicornCommandForModule_moduleAndPath(t *testing.T) {
+func Test_buildGunicornCommandForModule_moduleAndPath(t *testing.T) {
 	// Arrange
 	expected := "GUNICORN_CMD_ARGS=\"--timeout 600 --access-logfile '-' --error-logfile '-'" +
 		" --chdir=/a/b/c\" gunicorn module.py"
@@ -40,7 +42,105 @@ func ExamplePythonStartupScriptGenerator_buildGunicornCommandForModule_moduleAnd
 	assert.Equal(t, expected, actual)
 }
 
-func ExamplePythonStartupScriptGenerator_buildGunicornCommandForModule_moduleAndPathAndHost(t *testing.T) {
+// FastAPI: gunicorn command with uvicorn worker class
+func Test_buildGunicornCommandForModule_FastAPI_withUvicornWorker(t *testing.T) {
+	// Arrange
+	expected := "GUNICORN_CMD_ARGS=\"--timeout 600 --access-logfile '-' --error-logfile '-'" +
+		" --bind=0.0.0.0:80 --chdir=/home/site/wwwroot\" gunicorn " +
+		"-k uvicorn.workers.UvicornWorker main:app"
+	gen := PythonStartupScriptGenerator{
+		BindPort: "80",
+	}
+
+	// Act
+	actual := gen.buildGunicornCommandForModule(
+		"-k uvicorn.workers.UvicornWorker main:app", "/home/site/wwwroot")
+
+	// Assert
+	assert.Equal(t, expected, actual)
+}
+
+// FastAPI: debug command with uvicorn
+func Test_buildDebugPyCommandForModule_FastAPI(t *testing.T) {
+	// Arrange
+	// Note: cdcmd is prepended twice (once in Sprintf, once in return cdcmd + pycmd)
+	expected := "cd /app && cd /app && python -m debugpy --listen 0.0.0.0:5678  -m " +
+		"uvicorn main:app --host $HOST --port $PORT"
+	gen := PythonStartupScriptGenerator{
+		DebugPort: "5678",
+	}
+
+	// Act
+	actual := gen.buildDebugPyCommandForModule(
+		"uvicorn main:app --host $HOST --port $PORT", "/app")
+
+	// Assert
+	assert.Equal(t, expected, actual)
+}
+
+// FastAPI detection: main.py with FastAPI import, validates detection + all output methods
+func Test_fastAPIDetector_detect_mainPy(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "main.py"),
+		[]byte("from fastapi import FastAPI\napp = FastAPI()\n"), 0644)
+
+	detector := &fastAPIDetector{appPath: dir}
+
+	// Act & Assert
+	assert.True(t, detector.detect())
+	assert.Equal(t, "main.py", detector.mainFile)
+	assert.Equal(t, "-k uvicorn.workers.UvicornWorker main:app", detector.GetGunicornModuleArg())
+	assert.Equal(t, "uvicorn main:app --host $HOST --port $PORT", detector.GetDebuggableModule())
+}
+
+// FastAPI detection: no FastAPI import should return false
+func Test_fastAPIDetector_detect_notFastAPI(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "main.py"),
+		[]byte("from flask import Flask\napp = Flask(__name__)\n"), 0644)
+
+	detector := &fastAPIDetector{appPath: dir}
+
+	// Act & Assert
+	assert.False(t, detector.detect())
+}
+
+// DetectFramework: FastAPI detected before Flask when app.py has FastAPI
+func Test_DetectFramework_FastAPI_beforeFlask(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "app.py"),
+		[]byte("from fastapi import FastAPI\napp = FastAPI()\n"), 0644)
+
+	// Act
+	fw := DetectFramework(dir, "")
+
+	// Assert
+	assert.NotNil(t, fw)
+	assert.Equal(t, "FastAPI", fw.Name())
+}
+
+// DetectFramework: Django wins over FastAPI when wsgi.py exists in subdirectory
+func Test_DetectFramework_Django_overFastAPI(t *testing.T) {
+	// Arrange
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "myproject")
+	os.MkdirAll(subDir, 0755)
+	os.WriteFile(filepath.Join(subDir, "wsgi.py"), []byte(""), 0644)
+	os.WriteFile(filepath.Join(dir, "main.py"),
+		[]byte("from fastapi import FastAPI\napp = FastAPI()\n"), 0644)
+
+	// Act
+	fw := DetectFramework(dir, "")
+
+	// Assert
+	assert.NotNil(t, fw)
+	assert.Equal(t, "Django", fw.Name())
+}
+
+func Test_buildGunicornCommandForModule_moduleAndPathAndHost(t *testing.T) {
 	// Arrange
 	expected := "GUNICORN_CMD_ARGS=\"--timeout 600 --access-logfile '-' --error-logfile '-'" +
 		" --bind=0.0.0.0:12345 --chdir=/a/b/c\" gunicorn module.py"

--- a/src/startupscriptgenerator/src/python/scriptgenerator_test.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator_test.go
@@ -63,8 +63,7 @@ func Test_buildGunicornCommandForModule_FastAPI_withUvicornWorker(t *testing.T) 
 // FastAPI: debug command with uvicorn
 func Test_buildDebugPyCommandForModule_FastAPI(t *testing.T) {
 	// Arrange
-	// Note: cdcmd is prepended twice (once in Sprintf, once in return cdcmd + pycmd)
-	expected := "cd /app && cd /app && python -m debugpy --listen 0.0.0.0:5678  -m " +
+	expected := "cd /app && python -m debugpy --listen 0.0.0.0:5678  -m " +
 		"uvicorn main:app --host $HOST --port $PORT"
 	gen := PythonStartupScriptGenerator{
 		DebugPort: "5678",

--- a/src/startupscriptgenerator/src/python/scriptgenerator_test.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator_test.go
@@ -47,14 +47,14 @@ func Test_buildGunicornCommandForModule_FastAPI_withUvicornWorker(t *testing.T) 
 	// Arrange
 	expected := "GUNICORN_CMD_ARGS=\"--timeout 600 --access-logfile '-' --error-logfile '-'" +
 		" --bind=0.0.0.0:80 --chdir=/home/site/wwwroot\" gunicorn " +
-		"-k uvicorn.workers.UvicornWorker main:app"
+		"-k uvicorn_worker.UvicornWorker main:app"
 	gen := PythonStartupScriptGenerator{
 		BindPort: "80",
 	}
 
 	// Act
 	actual := gen.buildGunicornCommandForModule(
-		"-k uvicorn.workers.UvicornWorker main:app", "/home/site/wwwroot")
+		"-k uvicorn_worker.UvicornWorker main:app", "/home/site/wwwroot")
 
 	// Assert
 	assert.Equal(t, expected, actual)
@@ -90,7 +90,7 @@ func Test_fastAPIDetector_detect_mainPy(t *testing.T) {
 	// Act & Assert
 	assert.True(t, detector.detect())
 	assert.Equal(t, "main.py", detector.mainFile)
-	assert.Equal(t, "-k uvicorn.workers.UvicornWorker main:app", detector.GetGunicornModuleArg())
+	assert.Equal(t, "-k uvicorn_worker.UvicornWorker main:app", detector.GetGunicornModuleArg())
 	assert.Equal(t, "uvicorn main:app --host $HOST --port $PORT", detector.GetDebuggableModule())
 }
 

--- a/src/startupscriptgenerator/src/python/scriptgenerator_test.go
+++ b/src/startupscriptgenerator/src/python/scriptgenerator_test.go
@@ -114,7 +114,7 @@ func Test_DetectFramework_FastAPI_beforeFlask(t *testing.T) {
 		[]byte("from fastapi import FastAPI\napp = FastAPI()\n"), 0644)
 
 	// Act
-	fw := DetectFramework(dir, "")
+	fw := DetectFramework(dir, "", "3.14.0")
 
 	// Assert
 	assert.NotNil(t, fw)
@@ -132,7 +132,7 @@ func Test_DetectFramework_Django_overFastAPI(t *testing.T) {
 		[]byte("from fastapi import FastAPI\napp = FastAPI()\n"), 0644)
 
 	// Act
-	fw := DetectFramework(dir, "")
+	fw := DetectFramework(dir, "", "3.14.0")
 
 	// Assert
 	assert.NotNil(t, fw)

--- a/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Oryx.Integration.Tests
 
         [Theory]
         [Trait("category", "python")]
-        [InlineData("3.12", ImageTestHelperConstants.OsTypeDebianBullseye, ImageTestHelperConstants.GitHubActionsBullseye)]
-        [InlineData("3.13", ImageTestHelperConstants.OsTypeDebianBookworm, ImageTestHelperConstants.GitHubActionsBookworm)]
+        [InlineData("3.14", ImageTestHelperConstants.OsTypeUbuntuNoble, ImageTestHelperConstants.GitHubActionsNoble)]
         public async Task CanBuildAndRun_FastAPIAppAsync(string version, string osType, string buildImageTag)
         {
             // Arrange
@@ -71,8 +70,8 @@ namespace Microsoft.Oryx.Integration.Tests
         public async Task CanBuildAndRun_FastAPIApp_WithGunicornMultiWorkersAsync()
         {
             // Arrange
-            var version = "3.12";
-            var osType = ImageTestHelperConstants.OsTypeDebianBullseye;
+            var version = "3.14";
+            var osType = ImageTestHelperConstants.OsTypeUbuntuNoble;
             var appName = "fastapi-app";
             var volume = CreateAppVolume(appName);
             var appDir = volume.ContainerDir;
@@ -97,7 +96,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 appName,
                 _output,
                 new[] { volume, appOutputDirVolume },
-                _imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBullseye),
+                _imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsNoble),
                 "/bin/bash",
                 new[]
                 {

--- a/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Oryx.Integration.Tests
                     ExtVarNames.PythonEnableGunicornMultiWorkersEnvVarName,
                     "true")
                 .AddCommand($"oryx build {appDir} -i /tmp/int -o {appOutputDir} " +
-                $"--platform {PythonConstants.PlatformName} --platform-version {PythonVersions.Python312Version}")
+                $"--platform {PythonConstants.PlatformName} --platform-version {version}")
                 .ToString();
             var runScript = new ShellScriptBuilder()
                 .SetEnvironmentVariable(

--- a/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
@@ -1,0 +1,172 @@
+// --------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// --------------------------------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Microsoft.Oryx.BuildScriptGenerator.Python;
+using Microsoft.Oryx.BuildScriptGenerator.Common;
+using Microsoft.Oryx.Tests.Common;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Oryx.Integration.Tests
+{
+    public class PythonFastAPIAppTests : PythonEndToEndTestsBase
+    {
+        public PythonFastAPIAppTests(ITestOutputHelper output, TestTempDirTestFixture testTempDirTestFixture)
+            : base(output, testTempDirTestFixture)
+        {
+        }
+
+        [Fact]
+        [Trait("category", "githubactions")]
+        [Trait("build-image", "github-actions-debian-bullseye")]
+        public async Task CanBuildAndRun_FastAPIApp_OnBullseyeAsync()
+        {
+            // Arrange
+            var version = "3.12";
+            var osType = ImageTestHelperConstants.OsTypeDebianBullseye;
+            var appName = "fastapi-app";
+            var volume = CreateAppVolume(appName);
+            var appDir = volume.ContainerDir;
+            var appOutputDirVolume = CreateAppOutputDirVolume();
+            var appOutputDir = appOutputDirVolume.ContainerDir;
+            var buildScript = new ShellScriptBuilder()
+                .AddCommand($"oryx build {appDir} -i /tmp/int -o {appOutputDir} " +
+                $"--platform {PythonConstants.PlatformName} --platform-version {PythonVersions.Python312Version}")
+                .ToString();
+            var runScript = new ShellScriptBuilder()
+                .AddCommand($"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
+                .AddCommand(DefaultStartupFilePath)
+                .ToString();
+
+            await EndToEndTestHelper.BuildRunAndAssertAppAsync(
+                appName,
+                _output,
+                new[] { volume, appOutputDirVolume },
+                _imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBullseye),
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    buildScript
+                },
+                _imageHelper.GetRuntimeImage("python", version, osType),
+                ContainerPort,
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    runScript
+                },
+                async (hostPort) =>
+                {
+                    var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
+                    Assert.Contains("Hello FastAPI!", data);
+                });
+        }
+
+        [Fact]
+        [Trait("category", "githubactions")]
+        [Trait("build-image", "github-actions-debian-bookworm")]
+        public async Task CanBuildAndRun_FastAPIApp_OnBookwormAsync()
+        {
+            // Arrange
+            var version = "3.12";
+            var osType = ImageTestHelperConstants.OsTypeDebianBookworm;
+            var appName = "fastapi-app";
+            var volume = CreateAppVolume(appName);
+            var appDir = volume.ContainerDir;
+            var appOutputDirVolume = CreateAppOutputDirVolume();
+            var appOutputDir = appOutputDirVolume.ContainerDir;
+            var buildScript = new ShellScriptBuilder()
+                .AddCommand($"oryx build {appDir} -i /tmp/int -o {appOutputDir} " +
+                $"--platform {PythonConstants.PlatformName} --platform-version {PythonVersions.Python312Version}")
+                .ToString();
+            var runScript = new ShellScriptBuilder()
+                .AddCommand($"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
+                .AddCommand(DefaultStartupFilePath)
+                .ToString();
+
+            await EndToEndTestHelper.BuildRunAndAssertAppAsync(
+                appName,
+                _output,
+                new[] { volume, appOutputDirVolume },
+                _imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBookworm),
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    buildScript
+                },
+                _imageHelper.GetRuntimeImage("python", version, osType),
+                ContainerPort,
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    runScript
+                },
+                async (hostPort) =>
+                {
+                    var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
+                    Assert.Contains("Hello FastAPI!", data);
+                });
+        }
+
+        [Fact]
+        [Trait("category", "githubactions")]
+        [Trait("build-image", "github-actions-debian-bullseye")]
+        public async Task CanBuildAndRun_FastAPIApp_WithGunicornMultiWorkersAsync()
+        {
+            // Arrange
+            var version = "3.12";
+            var osType = ImageTestHelperConstants.OsTypeDebianBullseye;
+            var appName = "fastapi-app";
+            var volume = CreateAppVolume(appName);
+            var appDir = volume.ContainerDir;
+            var appOutputDirVolume = CreateAppOutputDirVolume();
+            var appOutputDir = appOutputDirVolume.ContainerDir;
+            var buildScript = new ShellScriptBuilder()
+                .SetEnvironmentVariable(
+                    ExtVarNames.PythonEnableGunicornMultiWorkersEnvVarName,
+                    "true")
+                .AddCommand($"oryx build {appDir} -i /tmp/int -o {appOutputDir} " +
+                $"--platform {PythonConstants.PlatformName} --platform-version {PythonVersions.Python312Version}")
+                .ToString();
+            var runScript = new ShellScriptBuilder()
+                .SetEnvironmentVariable(
+                    ExtVarNames.PythonEnableGunicornMultiWorkersEnvVarName,
+                    "true")
+                .AddCommand($"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
+                .AddCommand(DefaultStartupFilePath)
+                .ToString();
+
+            await EndToEndTestHelper.BuildRunAndAssertAppAsync(
+                appName,
+                _output,
+                new[] { volume, appOutputDirVolume },
+                _imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBullseye),
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    buildScript
+                },
+                _imageHelper.GetRuntimeImage("python", version, osType),
+                ContainerPort,
+                "/bin/bash",
+                new[]
+                {
+                    "-c",
+                    runScript
+                },
+                async (hostPort) =>
+                {
+                    var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
+                    Assert.Contains("Hello FastAPI!", data);
+                });
+        }
+    }
+}

--- a/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
+++ b/tests/Oryx.Integration.Tests/Python/PythonFastAPIAppTests.cs
@@ -19,14 +19,13 @@ namespace Microsoft.Oryx.Integration.Tests
         {
         }
 
-        [Fact]
-        [Trait("category", "githubactions")]
-        [Trait("build-image", "github-actions-debian-bullseye")]
-        public async Task CanBuildAndRun_FastAPIApp_OnBullseyeAsync()
+        [Theory]
+        [Trait("category", "python")]
+        [InlineData("3.12", ImageTestHelperConstants.OsTypeDebianBullseye, ImageTestHelperConstants.GitHubActionsBullseye)]
+        [InlineData("3.13", ImageTestHelperConstants.OsTypeDebianBookworm, ImageTestHelperConstants.GitHubActionsBookworm)]
+        public async Task CanBuildAndRun_FastAPIAppAsync(string version, string osType, string buildImageTag)
         {
             // Arrange
-            var version = "3.12";
-            var osType = ImageTestHelperConstants.OsTypeDebianBullseye;
             var appName = "fastapi-app";
             var volume = CreateAppVolume(appName);
             var appDir = volume.ContainerDir;
@@ -34,7 +33,7 @@ namespace Microsoft.Oryx.Integration.Tests
             var appOutputDir = appOutputDirVolume.ContainerDir;
             var buildScript = new ShellScriptBuilder()
                 .AddCommand($"oryx build {appDir} -i /tmp/int -o {appOutputDir} " +
-                $"--platform {PythonConstants.PlatformName} --platform-version {PythonVersions.Python312Version}")
+                $"--platform {PythonConstants.PlatformName} --platform-version {version}")
                 .ToString();
             var runScript = new ShellScriptBuilder()
                 .AddCommand($"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
@@ -45,7 +44,7 @@ namespace Microsoft.Oryx.Integration.Tests
                 appName,
                 _output,
                 new[] { volume, appOutputDirVolume },
-                _imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBullseye),
+                _imageHelper.GetGitHubActionsBuildImage(buildImageTag),
                 "/bin/bash",
                 new[]
                 {
@@ -68,56 +67,7 @@ namespace Microsoft.Oryx.Integration.Tests
         }
 
         [Fact]
-        [Trait("category", "githubactions")]
-        [Trait("build-image", "github-actions-debian-bookworm")]
-        public async Task CanBuildAndRun_FastAPIApp_OnBookwormAsync()
-        {
-            // Arrange
-            var version = "3.12";
-            var osType = ImageTestHelperConstants.OsTypeDebianBookworm;
-            var appName = "fastapi-app";
-            var volume = CreateAppVolume(appName);
-            var appDir = volume.ContainerDir;
-            var appOutputDirVolume = CreateAppOutputDirVolume();
-            var appOutputDir = appOutputDirVolume.ContainerDir;
-            var buildScript = new ShellScriptBuilder()
-                .AddCommand($"oryx build {appDir} -i /tmp/int -o {appOutputDir} " +
-                $"--platform {PythonConstants.PlatformName} --platform-version {PythonVersions.Python312Version}")
-                .ToString();
-            var runScript = new ShellScriptBuilder()
-                .AddCommand($"oryx create-script -appPath {appOutputDir} -bindPort {ContainerPort}")
-                .AddCommand(DefaultStartupFilePath)
-                .ToString();
-
-            await EndToEndTestHelper.BuildRunAndAssertAppAsync(
-                appName,
-                _output,
-                new[] { volume, appOutputDirVolume },
-                _imageHelper.GetGitHubActionsBuildImage(ImageTestHelperConstants.GitHubActionsBookworm),
-                "/bin/bash",
-                new[]
-                {
-                    "-c",
-                    buildScript
-                },
-                _imageHelper.GetRuntimeImage("python", version, osType),
-                ContainerPort,
-                "/bin/bash",
-                new[]
-                {
-                    "-c",
-                    runScript
-                },
-                async (hostPort) =>
-                {
-                    var data = await _httpClient.GetStringAsync($"http://localhost:{hostPort}/");
-                    Assert.Contains("Hello FastAPI!", data);
-                });
-        }
-
-        [Fact]
-        [Trait("category", "githubactions")]
-        [Trait("build-image", "github-actions-debian-bullseye")]
+        [Trait("category", "python")]
         public async Task CanBuildAndRun_FastAPIApp_WithGunicornMultiWorkersAsync()
         {
             // Arrange

--- a/tests/SampleApps/python/fastapi-app/main.py
+++ b/tests/SampleApps/python/fastapi-app/main.py
@@ -1,9 +1,55 @@
-from fastapi import FastAPI
+import asyncio
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import StreamingResponse
 from datetime import datetime
+from pydantic import BaseModel
 
 app = FastAPI()
+
+
+class Item(BaseModel):
+    name: str
+    price: float
+    quantity: int = 1
 
 
 @app.get("/")
 def read_root():
     return {"message": "Hello FastAPI!", "timestamp": str(datetime.now())}
+
+
+@app.get("/async")
+async def async_root():
+    await asyncio.sleep(0.1)
+    return {"message": "Hello from async!", "async": True}
+
+
+@app.get("/items/{item_id}")
+def get_item(item_id: int, q: str = None):
+    return {"item_id": item_id, "q": q}
+
+
+@app.post("/items")
+async def create_item(item: Item):
+    total = item.price * item.quantity
+    return {"name": item.name, "total": total}
+
+
+@app.get("/stream")
+async def stream_response():
+    async def generate():
+        for i in range(5):
+            yield f"chunk {i}\n"
+            await asyncio.sleep(0.05)
+    return StreamingResponse(generate(), media_type="text/plain")
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            data = await ws.receive_text()
+            await ws.send_text(f"echo: {data}")
+    except WebSocketDisconnect:
+        pass

--- a/tests/SampleApps/python/fastapi-app/main.py
+++ b/tests/SampleApps/python/fastapi-app/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+from datetime import datetime
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello FastAPI!", "timestamp": str(datetime.now())}

--- a/tests/SampleApps/python/fastapi-app/requirements.txt
+++ b/tests/SampleApps/python/fastapi-app/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.100.0
+uvicorn>=0.23.0

--- a/tests/SampleApps/python/fastapi-app/requirements.txt
+++ b/tests/SampleApps/python/fastapi-app/requirements.txt
@@ -1,2 +1,3 @@
 fastapi>=0.100.0
 uvicorn>=0.23.0
+websockets>=11.0

--- a/tests/SampleApps/python/fastapi-app/requirements.txt
+++ b/tests/SampleApps/python/fastapi-app/requirements.txt
@@ -1,3 +1,2 @@
 fastapi>=0.100.0
-uvicorn>=0.23.0
 websockets>=11.0


### PR DESCRIPTION
This PR onboards FastAPI as a first-class detected framework in Oryx, alongside Django and Flask.

**How detection works**
During startup, the script generator scans the app directory for common entry files — main.py, app.py, application.py, server.py — and looks for "from fastapi import" or "FastAPI(" in their contents. Detection runs in priority order: Django → FastAPI → Flask, so if an app somehow imports both FastAPI and Flask, FastAPI wins.

**How the app starts**
Once detected, Oryx generates a Gunicorn startup command with Uvicorn workers:

`gunicorn --timeout 600 --access-logfile '-' --error-logfile '-' -c /opt/startup/gunicorn.conf.py --chdir=/tmp/8dea620f57fccb8" gunicorn -k uvicorn_worker.UvicornWorker main:app`

FastAPI is ASGI, so it needs Uvicorn workers instead of Gunicorn's default sync workers. Gunicorn acts as the process manager (timeouts, restarts, worker scaling) while Uvicorn handles the async protocol.

**Debug mode**
In debug mode, Oryx skips Gunicorn entirely and runs:

`python -m debugpy --listen 0.0.0.0:5678 -m uvicorn main:app --host 0.0.0.0 --port 8000`Added Go startup script generator tests to unit-tests.yaml — they now run on every PR and push to main.

Added Go startup script generator tests to [unit-tests.yaml](https://github.com/microsoft/Oryx/actions/runs/24666987976) — they now run on every PR and push to main.

**Testing:**
Created a runtime image with these changes and deployed a fastapi app

For python 3.14:
<img width="1210" height="250" alt="image" src="https://github.com/user-attachments/assets/47d57da7-ef48-42f4-9007-369ad32d9ce2" />


For python 3.13:
Deployed the same fastapi app as above, but it detected the app as flask - as expected
<img width="702" height="61" alt="image" src="https://github.com/user-attachments/assets/933ec373-bcfa-4ad4-8d06-9332219ee251" />

<img width="1877" height="170" alt="image" src="https://github.com/user-attachments/assets/fd2233d5-e0df-48b4-a99a-107b90dab2d7" />


Debug mode:
<img width="1496" height="146" alt="image" src="https://github.com/user-attachments/assets/538643ae-ae89-491e-8d29-8ddca47edfeb" />
<img width="1883" height="350" alt="image" src="https://github.com/user-attachments/assets/308c7094-f886-4614-981c-8398f1aabb4f" />


- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
