### PR TITLE
Add skip detection option for oryx build command

### DIFF
--- a/src/BuildScriptGenerator/DefaultPlatformsInformationProvider.cs
+++ b/src/BuildScriptGenerator/DefaultPlatformsInformationProvider.cs
@@ -112,6 +112,16 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 return false;
             }
 
+            // When --skip-detection is set, only detect the user-specified platform
+            if (this.commonOptions.SkipDetection && !string.IsNullOrEmpty(this.commonOptions.PlatformName) && platform.Name != this.commonOptions.PlatformName)
+            {
+                this.logger.LogDebug(
+                    "Skipping detection for platform '{PlatformName}' because --skip-detection is enabled and only user-specified platform '{UserPlatform}' is considered.",
+                    platform.Name,
+                    this.commonOptions.PlatformName);
+                return false;
+            }
+
             if (this.commonOptions.EnableExternalAcrSdkProvider && !string.IsNullOrEmpty(this.commonOptions.PlatformName) && platform.Name != this.commonOptions.PlatformName)
             {
                 this.logger.LogDebug(

--- a/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
+++ b/src/BuildScriptGenerator/Options/BuildScriptGeneratorOptions.cs
@@ -106,6 +106,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         public bool EnableExternalAcrSdkProvider { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether platform detection should be skipped.
+        /// When true, only the explicitly specified platform (via --platform) will be used.
+        /// </summary>
+        public bool SkipDetection { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the direct ACR SDK provider is enabled.
         /// When true, Oryx will discover and download SDKs directly from an OCI-compliant container registry.
         /// </summary>

--- a/src/BuildScriptGeneratorCli/Commands/Binders/BuildCommandBaseBinder.cs
+++ b/src/BuildScriptGeneratorCli/Commands/Binders/BuildCommandBaseBinder.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
             Option<bool> compressDestinationDir,
             Option<string[]> property,
             Option<string> dynamicInstallRootDir,
+            Option<bool> skipDetection,
             Option<string> logPath,
             Option<bool> debugMode)
             : base(logPath, debugMode)
@@ -41,6 +42,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
             this.CompressDestinationDir = compressDestinationDir;
             this.Property = property;
             this.DynamicInstallRootDir = dynamicInstallRootDir;
+            this.SkipDetection = skipDetection;
         }
 
         protected Argument<string> SourceDir { get; set; }
@@ -62,5 +64,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
         protected Option<string[]> Property { get; set; }
 
         protected Option<string> DynamicInstallRootDir { get; set; }
+
+        protected Option<bool> SkipDetection { get; set; }
     }
 }

--- a/src/BuildScriptGeneratorCli/Commands/Binders/BuildCommandBinder.cs
+++ b/src/BuildScriptGeneratorCli/Commands/Binders/BuildCommandBinder.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
             Option<bool> compressDestinationDir,
             Option<string[]> property,
             Option<string> dynamicInstallRootDir,
+            Option<bool> skipDetection,
             Option<string> logPath,
             Option<bool> debugMode)
             : base(
@@ -39,6 +40,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
                 compressDestinationDir,
                 property,
                 dynamicInstallRootDir,
+                skipDetection,
                 logPath,
                 debugMode)
         {
@@ -77,6 +79,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
                 CompressDestinationDir = bindingContext.ParseResult.GetValueForOption(this.CompressDestinationDir),
                 Property = bindingContext.ParseResult.GetValueForOption(this.Property),
                 DynamicInstallRootDir = bindingContext.ParseResult.GetValueForOption(this.DynamicInstallRootDir),
+                SkipDetection = bindingContext.ParseResult.GetValueForOption(this.SkipDetection),
                 LogPath = bindingContext.ParseResult.GetValueForOption(this.LogPath),
                 DebugMode = bindingContext.ParseResult.GetValueForOption(this.DebugMode),
             };

--- a/src/BuildScriptGeneratorCli/Commands/Binders/BuildScriptCommandBinder.cs
+++ b/src/BuildScriptGeneratorCli/Commands/Binders/BuildScriptCommandBinder.cs
@@ -27,9 +27,10 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
             Option<bool> compressDestinationDir,
             Option<string[]> property,
             Option<string> dynamicInstallRootDir,
