### PR TITLE
Update SHA validation: Tighten and align grep pattern with script output

### DIFF
--- a/.github/workflows/validate-sha.yaml
+++ b/.github/workflows/validate-sha.yaml
@@ -41,7 +41,7 @@ jobs:
           echo 'output<<EOF' >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
-          echo "$output" | grep -q "^PASSED$" && exit 0 || exit 1
+          echo "$output" | grep -q "SHA VALIDATION PASSED" && exit 0 || exit 1
 
       - name: Validate .NET SHA512
         id: dotnet
@@ -53,7 +53,7 @@ jobs:
           echo 'output<<EOF' >> $GITHUB_OUTPUT
           echo "$output" >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
-          echo "$output" | grep -q "^PASSED$" && exit 0 || exit 1
+          echo "$output" | grep -q "SHA VALIDATION PASSED" && exit 0 || exit 1
 
       - name: Post summary
         if: always() && (steps.changes.outputs.php == 'true' || steps.changes.outputs.dotnet == 'true')

--- a/build/scripts/validate-dotnet-sha.sh
+++ b/build/scripts/validate-dotnet-sha.sh
@@ -51,4 +51,4 @@ for prefix in NET_CORE_APP ASPNET_CORE_APP; do
     done < <(grep -E "^[[:space:]]+${prefix}_[0-9]+:" "$CONSTANTS_FILE")
 done
 
-[[ $failed -eq 0 ]] && echo "PASSED" || { echo "FAILED"; exit 1; }
+[[ $failed -eq 0 ]] && echo "SHA VALIDATION PASSED" || { echo "SHA VALIDATION FAILED"; exit 1; }

--- a/build/scripts/validate-php-sha.sh
+++ b/build/scripts/validate-php-sha.sh
@@ -144,9 +144,9 @@ echo "=================================================="
 echo "Validated: $validated PHP version(s)"
 
 if [[ $failed -eq 1 ]]; then
-    echo -e "${RED}VALIDATION FAILED - SHA256 mismatches detected!${NC}"
+    echo -e "${RED}SHA VALIDATION FAILED - SHA256 mismatches detected!${NC}"
     exit 1
 else
-    echo -e "${GREEN}VALIDATION PASSED${NC}"
+    echo -e "${GREEN}SHA VALIDATION PASSED${NC}"
     exit 0
 fi


### PR DESCRIPTION
 The `validate-sha` workflow grepped for `^PASSED$` but the scripts used inconsistent output messages. This PR aligns all scripts and the workflow to use `SHA VALIDATION PASSED` / `SHA VALIDATION FAILED`.
 
 ### Changes
 - **`build/scripts/validate-dotnet-sha.sh`** — output `SHA VALIDATION PASSED` / `SHA VALIDATION FAILED`
 - **`build/scripts/validate-php-sha.sh`** — output `SHA VALIDATION PASSED` / `SHA VALIDATION FAILED`
 - **`.github/workflows/validate-sha.yaml`** — grep for `SHA VALIDATION PASSED` in both PHP and .NET steps
 
 ### Testing
 
 Both scripts were run locally against `images/constants.yml` with valid and tampered SHAs.
 
 | Scenario | Script Output | Workflow grep | Result |
 |----------|--------------|---------------|--------|
 | .NET all SHAs valid | `SHA VALIDATION PASSED` | exit 0 | ✅ |
 | .NET SHA mismatch (tampered ASPNET_CORE_APP_80_SHA) | `SHA VALIDATION FAILED` | exit 1 | ✅ |
 | PHP all SHAs valid | `SHA VALIDATION PASSED` | exit 0 | ✅ |
 | PHP SHA mismatch (tampered php84Version_SHA) | `SHA VALIDATION FAILED - SHA256 mismatches detected!` | exit 1 | ✅ |
 
 The workflow also triggers on this PR since it touches `build/scripts/validate-*-sha.sh`.

<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