+            Option<bool> skipDetection,
             Option<string> logPath,
             Option<bool> debugMode)
-            : base(sourceDir, platform, platformVersion, package, osRequirements, appType, buildCommandFile, compressDestinationDir, property, dynamicInstallRootDir, logPath, debugMode)
+            : base(sourceDir, platform, platformVersion, package, osRequirements, appType, buildCommandFile, compressDestinationDir, property, dynamicInstallRootDir, skipDetection, logPath, debugMode)
         {
             this.OutputPath = outputPath;
         }
@@ -50,6 +51,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
                 CompressDestinationDir = bindingContext.ParseResult.GetValueForOption(this.CompressDestinationDir),
                 Property = bindingContext.ParseResult.GetValueForOption(this.Property),
                 DynamicInstallRootDir = bindingContext.ParseResult.GetValueForOption(this.DynamicInstallRootDir),
+                SkipDetection = bindingContext.ParseResult.GetValueForOption(this.SkipDetection),
                 LogPath = bindingContext.ParseResult.GetValueForOption(this.LogPath),
                 DebugMode = bindingContext.ParseResult.GetValueForOption(this.DebugMode),
             };

--- a/src/BuildScriptGeneratorCli/Commands/Binders/BuildpackBuildCommandBinder.cs
+++ b/src/BuildScriptGeneratorCli/Commands/Binders/BuildpackBuildCommandBinder.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
             Option<bool> compressDestinationDir,
             Option<string[]> property,
             Option<string> dynamicInstallRootDir,
+            Option<bool> skipDetection,
             Option<string> logPath,
             Option<bool> debugMode)
             : base(
@@ -47,6 +48,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
                 compressDestinationDir,
                 property,
                 dynamicInstallRootDir,
+                skipDetection,
                 logPath,
                 debugMode)
         {
@@ -97,6 +99,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
                 CompressDestinationDir = bindingContext.ParseResult.GetValueForOption(this.CompressDestinationDir),
                 Property = bindingContext.ParseResult.GetValueForOption(this.Property),
                 DynamicInstallRootDir = bindingContext.ParseResult.GetValueForOption(this.DynamicInstallRootDir),
+                SkipDetection = bindingContext.ParseResult.GetValueForOption(this.SkipDetection),
                 LogPath = bindingContext.ParseResult.GetValueForOption(this.LogPath),
                 DebugMode = bindingContext.ParseResult.GetValueForOption(this.DebugMode),
             };

--- a/src/BuildScriptGeneratorCli/Commands/BuildCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/BuildCommand.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             this.CompressDestinationDir = input.CompressDestinationDir;
             this.Properties = input.Property;
             this.DynamicInstallRootDir = input.DynamicInstallRootDir;
+            this.SkipDetection = input.SkipDetection;
             this.LogFilePath = input.LogPath;
             this.DebugMode = input.DebugMode;
 
@@ -123,6 +124,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             var compressDestDirOption = new Option<bool>(OptionArgumentTemplates.CompressDestinationDir, OptionArgumentTemplates.CompressDestinationDirDescription);
             var propertyOption = new Option<string[]>(OptionArgumentTemplates.Property, OptionArgumentTemplates.PropertyDescription);
             var dynamicInstallRootDirOption = new Option<string>(OptionArgumentTemplates.DynamicInstallRootDir, OptionArgumentTemplates.DynamicInstallRootDirDescription);
+            var skipDetectionOption = new Option<bool>(OptionArgumentTemplates.SkipDetection, OptionArgumentTemplates.SkipDetectionDescription);
 
             // Hiding Language Option because it is obselete
             var languageOption = new Option<string>(OptionArgumentTemplates.Language, OptionArgumentTemplates.LanguageDescription);
@@ -155,6 +157,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 compressDestDirOption,
                 propertyOption,
                 dynamicInstallRootDirOption,
+                skipDetectionOption,
                 languageOption,
                 languageVerOption,
                 logOption,
@@ -185,6 +188,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                     compressDestinationDir: compressDestDirOption,
                     property: propertyOption,
                     dynamicInstallRootDir: dynamicInstallRootDirOption,
+                    skipDetection: skipDetectionOption,
                     logPath: logOption,
                     debugMode: debugOption));
             return command;
@@ -433,6 +437,14 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 return false;
             }
 
+            // --skip-detection requires --platform to be specified
+            if (options.SkipDetection && string.IsNullOrEmpty(options.PlatformName))
+            {
+                logger.LogError("Cannot use --skip-detection without --platform");
+                console.WriteErrorLine("Cannot use --skip-detection without specifying --platform also.");
+                return false;
+            }
+
             if (!string.IsNullOrEmpty(options.AppType))
             {
                 var appType = options.AppType.ToLower();
@@ -518,6 +530,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                             options.ManifestDir = this.ManifestDir;
                             options.Properties = buildProperties;
                             options.ScriptOnly = false;
+                            options.SkipDetection = this.SkipDetection;
                             options.DebianFlavor = this.ResolveOsType(options, console);
                             options.ImageType = this.ResolveImageType(options, console);
                         });

--- a/src/BuildScriptGeneratorCli/Commands/BuildCommandBase.cs
+++ b/src/BuildScriptGeneratorCli/Commands/BuildCommandBase.cs
@@ -37,5 +37,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
         public string[] Properties { get; set; }
 
         public string DynamicInstallRootDir { get; set; }
+
+        public bool SkipDetection { get; set; }
     }
 }

--- a/src/BuildScriptGeneratorCli/Commands/BuildScriptCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/BuildScriptCommand.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             this.CompressDestinationDir = input.CompressDestinationDir;
             this.Properties = input.Property;
             this.DynamicInstallRootDir = input.DynamicInstallRootDir;
+            this.SkipDetection = input.SkipDetection;
             this.LogFilePath = input.LogPath;
             this.DebugMode = input.DebugMode;
         }
@@ -63,6 +64,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             var compressDestDirOption = new Option<bool>(OptionArgumentTemplates.CompressDestinationDir, OptionArgumentTemplates.CompressDestinationDirDescription);
             var propertyOption = new Option<string[]>(OptionArgumentTemplates.Property, OptionArgumentTemplates.PropertyDescription);
             var dynamicInstallRootDirOption = new Option<string>(OptionArgumentTemplates.DynamicInstallRootDir, OptionArgumentTemplates.DynamicInstallRootDirDescription);
+            var skipDetectionOption = new Option<bool>(OptionArgumentTemplates.SkipDetection, OptionArgumentTemplates.SkipDetectionDescription);
             var buildScriptOutputOption = new Option<string>(
                 aliases: OptionArgumentTemplates.Output,
                 description: OptionArgumentTemplates.BuildScriptOutputDescription);
@@ -81,6 +83,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 compressDestDirOption,
                 propertyOption,
                 dynamicInstallRootDirOption,
+                skipDetectionOption,
                 buildScriptOutputOption,
             };
 
@@ -102,6 +105,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                     compressDestinationDir: compressDestDirOption,
                     property: propertyOption,
                     dynamicInstallRootDir: dynamicInstallRootDirOption,
+                    skipDetection: skipDetectionOption,
                     logPath: logOption,
                     debugMode: debugOption));
             return command;
@@ -158,6 +162,13 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 return false;
             }
 
+            // --skip-detection requires --platform to be specified
+            if (options.SkipDetection && string.IsNullOrEmpty(options.PlatformName))
+            {
+                console.WriteErrorLine("Cannot use --skip-detection without specifying --platform also.");
+                return false;
+            }
+
             return true;
         }
 
@@ -195,6 +206,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 {
                     this.ConfigureBuildScriptGeneratorOptions(opts);
 
+                    opts.SkipDetection = this.SkipDetection;
                     opts.DebianFlavor = this.ResolveOsType(opts, console);
                     opts.ImageType = this.ResolveImageType(opts, console);
                 });

--- a/src/BuildScriptGeneratorCli/Commands/BuildpackBuildCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/BuildpackBuildCommand.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             this.CompressDestinationDir = input.CompressDestinationDir;
             this.Properties = input.Property;
             this.DynamicInstallRootDir = input.DynamicInstallRootDir;
+            this.SkipDetection = input.SkipDetection;
             this.LogFilePath = input.LogPath;
             this.DebugMode = input.DebugMode;
         }
@@ -77,6 +78,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
             var compressDestDirOption = new Option<bool>(OptionArgumentTemplates.CompressDestinationDir, OptionArgumentTemplates.CompressDestinationDirDescription);
             var propertyOption = new Option<string[]>(OptionArgumentTemplates.Property, OptionArgumentTemplates.PropertyDescription);
             var dynamicInstallRootDirOption = new Option<string>(OptionArgumentTemplates.DynamicInstallRootDir, OptionArgumentTemplates.DynamicInstallRootDirDescription);
+            var skipDetectionOption = new Option<bool>(OptionArgumentTemplates.SkipDetection, OptionArgumentTemplates.SkipDetectionDescription);
 
             // Hiding Language Option because it is obselete
             var languageOption = new Option<string>(OptionArgumentTemplates.Language, OptionArgumentTemplates.LanguageDescription);
@@ -107,6 +109,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 compressDestDirOption,
                 propertyOption,
                 dynamicInstallRootDirOption,
+                skipDetectionOption,
                 languageOption,
                 languageVerOption,
                 intermediateDirOption,
@@ -139,6 +142,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                     compressDestinationDir: compressDestDirOption,
                     property: propertyOption,
                     dynamicInstallRootDir: dynamicInstallRootDirOption,
+                    skipDetection: skipDetectionOption,
                     logPath: logOption,
                     debugMode: debugOption));
 

--- a/src/BuildScriptGeneratorCli/Commands/OptionArgumentTemplates.cs
+++ b/src/BuildScriptGeneratorCli/Commands/OptionArgumentTemplates.cs
@@ -86,6 +86,10 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
         public static readonly string PlatformsJsonOutput = "--json";
         public static readonly string PlatformsJsonOutputDescription = "Output the supported platform data in JSON format.";
 
+        // Skip-detection option
+        public static readonly string SkipDetection = "--skip-detection";
+        public static readonly string SkipDetectionDescription = "Skip auto-detection of platforms and use only the explicitly provided platform and version.";
+
         // PrepareEnvironmentCommand
         public static readonly string PrepareEnvironmentPlatformsAndVersions = "--platforms-and-versions";
         public static readonly string PrepareEnvironmentPlatformsAndVersionsDescription = "Comma separated values of platforms and versions to be installed. Example: dotnet=3.1.200,php=7.4.5,node=2.3";

--- a/src/BuildScriptGeneratorCli/Commands/Properties/BuildCommandBaseProperty.cs
+++ b/src/BuildScriptGeneratorCli/Commands/Properties/BuildCommandBaseProperty.cs
@@ -32,5 +32,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Commands
         public string[] Property { get; set; }
 
         public string DynamicInstallRootDir { get; set; }
+
+        public bool SkipDetection { get; set; }
     }
 }

--- a/tests/BuildScriptGenerator.Tests/DefaultPlatformDetectorTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DefaultPlatformDetectorTest.cs
@@ -115,11 +115,148 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests
         private DefaultPlatformsInformationProvider CreatePlatformDetector(
             IEnumerable<IProgrammingPlatform> platforms)
         {
+            return CreatePlatformDetector(platforms, new BuildScriptGeneratorOptions());
+        }
+
+        private DefaultPlatformsInformationProvider CreatePlatformDetector(
+            IEnumerable<IProgrammingPlatform> platforms,
+            BuildScriptGeneratorOptions options)
+        {
             return new DefaultPlatformsInformationProvider(
                 platforms,
                 new DefaultStandardOutputWriter(),
                 NullLogger<DefaultPlatformsInformationProvider>.Instance,
-                Options.Create(new BuildScriptGeneratorOptions()));
+                Options.Create(options));
+        }
+
+        [Fact]
+        public void SkipDetection_OnlyDetectsSpecifiedPlatform()
+        {
+            // Arrange
+            var platform1 = new Mock<IProgrammingPlatform>();
+            platform1.Setup(p => p.Name).Returns("nodejs");
+            platform1
+                .Setup(p => p.Detect(It.IsAny<RepositoryContext>()))
+                .Returns(new PlatformDetectorResult { Platform = "nodejs", PlatformVersion = "18.0.0" });
+            platform1
+                .Setup(p => p.IsEnabled(It.IsAny<RepositoryContext>()))
+                .Returns(true);
+
+            var platform2 = new Mock<IProgrammingPlatform>();
+            platform2.Setup(p => p.Name).Returns("python");
+            platform2
+                .Setup(p => p.Detect(It.IsAny<RepositoryContext>()))
+                .Returns(new PlatformDetectorResult { Platform = "python", PlatformVersion = "3.10.0" });
+            platform2
+                .Setup(p => p.IsEnabled(It.IsAny<RepositoryContext>()))
+                .Returns(true);
+
+            var platform3 = new Mock<IProgrammingPlatform>();
+            platform3.Setup(p => p.Name).Returns("dotnet");
+            platform3
+                .Setup(p => p.Detect(It.IsAny<RepositoryContext>()))
+                .Returns(new PlatformDetectorResult { Platform = "dotnet", PlatformVersion = "6.0.0" });
+            platform3
+                .Setup(p => p.IsEnabled(It.IsAny<RepositoryContext>()))
+                .Returns(true);
+
+            var options = new BuildScriptGeneratorOptions
+            {
+                SkipDetection = true,
+                PlatformName = "nodejs",
+            };
+
+            var detector = CreatePlatformDetector(
+                new[] { platform1.Object, platform2.Object, platform3.Object },
+                options);
+            var context = CreateScriptGeneratorContext();
+
+            // Act
+            var actualResults = detector.GetPlatformsInfo(context);
+
+            // Assert
+            Assert.NotNull(actualResults);
+            var actualResult = Assert.Single(actualResults);
+            Assert.Equal("nodejs", actualResult.DetectorResult.Platform);
+            Assert.Equal("18.0.0", actualResult.DetectorResult.PlatformVersion);
+
+            // Verify that Detect was NOT called on the other platforms
+            platform2.Verify(p => p.Detect(It.IsAny<RepositoryContext>()), Times.Never);
+            platform3.Verify(p => p.Detect(It.IsAny<RepositoryContext>()), Times.Never);
+        }
+
+        [Fact]
+        public void SkipDetection_False_DetectsAllPlatforms()
+        {
+            // Arrange
+            var platform1 = new Mock<IProgrammingPlatform>();
+            platform1.Setup(p => p.Name).Returns("nodejs");
+            platform1
+                .Setup(p => p.Detect(It.IsAny<RepositoryContext>()))
+                .Returns(new PlatformDetectorResult { Platform = "nodejs", PlatformVersion = "18.0.0" });
+            platform1
+                .Setup(p => p.IsEnabled(It.IsAny<RepositoryContext>()))
+                .Returns(true);
+
+            var platform2 = new Mock<IProgrammingPlatform>();
+            platform2.Setup(p => p.Name).Returns("python");
+            platform2
+                .Setup(p => p.Detect(It.IsAny<RepositoryContext>()))
+                .Returns(new PlatformDetectorResult { Platform = "python", PlatformVersion = "3.10.0" });
+            platform2
+                .Setup(p => p.IsEnabled(It.IsAny<RepositoryContext>()))
+                .Returns(true);
+
+            var options = new BuildScriptGeneratorOptions
+            {
+                SkipDetection = false,
+                PlatformName = "nodejs",
+            };
+
+            var detector = CreatePlatformDetector(
+                new[] { platform1.Object, platform2.Object },
+                options);
+            var context = CreateScriptGeneratorContext();
+
+            // Act
+            var actualResults = detector.GetPlatformsInfo(context);
+
+            // Assert — both platforms should be detected
+            Assert.NotNull(actualResults);
+            Assert.Equal(2, actualResults.Count());
+            platform1.Verify(p => p.Detect(It.IsAny<RepositoryContext>()), Times.Once);
+            platform2.Verify(p => p.Detect(It.IsAny<RepositoryContext>()), Times.Once);
+        }
+
+        [Fact]
+        public void SkipDetection_StillRespectsDisabledPlatform()
+        {
+            // Arrange — the specified platform is disabled
+            var platform1 = new Mock<IProgrammingPlatform>();
+            platform1.Setup(p => p.Name).Returns("nodejs");
+            platform1
+                .Setup(p => p.Detect(It.IsAny<RepositoryContext>()))
+                .Returns(new PlatformDetectorResult { Platform = "nodejs", PlatformVersion = "18.0.0" });
+            platform1
+                .Setup(p => p.IsEnabled(It.IsAny<RepositoryContext>()))
+                .Returns(false);
+
+            var options = new BuildScriptGeneratorOptions
+            {
+                SkipDetection = true,
+                PlatformName = "nodejs",
+            };
+
+            var detector = CreatePlatformDetector(new[] { platform1.Object }, options);
+            var context = CreateScriptGeneratorContext();
+
+            // Act
+            var actualResults = detector.GetPlatformsInfo(context);
+
+            // Assert — platform is disabled, so no results even with skip-detection
+            Assert.NotNull(actualResults);
+            Assert.Empty(actualResults);
+            platform1.Verify(p => p.Detect(It.IsAny<RepositoryContext>()), Times.Never);
         }
 
         private static BuildScriptGeneratorContext CreateScriptGeneratorContext()

--- a/tests/BuildScriptGeneratorCli.Tests/BuildCommandTest.cs
+++ b/tests/BuildScriptGeneratorCli.Tests/BuildCommandTest.cs
@@ -199,6 +199,46 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Tests
         }
 
         [Fact]
+        public void IsValidInput_IsFalse_WhenSkipDetection_WithoutPlatform()
+        {
+            // Arrange
+            var buildCommand = new BuildCommand
+            {
+                SourceDir = _testDir.CreateChildDir(),
+                SkipDetection = true,
+            };
+            var testConsole = new TestConsole();
+            var serviceProvider = buildCommand.TryGetServiceProvider(testConsole);
+
+            // Act
+            var isValid = buildCommand.IsValidInput(serviceProvider, testConsole);
+
+            // Assert
+            Assert.False(isValid);
+            Assert.Contains("Cannot use --skip-detection without specifying --platform also.", testConsole.StdError);
+        }
+
+        [Fact]
+        public void IsValidInput_IsTrue_WhenSkipDetection_WithPlatform()
+        {
+            // Arrange
+            var buildCommand = new BuildCommand
+            {
+                SourceDir = _testDir.CreateChildDir(),
+                PlatformName = "nodejs",
+                SkipDetection = true,
+            };
+            var testConsole = new TestConsole();
+            var serviceProvider = buildCommand.TryGetServiceProvider(testConsole);
+
+            // Act
+            var isValid = buildCommand.IsValidInput(serviceProvider, testConsole);
+
+            // Assert
+            Assert.True(isValid);
+        }
+
+        [Fact]
         public void DoesNotShowHelp_EvenIfIntermediateDir_DoesNotExistYet()
         {
             // Arrange


### PR DESCRIPTION
Implements #2917 
This change introduces a new `--skip-detection` CLI option for build commands, which allows users to skip automatic platform detection and only use a user-specified platform. The change is implemented across the core build logic and all relevant command-line interfaces. This will help provide users with more control over platform selection during builds and improve the build robustness and preventing false detections.


## Testing
Deployed an app which consists both nodejs and python files
* Before this change -  when passing nodejs as specified platform 
<img width="1379" height="530" alt="image" src="https://github.com/user-attachments/assets/d67779a5-d8df-443e-8cac-b31492378938" />
* after this change but without --skip-detection flag
<img width="1201" height="417" alt="image" src="https://github.com/user-attachments/assets/62651214-e5ae-4757-a965-d9548a61eebd" />

* after this change with --skip-detection flag
<img width="1313" height="655" alt="image" src="https://github.com/user-attachments/assets/7fb2b60a-5590-41f2-abd1-d4a4a87c58fa" />



