### PR TITLE
Add support for custom build commands

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -34,7 +34,7 @@ DISABLE\_DOTNETCORE\_BUILD   | Do not apply .NET Core build even if repo indicat
 PROJECT                      | repo-relative path to directory with `.csproj` file for build  | ""      | "src/WebApp1/WebApp1.csproj"
 MSBUILD\_CONFIGURATION       | Configuration (Debug or Release) that is used to build a .NET Core project | `Release` | `Debug`, `Release`
 
-> When `CUSTOM_BUILD_COMMAND` is set for .NET apps, it replaces the default `dotnet restore` and `dotnet publish` commands
+> When `CUSTOM_BUILD_COMMAND` is set for .NET apps, it replaces the default `dotnet restore` and `dotnet publish` commands. The custom command must output to `$DESTINATION_DIR` (e.g., `dotnet publish -o $DESTINATION_DIR`).
 
 Setting name for Nodejs apps | Description                                                    | Default | Example
 -----------------------------|----------------------------------------------------------------|---------|----------------

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -23,6 +23,8 @@ PLATFORM\_NAME               | Specify which platform the app is using. Possible
 PLATFORM\_VERSION            | Specify which platform version the app is using           | ""      | "3.7.1"
 REQUIRED\_OS\_PACKAGES       | Indicate if it requires OS packages for Node or Python packages | `false` | `true`, `false`
 CREATE\_PACKAGE              | Indicate if it should create packages for the app          | `false` | `true`, `false`
+CUSTOM\_BUILD\_COMMAND       | Custom build command to run instead of the default build. Supported for Node.js, Python, PHP, and .NET. | ""  | See per-stack docs
+SKIP\_PLATFORM\_DETECTION    | Skip auto-detection of platforms. Only the platform specified via `PLATFORM_NAME` (or `--platform`) will be used. Requires `PLATFORM_NAME` to be set. | `false` | `true`, `false`
 
 Setting name for .NET apps   | Description                                                    | Default | Example
 -----------------------------|----------------------------------------------------------------|---------|----------------
@@ -32,12 +34,13 @@ DISABLE\_DOTNETCORE\_BUILD   | Do not apply .NET Core build even if repo indicat
 PROJECT                      | repo-relative path to directory with `.csproj` file for build  | ""      | "src/WebApp1/WebApp1.csproj"
 MSBUILD\_CONFIGURATION       | Configuration (Debug or Release) that is used to build a .NET Core project | `Release` | `Debug`, `Release`
 
+> When `CUSTOM_BUILD_COMMAND` is set for .NET apps, it replaces the default `dotnet restore` and `dotnet publish` commands
+
 Setting name for Nodejs apps | Description                                                    | Default | Example
 -----------------------------|----------------------------------------------------------------|---------|----------------
 NODE\_VERSION                | Specify which Node version the app is using                    | ""      | "14.15.0"
 NODE\_DEFAULT\_VERSION       | Specify which Node version the app defaults to if none detected | ""      | "14.15.0"
 DISABLE\_NODEJS\_BUILD       | Do not apply Node.js build even if repo indicates it           | `false` | `true`, `false`
-CUSTOM_BUILD_COMMAND         | Custom build command to be run to build Node app               | ""  | "npm ci"
 RUN_BUILD_COMMAND            | Custom run build command to be run after package install commands  | ""  | "npm run build"
 ENABLE\_NODE\_MONOREPO\_BUILD| Apply node monorepo build if repo indicates it                 | `false` | `true`, `false`
 COMPRESS\_DESTINATION\_DIR   | Indicates if the entire output directory needs to be compressed.   | ""      | `false` | `true`, `false`
@@ -60,6 +63,8 @@ PYTHON\_GUNICORN\_CUSTOM\_THREAD\_NUM| Only works when `PYTHON\_ENABLE\_GUNICORN
 ORYX\_DISABLE\_PIP\_UPGRADE  | Remove the --upgrade flag from the pip install command when targeting a specific package installation directory. | `false` | `true`, `false`
 NGINX\_CONF\_FILE            | Specify a customized configuration file to modify nginx.conf file        | ""      | "newconfigfile.conf"
 
+> When `CUSTOM_BUILD_COMMAND` is set for Python apps, it replaces the default dependency installation (pip install, poetry install, uv sync) but preserves virtual environment setup
+
 Setting name for Php apps    | Description                                                    | Default | Example
 -----------------------------|----------------------------------------------------------------|---------|----------------
 PHP\_VERSION                 | Specify which Php version the app is using                     | ""      | "7.4"
@@ -71,6 +76,8 @@ FPM\_MAX\_CHILDREN           | The maximum number of child processes to be creat
 FPM\_START\_SERVERS          | The number of child processes created on startup               | `min_spare_servers + (max_spare_servers - min_spare_servers) / 2` | "10"
 FPM\_MAX\_SPARE\_SERVERS     | The desired maximum number of idle server processes            | `3`      | "15"
 FPM\_MIN\_SPARE\_SERVERS     | The desired minimum number of idle server processes            | `1`      | "5"
+
+> When `CUSTOM_BUILD_COMMAND` is set for PHP apps, it replaces the default `composer install` command.
 
 Setting name for Java apps | Description                                                    | Default | Example
 ---------------------------|----------------------------------------------------------------|---------|----------------

--- a/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippet.sh.tpl
@@ -9,6 +9,12 @@ echo "Using .NET Core SDK Version: $dotnetCoreVersion"
     {{ InstallBlazorWebAssemblyAOTWorkloadCommand }}
 {{ end }}
 
+{{ if CustomBuildCommand | IsNotBlank }}
+echo
+echo "Running custom build command '{{ CustomBuildCommand }}'..."
+echo
+{{ CustomBuildCommand }}
+{{ else }}
 doc="https://docs.microsoft.com/en-us/azure/app-service/configure-language-dotnetcore?pivots=platform-linux"
 suggestion="Please build your app locally before publishing." 
 msg="${suggestion} | ${doc}"
@@ -39,3 +45,4 @@ else
     # but not during other dotnet builds
     cp ${SOURCE_DIR}/*.csproj ${DESTINATION_DIR} 2>/dev/null || :
 fi
+{{ end }}

--- a/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippet.sh.tpl
@@ -12,6 +12,7 @@ echo "Using .NET Core SDK Version: $dotnetCoreVersion"
 {{ if CustomBuildCommand | IsNotBlank }}
 echo
 echo "Running custom build command '{{ CustomBuildCommand }}'..."
+echo "Note: the custom build command must output to \$DESTINATION_DIR (e.g., dotnet publish -c Release -o \$DESTINATION_DIR)."
 echo
 {{ CustomBuildCommand }}
 {{ else }}

--- a/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippetProperties.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippetProperties.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
         public string Configuration { get; set; }
 
         public string InstallBlazorWebAssemblyAOTWorkloadCommand { get; set; }
+
+        public string CustomBuildCommand { get; set; }
     }
 }

--- a/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
                 ProjectFile = projectFile,
                 Configuration = this.GetBuildConfiguration(),
                 InstallBlazorWebAssemblyAOTWorkloadCommand = installBlazorWebAssemblyAOTWorkloadCommand,
+                CustomBuildCommand = this.dotNetCoreScriptGeneratorOptions.CustomBuildCommand,
             };
 
             var script = TemplateHelper.Render(
@@ -177,13 +178,20 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 
             SetStartupFileNameInfoInManifestFile(context, projectFile, manifestFileProperties);
 
+            // When a custom build command is used, the user has opted out of the standard
+            // 'dotnet publish -o $DESTINATION_DIR' flow and may be using a different build tool.
+            // In that case, enable auto-copy so the build output reaches $DESTINATION_DIR
+            var copySourceToDestination = !string.IsNullOrEmpty(
+                this.dotNetCoreScriptGeneratorOptions.CustomBuildCommand);
+
             return new BuildScriptSnippet
             {
                 BashBuildScriptSnippet = script,
                 BuildProperties = manifestFileProperties,
 
                 // Setting this to false to avoid copying files like '.cs' to the destination
-                CopySourceDirectoryContentToDestinationDirectory = false,
+                // unless a custom build command is used, in which case we enable auto-copy.
+                CopySourceDirectoryContentToDestinationDirectory = copySourceToDestination,
             };
         }
 

--- a/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCorePlatform.cs
@@ -178,20 +178,15 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
 
             SetStartupFileNameInfoInManifestFile(context, projectFile, manifestFileProperties);
 
-            // When a custom build command is used, the user has opted out of the standard
-            // 'dotnet publish -o $DESTINATION_DIR' flow and may be using a different build tool.
-            // In that case, enable auto-copy so the build output reaches $DESTINATION_DIR
-            var copySourceToDestination = !string.IsNullOrEmpty(
-                this.dotNetCoreScriptGeneratorOptions.CustomBuildCommand);
-
             return new BuildScriptSnippet
             {
                 BashBuildScriptSnippet = script,
                 BuildProperties = manifestFileProperties,
 
-                // Setting this to false to avoid copying files like '.cs' to the destination
-                // unless a custom build command is used, in which case we enable auto-copy.
-                CopySourceDirectoryContentToDestinationDirectory = copySourceToDestination,
+                // Always false for .NET: the custom build command (or default dotnet publish)
+                // must place output in $DESTINATION_DIR directly. Auto-copying source files
+                // would overwrite published output with .cs/.csproj files, breaking the app.
+                CopySourceDirectoryContentToDestinationDirectory = false,
             };
         }
 

--- a/src/BuildScriptGenerator/DotNetCore/DotnetCoreScriptGeneratorOptions.cs
+++ b/src/BuildScriptGenerator/DotNetCore/DotnetCoreScriptGeneratorOptions.cs
@@ -12,6 +12,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator.DotNetCore
         /// </summary>
         public string MSBuildConfiguration { get; set; }
 
+        /// <summary>
+        /// Gets or sets custom build command that will run instead of the default
+        /// 'dotnet restore' and 'dotnet publish' in the generated build script.
+        /// </summary>
+        public string CustomBuildCommand { get; set; }
+
         public string DotNetCoreRuntimeVersion { get; set; }
 
         public string DefaultRuntimeVersion { get; set; }

--- a/src/BuildScriptGenerator/Php/PhpBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Php/PhpBashBuildSnippet.sh.tpl
@@ -1,7 +1,12 @@
 ﻿phpBin=`which php`
 echo "PHP executable: $phpBin"
 
-{{ if ComposerFileExists }}
+{{ if CustomBuildCommand | IsNotBlank }}
+echo
+echo "Running custom build command '{{ CustomBuildCommand }}'..."
+echo
+{{ CustomBuildCommand }}
+{{ else if ComposerFileExists }}
 echo "Composer archive: $composer"
 echo "Running 'composer install --ignore-platform-reqs --no-interaction'..."
 echo

--- a/src/BuildScriptGenerator/Php/PhpBashBuildSnippetProperties.cs
+++ b/src/BuildScriptGenerator/Php/PhpBashBuildSnippetProperties.cs
@@ -11,5 +11,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
     public class PhpBashBuildSnippetProperties
     {
         public bool ComposerFileExists { get; set; }
+
+        public string CustomBuildCommand { get; set; }
     }
 }

--- a/src/BuildScriptGenerator/Php/PhpPlatform.cs
+++ b/src/BuildScriptGenerator/Php/PhpPlatform.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
             var props = new PhpBashBuildSnippetProperties
             {
                 ComposerFileExists = composerFileExists,
+                CustomBuildCommand = this.phpScriptGeneratorOptions.CustomBuildCommand,
             };
             string snippet = TemplateHelper.Render(TemplateHelper.TemplateResource.PhpBuildSnippet, props, this.logger, this.telemetryClient);
             return new BuildScriptSnippet { BashBuildScriptSnippet = snippet, BuildProperties = buildProperties };

--- a/src/BuildScriptGenerator/Php/PhpScriptGeneratorOptions.cs
+++ b/src/BuildScriptGenerator/Php/PhpScriptGeneratorOptions.cs
@@ -14,5 +14,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
         public string PhpComposerVersion { get; set; }
 
         public string PhpComposerDefaultVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets custom build command that will run instead of the default
+        /// 'composer install' in the generated build script.
+        /// </summary>
+        public string CustomBuildCommand { get; set; }
     }
 }

--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippet.sh.tpl
@@ -206,285 +206,299 @@ install_python_packages_impl() {
     source $VIRTUALENVIRONMENTNAME/bin/activate
 
     moreInformation="More information: https://aka.ms/troubleshoot-python"
-    if [ -e "$REQUIREMENTS_TXT_FILE" ]
-    then
-        if [ "$PYTHON_FAST_BUILD_ENABLED" = "true" ]; then
-            set +e
-            echo "Fast build is enabled"
-            install_python_packages_impl "python" "$REQUIREMENTS_TXT_FILE" "" ""
-            pipInstallExitCode=$?
-            set -e
-            if [[ $pipInstallExitCode != 0 ]]
-            then
-                LogError "Package installation failed | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
-                exit $pipInstallExitCode
-            fi
-        else
-            set +e
-            echo "Running pip install..."
-            START_TIME=$SECONDS
-            InstallCommand="python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE" 
-            
-            # Add find-links if PYTHON_PRELOADED_WHEELS_DIR is set
-            if [ -n "$PYTHON_PRELOADED_WHEELS_DIR" ]; then
-                echo "Using preloaded wheels from: $PYTHON_PRELOADED_WHEELS_DIR"
-                InstallCommand="$InstallCommand --find-links=$PYTHON_PRELOADED_WHEELS_DIR"
-            fi
-            
-            printf %s " , $InstallCommand | ts $TS_FMT" >> "$COMMAND_MANIFEST_FILE"
-            output=$( ( $InstallCommand | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
-            pipInstallExitCode=${PIPESTATUS[0]}
+    {{ if CustomBuildCommand | IsNotBlank }}
+        echo
+        echo "Running custom build command '{{ CustomBuildCommand }}'..."
+        echo
+        {{ CustomBuildCommand }}
+    {{ else }}
+        if [ -e "$REQUIREMENTS_TXT_FILE" ]
+        then
+            if [ "$PYTHON_FAST_BUILD_ENABLED" = "true" ]; then
+                set +e
+                echo "Fast build is enabled"
+                install_python_packages_impl "python" "$REQUIREMENTS_TXT_FILE" "" ""
+                pipInstallExitCode=$?
+                set -e
+                if [[ $pipInstallExitCode != 0 ]]
+                then
+                    LogError "Package installation failed | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
+                    exit $pipInstallExitCode
+                fi
+            else
+                set +e
+                echo "Running pip install..."
+                START_TIME=$SECONDS
+                InstallCommand="python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE" 
+                
+                # Add find-links if PYTHON_PRELOADED_WHEELS_DIR is set
+                if [ -n "$PYTHON_PRELOADED_WHEELS_DIR" ]; then
+                    echo "Using preloaded wheels from: $PYTHON_PRELOADED_WHEELS_DIR"
+                    InstallCommand="$InstallCommand --find-links=$PYTHON_PRELOADED_WHEELS_DIR"
+                fi
+                
+                printf %s " , $InstallCommand | ts $TS_FMT" >> "$COMMAND_MANIFEST_FILE"
+                output=$( ( $InstallCommand | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
+                pipInstallExitCode=${PIPESTATUS[0]}
 
+                ELAPSED_TIME=$(($SECONDS - $START_TIME))
+                set -e
+                echo "${output}"
+                echo "pip install done in $ELAPSED_TIME sec(s)."
+                if [[ $pipInstallExitCode != 0 ]]
+                then
+                    LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
+                    exit $pipInstallExitCode
+                fi
+            fi
+        elif [ -e "setup.py" ]
+        then
+            set +e
+            echo "Running pip install setuptools..."
+            START_TIME=$SECONDS
+            InstallSetuptoolsPipCommand="pip install setuptools"
+            printf %s " , $InstallSetuptoolsPipCommand" >> "$COMMAND_MANIFEST_FILE"
+            pip install setuptools
+            ELAPSED_TIME=$(($SECONDS - $START_TIME))
+            echo "pip install setuptools done in $ELAPSED_TIME sec(s)."
+            echo "Running python setup.py install..."
+            START_TIME=$SECONDS
+            InstallCommand="pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary | ts $TS_FMT"
+            printf %s " , $InstallCommand" >> "$COMMAND_MANIFEST_FILE"
+            output=$( ( pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
+            pythonBuildExitCode=${PIPESTATUS[0]}
             ELAPSED_TIME=$(($SECONDS - $START_TIME))
             set -e
             echo "${output}"
             echo "pip install done in $ELAPSED_TIME sec(s)."
-            if [[ $pipInstallExitCode != 0 ]]
+            if [[ $pythonBuildExitCode != 0 ]]
             then
-                LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
-                exit $pipInstallExitCode
+                LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your setup.py | ${moreInformation}"
+                exit $pythonBuildExitCode
             fi
-        fi
-    elif [ -e "setup.py" ]
-    then
-        set +e
-        echo "Running pip install setuptools..."
-        START_TIME=$SECONDS
-        InstallSetuptoolsPipCommand="pip install setuptools"
-        printf %s " , $InstallSetuptoolsPipCommand" >> "$COMMAND_MANIFEST_FILE"
-        pip install setuptools
-        ELAPSED_TIME=$(($SECONDS - $START_TIME))
-        echo "pip install setuptools done in $ELAPSED_TIME sec(s)."
-        echo "Running python setup.py install..."
-        START_TIME=$SECONDS
-        InstallCommand="pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary | ts $TS_FMT"
-        printf %s " , $InstallCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
-        pythonBuildExitCode=${PIPESTATUS[0]}
-        ELAPSED_TIME=$(($SECONDS - $START_TIME))
-        set -e
-        echo "${output}"
-        echo "pip install done in $ELAPSED_TIME sec(s)."
-        if [[ $pythonBuildExitCode != 0 ]]
+        elif [ -e "pyproject.toml" ]
         then
-            LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your setup.py | ${moreInformation}"
-            exit $pythonBuildExitCode
-        fi
-    elif [ -e "pyproject.toml" ]
-    then
-        if [ -e "uv.lock" ];
-        then
-            # Install using uv
-            set +e
-            echo "Detected uv.lock. Installing dependencies with uv..."
-            START_TIME=$SECONDS
-            InstallUvCommand="uv sync --active --link-mode copy"
-            printf %s " , $InstallUvCommand" >> "$COMMAND_MANIFEST_FILE"
-            output=$( ( $InstallUvCommand; exit ${PIPESTATUS[0]} ) 2>&1 )
-            uvExitCode=${PIPESTATUS[0]}
-            ELAPSED_TIME=$(($SECONDS - $START_TIME))
-            echo "uv sync done in $ELAPSED_TIME sec(s)."
-            set -e
-            echo "${output}"
-            if [[ $uvExitCode != 0 ]]; then
-                LogError "${output} | Exit code: ${uvExitCode} | Please review your uv.lock | ${moreInformation}"
-                exit $uvExitCode
-            fi
-        else
-            # Fallback to poetry
+            if [ -e "uv.lock" ];
+            then
+                # Install using uv
+                set +e
+                echo "Detected uv.lock. Installing dependencies with uv..."
+                START_TIME=$SECONDS
+                InstallUvCommand="uv sync --active --link-mode copy"
+                printf %s " , $InstallUvCommand" >> "$COMMAND_MANIFEST_FILE"
+                output=$( ( $InstallUvCommand; exit ${PIPESTATUS[0]} ) 2>&1 )
+                uvExitCode=${PIPESTATUS[0]}
+                ELAPSED_TIME=$(($SECONDS - $START_TIME))
+                echo "uv sync done in $ELAPSED_TIME sec(s)."
+                set -e
+                echo "${output}"
+                if [[ $uvExitCode != 0 ]]; then
+                    LogError "${output} | Exit code: ${uvExitCode} | Please review your uv.lock | ${moreInformation}"
+                    exit $uvExitCode
+                fi
+            else
+                # Fallback to poetry
 
-            set +e
-            echo "Running pip install poetry..."
-            START_TIME=$SECONDS
-            InstallPipCommand="pip install poetry"
-            printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
-            pip install poetry
-            echo "Running poetry install..."
+                set +e
+                echo "Running pip install poetry..."
+                START_TIME=$SECONDS
+                InstallPipCommand="pip install poetry"
+                printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
+                pip install poetry
+                echo "Running poetry install..."
 
-            # Try with --only main flag as --no-dev option is depreciated in latest poetry versions
-            InstallPoetryCommand="poetry install --only main"
-            printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
-            output=$( ( $InstallPoetryCommand; exit ${PIPESTATUS[0]} ) 2>&1)
-            pythonBuildExitCode=${PIPESTATUS[0]}
-
-            # Fallback to --no-dev flag
-            if [[ $pythonBuildExitCode != 0 ]]; then
-                echo "poetry install failed with --only main flag, falling back to --no-dev"
-                pip install poetry==1.8.5
-                InstallPoetryCommand="poetry install --no-dev"
+                # Try with --only main flag as --no-dev option is depreciated in latest poetry versions
+                InstallPoetryCommand="poetry install --only main"
                 printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
                 output=$( ( $InstallPoetryCommand; exit ${PIPESTATUS[0]} ) 2>&1)
                 pythonBuildExitCode=${PIPESTATUS[0]}
-                
-                # Final check after fallback
-                if [[ $pythonBuildExitCode != 0 ]]; then
-                    set -e
-                    echo "${output}"
-                    LogWarning "${output} | Exit code: ${pythonBuildExitCode} | Please review message | ${moreInformation}"
-                    exit $pythonBuildExitCode
-                fi
-            fi
 
-            ELAPSED_TIME=$(($SECONDS - $START_TIME))
-            echo "poetry install done in $ELAPSED_TIME sec(s)."
-            set -e
-            echo "${output}"
+                # Fallback to --no-dev flag
+                if [[ $pythonBuildExitCode != 0 ]]; then
+                    echo "poetry install failed with --only main flag, falling back to --no-dev"
+                    pip install poetry==1.8.5
+                    InstallPoetryCommand="poetry install --no-dev"
+                    printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
+                    output=$( ( $InstallPoetryCommand; exit ${PIPESTATUS[0]} ) 2>&1)
+                    pythonBuildExitCode=${PIPESTATUS[0]}
+                    
+                    # Final check after fallback
+                    if [[ $pythonBuildExitCode != 0 ]]; then
+                        set -e
+                        echo "${output}"
+                        LogWarning "${output} | Exit code: ${pythonBuildExitCode} | Please review message | ${moreInformation}"
+                        exit $pythonBuildExitCode
+                    fi
+                fi
+
+                ELAPSED_TIME=$(($SECONDS - $START_TIME))
+                echo "poetry install done in $ELAPSED_TIME sec(s)."
+                set -e
+                echo "${output}"
+            fi
+        else
+            echo $REQS_NOT_FOUND_MSG
         fi
-    else
-        echo $REQS_NOT_FOUND_MSG
-    fi
+    {{ end }}
 
     # For virtual environment, we use the actual 'python' alias that as setup by the venv,
     python_bin=python
 {{ else }}
     moreInformation="More information: https://aka.ms/troubleshoot-python"
-    if [ -e "$REQUIREMENTS_TXT_FILE" ]
-    then
-        if [ "$PYTHON_FAST_BUILD_ENABLED" = "true" ]; then
-            set +e
-            echo "Fast build is enabled"
-            install_python_packages_impl "python" "$REQUIREMENTS_TXT_FILE" "" ""
-            pipInstallExitCode=$?
-            set -e
-            if [[ $pipInstallExitCode != 0 ]]
-            then
-                LogError "Package installation failed | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
-                exit $pipInstallExitCode
+    {{ if CustomBuildCommand | IsNotBlank }}
+        echo
+        echo "Running custom build command '{{ CustomBuildCommand }}'..."
+        echo
+        {{ CustomBuildCommand }}
+    {{ else }}
+        if [ -e "$REQUIREMENTS_TXT_FILE" ]
+        then
+            if [ "$PYTHON_FAST_BUILD_ENABLED" = "true" ]; then
+                set +e
+                echo "Fast build is enabled"
+                install_python_packages_impl "python" "$REQUIREMENTS_TXT_FILE" "" ""
+                pipInstallExitCode=$?
+                set -e
+                if [[ $pipInstallExitCode != 0 ]]
+                then
+                    LogError "Package installation failed | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
+                    exit $pipInstallExitCode
+                fi
+            else
+                set +e
+                echo
+                echo Running pip install...
+                START_TIME=$SECONDS
+                InstallCommand="$python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE --target="{{ PackagesDirectory }}" {{ PipUpgradeFlag }}" 
+
+                # Add find-links if PYTHON_PRELOADED_WHEELS_DIR is set
+                if [ -n "$PYTHON_PRELOADED_WHEELS_DIR" ]; then
+                    echo "Using preloaded wheels from: $PYTHON_PRELOADED_WHEELS_DIR"
+                    InstallCommand="$InstallCommand --find-links=$PYTHON_PRELOADED_WHEELS_DIR"
+                fi
+
+                printf %s " , $InstallCommand | ts $TS_FMT" >> "$COMMAND_MANIFEST_FILE"
+                output=$( ( $InstallCommand | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
+                pipInstallExitCode=${PIPESTATUS[0]}
+
+                ELAPSED_TIME=$(($SECONDS - $START_TIME))
+                set -e
+                echo "${output}"
+                echo "pip install done in $ELAPSED_TIME sec(s)."
+                if [[ $pipInstallExitCode != 0 ]]
+                then
+                    LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
+                    exit $pipInstallExitCode
+                fi
             fi
-        else
-            set +e
+        elif [ -e "setup.py" ]
+        then
             echo
-            echo Running pip install...
             START_TIME=$SECONDS
-            InstallCommand="$python -m pip install --cache-dir $PIP_CACHE_DIR --prefer-binary -r $REQUIREMENTS_TXT_FILE --target="{{ PackagesDirectory }}" {{ PipUpgradeFlag }}" 
+            UpgradeCommand="pip install --upgrade pip"
+            printf %s " , $UpgradeCommand" >> "$COMMAND_MANIFEST_FILE"
+            pip install --upgrade pip
+            ELAPSED_TIME=$(($SECONDS - $START_TIME))
+            echo "pip upgrade done in $ELAPSED_TIME sec(s)."
 
-            # Add find-links if PYTHON_PRELOADED_WHEELS_DIR is set
-            if [ -n "$PYTHON_PRELOADED_WHEELS_DIR" ]; then
-                echo "Using preloaded wheels from: $PYTHON_PRELOADED_WHEELS_DIR"
-                InstallCommand="$InstallCommand --find-links=$PYTHON_PRELOADED_WHEELS_DIR"
-            fi
-
-            printf %s " , $InstallCommand | ts $TS_FMT" >> "$COMMAND_MANIFEST_FILE"
-            output=$( ( $InstallCommand | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
-            pipInstallExitCode=${PIPESTATUS[0]}
-
+            set +e
+            echo "Running pip install setuptools..."
+            START_TIME=$SECONDS
+            InstallSetuptoolsPipCommand="pip install setuptools"
+            printf %s " , $InstallSetuptoolsPipCommand" >> "$COMMAND_MANIFEST_FILE"
+            pip install setuptools
+            ELAPSED_TIME=$(($SECONDS - $START_TIME))
+            echo "pip install setuptools done in $ELAPSED_TIME sec(s)."
+            echo "Running pip install..."
+            START_TIME=$SECONDS
+            InstallCommand="$python -m pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary --target=\"{{ PackagesDirectory }}\" {{ PipUpgradeFlag }} | ts $TS_FMT"
+            printf %s " , $InstallCommand" >> "$COMMAND_MANIFEST_FILE"
+            output=$( ( $python -m pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary --target="{{ PackagesDirectory }}" {{ PipUpgradeFlag }} | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
+            pythonBuildExitCode=${PIPESTATUS[0]}
             ELAPSED_TIME=$(($SECONDS - $START_TIME))
             set -e
             echo "${output}"
             echo "pip install done in $ELAPSED_TIME sec(s)."
-            if [[ $pipInstallExitCode != 0 ]]
+            if [[ $pythonBuildExitCode != 0 ]]
             then
-                LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your requirements.txt | ${moreInformation}"
-                exit $pipInstallExitCode
+                LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your setup.py | ${moreInformation}"
+                exit $pythonBuildExitCode
             fi
-        fi
-    elif [ -e "setup.py" ]
-    then
-        echo
-        START_TIME=$SECONDS
-        UpgradeCommand="pip install --upgrade pip"
-        printf %s " , $UpgradeCommand" >> "$COMMAND_MANIFEST_FILE"
-        pip install --upgrade pip
-        ELAPSED_TIME=$(($SECONDS - $START_TIME))
-        echo "pip upgrade done in $ELAPSED_TIME sec(s)."
-
-        set +e
-        echo "Running pip install setuptools..."
-        START_TIME=$SECONDS
-        InstallSetuptoolsPipCommand="pip install setuptools"
-        printf %s " , $InstallSetuptoolsPipCommand" >> "$COMMAND_MANIFEST_FILE"
-        pip install setuptools
-        ELAPSED_TIME=$(($SECONDS - $START_TIME))
-        echo "pip install setuptools done in $ELAPSED_TIME sec(s)."
-        echo "Running pip install..."
-        START_TIME=$SECONDS
-        InstallCommand="$python -m pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary --target=\"{{ PackagesDirectory }}\" {{ PipUpgradeFlag }} | ts $TS_FMT"
-        printf %s " , $InstallCommand" >> "$COMMAND_MANIFEST_FILE"
-        output=$( ( $python -m pip install . --cache-dir $PIP_CACHE_DIR --prefer-binary --target="{{ PackagesDirectory }}" {{ PipUpgradeFlag }} | ts $TS_FMT; exit ${PIPESTATUS[0]} ) 2>&1; exit ${PIPESTATUS[0]} )
-        pythonBuildExitCode=${PIPESTATUS[0]}
-        ELAPSED_TIME=$(($SECONDS - $START_TIME))
-        set -e
-        echo "${output}"
-        echo "pip install done in $ELAPSED_TIME sec(s)."
-        if [[ $pythonBuildExitCode != 0 ]]
+        elif [ -e "pyproject.toml" ]
         then
-            LogError "${output} | Exit code: ${pipInstallExitCode} | Please review your setup.py | ${moreInformation}"
-            exit $pythonBuildExitCode
-        fi
-    elif [ -e "pyproject.toml" ]
-    then
-        if [ -e "uv.lock" ];
-        then
-            # Install using uv
-            echo "Detected uv.lock. Installing dependencies with uv..."
-            START_TIME=$SECONDS
-            echo "Installing uv..."
-            InstallUv="python -m pip install uv"
-            printf %s " , $InstallUv" >> "$COMMAND_MANIFEST_FILE"
-            $python -m pip install uv
-            ELAPSED_TIME=$(($SECONDS - $START_TIME))
-            echo "Installing uv done in $ELAPSED_TIME sec(s)."
-            START_TIME=$SECONDS
-            
-            set +e
-            SITE_PACKAGES_PATH="{{ PackagesDirectory }}"
-            echo "Installing dependencies..."
-            # Stream the export directly into uv pip install using process substitution
-            InstallUvCommand="uv export --locked | uv pip install --link-mode copy --target $SITE_PACKAGES_PATH -r -"
-            printf %s " , $InstallUvCommand" >> "$COMMAND_MANIFEST_FILE"
-            output=$( ( eval $InstallUvCommand; exit ${PIPESTATUS[0]} ) 2>&1 )
-            uvExitCode=${PIPESTATUS[0]}
-            ELAPSED_TIME=$(($SECONDS - $START_TIME))
-            set -e
-            echo "${output}"
-            echo "uv pip install done in $ELAPSED_TIME sec(s)."
-            if [[ $uvExitCode != 0 ]]; then
-                LogError "${output} | Exit code: ${uvExitCode} | Please review your uv.lock | ${moreInformation}"
-                exit $uvExitCode
-            fi
-        else
-            # Fallback to poetry
+            if [ -e "uv.lock" ];
+            then
+                # Install using uv
+                echo "Detected uv.lock. Installing dependencies with uv..."
+                START_TIME=$SECONDS
+                echo "Installing uv..."
+                InstallUv="python -m pip install uv"
+                printf %s " , $InstallUv" >> "$COMMAND_MANIFEST_FILE"
+                $python -m pip install uv
+                ELAPSED_TIME=$(($SECONDS - $START_TIME))
+                echo "Installing uv done in $ELAPSED_TIME sec(s)."
+                START_TIME=$SECONDS
+                
+                set +e
+                SITE_PACKAGES_PATH="{{ PackagesDirectory }}"
+                echo "Installing dependencies..."
+                # Stream the export directly into uv pip install using process substitution
+                InstallUvCommand="uv export --locked | uv pip install --link-mode copy --target $SITE_PACKAGES_PATH -r -"
+                printf %s " , $InstallUvCommand" >> "$COMMAND_MANIFEST_FILE"
+                output=$( ( eval $InstallUvCommand; exit ${PIPESTATUS[0]} ) 2>&1 )
+                uvExitCode=${PIPESTATUS[0]}
+                ELAPSED_TIME=$(($SECONDS - $START_TIME))
+                set -e
+                echo "${output}"
+                echo "uv pip install done in $ELAPSED_TIME sec(s)."
+                if [[ $uvExitCode != 0 ]]; then
+                    LogError "${output} | Exit code: ${uvExitCode} | Please review your uv.lock | ${moreInformation}"
+                    exit $uvExitCode
+                fi
+            else
+                # Fallback to poetry
 
-            set +e
-            echo "Running pip install poetry..."
-            START_TIME=$SECONDS
-            InstallPipCommand="pip install poetry"
-            printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
-            pip install poetry
-            echo "Running poetry install..."
+                set +e
+                echo "Running pip install poetry..."
+                START_TIME=$SECONDS
+                InstallPipCommand="pip install poetry"
+                printf %s " , $InstallPipCommand" >> "$COMMAND_MANIFEST_FILE"
+                pip install poetry
+                echo "Running poetry install..."
 
-            # Try with --only main flag as --no-dev option is depreciated in latest poetry versions
-            InstallPoetryCommand="poetry install --only main"
-            printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
-            output=$( ( $InstallPoetryCommand; exit ${PIPESTATUS[0]} ) 2>&1)
-            pythonBuildExitCode=${PIPESTATUS[0]}
-
-            # Fallback to --no-dev flag
-            if [[ $pythonBuildExitCode != 0 ]]; then
-                echo "poetry install failed with --only main flag, falling back to --no-dev"
-                pip install poetry==1.8.5
-                InstallPoetryCommand="poetry install --no-dev"
+                # Try with --only main flag as --no-dev option is depreciated in latest poetry versions
+                InstallPoetryCommand="poetry install --only main"
                 printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
                 output=$( ( $InstallPoetryCommand; exit ${PIPESTATUS[0]} ) 2>&1)
                 pythonBuildExitCode=${PIPESTATUS[0]}
-                
-                # Final check after fallback
-                if [[ $pythonBuildExitCode != 0 ]]; then
-                    set -e
-                    echo "${output}"
-                    LogWarning "${output} | Exit code: ${pythonBuildExitCode} | Please review message | ${moreInformation}"
-                    exit $pythonBuildExitCode
-                fi
-            fi
 
-            ELAPSED_TIME=$(($SECONDS - $START_TIME))
-            echo "poetry install done in $ELAPSED_TIME sec(s)."
-            set -e
-            echo "${output}"
+                # Fallback to --no-dev flag
+                if [[ $pythonBuildExitCode != 0 ]]; then
+                    echo "poetry install failed with --only main flag, falling back to --no-dev"
+                    pip install poetry==1.8.5
+                    InstallPoetryCommand="poetry install --no-dev"
+                    printf %s " , $InstallPoetryCommand" >> "$COMMAND_MANIFEST_FILE"
+                    output=$( ( $InstallPoetryCommand; exit ${PIPESTATUS[0]} ) 2>&1)
+                    pythonBuildExitCode=${PIPESTATUS[0]}
+                    
+                    # Final check after fallback
+                    if [[ $pythonBuildExitCode != 0 ]]; then
+                        set -e
+                        echo "${output}"
+                        LogWarning "${output} | Exit code: ${pythonBuildExitCode} | Please review message | ${moreInformation}"
+                        exit $pythonBuildExitCode
+                    fi
+                fi
+
+                ELAPSED_TIME=$(($SECONDS - $START_TIME))
+                echo "poetry install done in $ELAPSED_TIME sec(s)."
+                set -e
+                echo "${output}"
+            fi
+        else
+            echo $REQS_NOT_FOUND_MSG
         fi
-    else
-        echo $REQS_NOT_FOUND_MSG
-    fi
+    {{ end }}
 
     # We need to use the python binary selected by benv
     python_bin=$python

--- a/src/BuildScriptGenerator/Python/PythonBashBuildSnippetProperties.cs
+++ b/src/BuildScriptGenerator/Python/PythonBashBuildSnippetProperties.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
             string pythonBuildCommandsFileName = null,
             string pythonPackageWheelProperty = null,
             string customRequirementsTxtPath = null,
-            string pipUpgradeFlag = null)
+            string pipUpgradeFlag = null,
+            string customBuildCommand = null)
         {
             this.VirtualEnvironmentName = virtualEnvironmentName;
             this.VirtualEnvironmentModule = virtualEnvironmentModule;
@@ -38,6 +39,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
             this.PythonVersion = pythonVersion;
             this.CustomRequirementsTxtPath = customRequirementsTxtPath;
             this.PipUpgradeFlag = pipUpgradeFlag;
+            this.CustomBuildCommand = customBuildCommand;
         }
 
         public string VirtualEnvironmentName { get; set; }
@@ -71,5 +73,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         public string CustomRequirementsTxtPath { get; set; }
 
         public string PipUpgradeFlag { get; set; }
+
+        public string CustomBuildCommand { get; set; }
     }
 }

--- a/src/BuildScriptGenerator/Python/PythonPlatform.cs
+++ b/src/BuildScriptGenerator/Python/PythonPlatform.cs
@@ -296,7 +296,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
                 pythonBuildCommandsFileName: pythonBuildCommandsFile,
                 pythonPackageWheelProperty: pythonPackageWheelType,
                 customRequirementsTxtPath: customRequirementsTxtPath,
-                pipUpgradeFlag: pipUpgrade);
+                pipUpgradeFlag: pipUpgrade,
+                customBuildCommand: this.pythonScriptGeneratorOptions.CustomBuildCommand);
 
             string script = TemplateHelper.Render(
                 TemplateHelper.TemplateResource.PythonSnippet,

--- a/src/BuildScriptGenerator/Python/PythonScriptGeneratorOptions.cs
+++ b/src/BuildScriptGenerator/Python/PythonScriptGeneratorOptions.cs
@@ -15,6 +15,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
 
         public string DefaultVersion { get; set; }
 
+        /// <summary>
+        /// Gets or sets custom build command that will run instead of the default
+        /// pip/poetry/uv install in the generated build script.
+        /// </summary>
+        public string CustomBuildCommand { get; set; }
+
         public string CustomRequirementsTxtPath { get; set; }
     }
 }

--- a/src/BuildScriptGeneratorCli/Commands/BuildCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/BuildCommand.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                             options.ManifestDir = this.ManifestDir;
                             options.Properties = buildProperties;
                             options.ScriptOnly = false;
-                            options.SkipDetection = this.SkipDetection;
+                            options.SkipDetection = options.SkipDetection || this.SkipDetection;
                             options.DebianFlavor = this.ResolveOsType(options, console);
                             options.ImageType = this.ResolveImageType(options, console);
                         });

--- a/src/BuildScriptGeneratorCli/Commands/BuildScriptCommand.cs
+++ b/src/BuildScriptGeneratorCli/Commands/BuildScriptCommand.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
                 {
                     this.ConfigureBuildScriptGeneratorOptions(opts);
 
-                    opts.SkipDetection = this.SkipDetection;
+                    opts.SkipDetection = opts.SkipDetection || this.SkipDetection;
                     opts.DebianFlavor = this.ResolveOsType(opts, console);
                     opts.ImageType = this.ResolveImageType(opts, console);
                 });

--- a/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/BuildScriptGeneratorOptionsSetup.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
 
             options.OsFlavor = this.GetStringValue(SettingsKeys.OsFlavor);
             options.DebianFlavor = this.GetStringValue(SettingsKeys.DebianFlavor);
+            options.SkipDetection = this.GetBooleanValue(SettingsKeys.SkipPlatformDetection);
         }
     }
 }

--- a/src/BuildScriptGeneratorCli/Options/DotNetCoreScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/DotNetCoreScriptGeneratorOptionsSetup.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
         public void Configure(DotNetCoreScriptGeneratorOptions options)
         {
             options.MSBuildConfiguration = this.GetStringValue(SettingsKeys.MSBuildConfiguration);
+            options.CustomBuildCommand = this.GetStringValue(SettingsKeys.CustomBuildCommand);
             options.DotNetCoreRuntimeVersion = this.GetStringValue(SettingsKeys.DotNetVersion);
             options.DefaultRuntimeVersion = this.GetStringValue(SettingsKeys.DotNetDefaultVersion);
         }

--- a/src/BuildScriptGeneratorCli/Options/PhpScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/PhpScriptGeneratorOptionsSetup.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
             options.PhpComposerVersion = this.GetStringValue(SettingsKeys.PhpComposerVersion);
             options.PhpDefaultVersion = this.GetStringValue(SettingsKeys.PhpDefaultVersion);
             options.PhpComposerDefaultVersion = this.GetStringValue(SettingsKeys.PhpComposerDefaultVersion);
+            options.CustomBuildCommand = this.GetStringValue(SettingsKeys.CustomBuildCommand);
         }
     }
 }

--- a/src/BuildScriptGeneratorCli/Options/PythonScriptGeneratorOptionsSetup.cs
+++ b/src/BuildScriptGeneratorCli/Options/PythonScriptGeneratorOptionsSetup.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli.Options
             options.DefaultVersion = this.GetStringValue(SettingsKeys.PythonDefaultVersion);
             options.EnableCollectStatic = !this.GetBooleanValue(SettingsKeys.DisableCollectStatic);
             options.VirtualEnvironmentName = this.GetStringValue(SettingsKeys.PythonVirtualEnvironmentName);
+            options.CustomBuildCommand = this.GetStringValue(SettingsKeys.CustomBuildCommand);
             options.CustomRequirementsTxtPath = this.GetStringValue(SettingsKeys.CustomRequirementsTxtPath);
         }
     }

--- a/src/BuildScriptGeneratorCli/SettingsKeys.cs
+++ b/src/BuildScriptGeneratorCli/SettingsKeys.cs
@@ -81,5 +81,8 @@ namespace Microsoft.Oryx.BuildScriptGeneratorCli
         public const string EnableAcrSdkProvider = "ORYX_ENABLE_ACR_SDK_PROVIDER";
         public const string OryxAcrSdkRegistryUrl = "ORYX_ACR_SDK_REGISTRY_URL";
         public const string OryxAcrSdkRepositoryPrefix = "ORYX_ACR_SDK_REPOSITORY_PREFIX";
+
+        // Detection
+        public const string SkipPlatformDetection = "SKIP_PLATFORM_DETECTION";
     }
 }

--- a/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
@@ -89,7 +89,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
             Assert.Contains("custom build command", buildScriptSnippet.BashBuildScriptSnippet);
             Assert.DoesNotContain("dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
             Assert.DoesNotContain("dotnet publish", buildScriptSnippet.BashBuildScriptSnippet);
-            Assert.True(buildScriptSnippet.CopySourceDirectoryContentToDestinationDirectory);
+            // .NET always requires custom command to output to $DESTINATION_DIR directly
+            Assert.False(buildScriptSnippet.CopySourceDirectoryContentToDestinationDirectory);
         }
 
         [Fact]

--- a/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
@@ -59,6 +59,149 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
                             buildScriptSnippet.BashBuildScriptSnippet);
         }
 
+        [Fact]
+        public void GeneratedBuildSnippet_CustomBuildCommandWillExecute_InsteadOfRestoreAndPublish()
+        {
+            // Arrange
+            var installationScript = "test-script";
+            var dotNetCorePlatform = CreateDotNetCorePlatform(
+                DotNetCoreScriptGeneratorOptions: new DotNetCoreScriptGeneratorOptions
+                {
+                    CustomBuildCommand = "custom build command",
+                },
+                isDotNetCoreVersionAlreadyInstalled: true,
+                dotNetCoreInstallationScript: installationScript);
+            var repo = new MemorySourceRepo();
+            repo.AddFile(ProjectFileAzureBlazorWasmClientWithTargetFramework6, "test.csproj");
+            var context = CreateContext(repo);
+            var detectedResult = new DotNetCorePlatformDetectorResult
+            {
+                Platform = DotNetCoreConstants.PlatformName,
+                PlatformVersion = "10.0",
+                ProjectFile = "test.csproj",
+            };
+
+            // Act
+            var buildScriptSnippet = dotNetCorePlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains("custom build command", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("dotnet publish", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.True(buildScriptSnippet.CopySourceDirectoryContentToDestinationDirectory);
+        }
+
+        [Fact]
+        public void GeneratedBuildSnippet_DoesNotCopySourceToDestination_WhenNoCustomBuildCommand()
+        {
+            // Arrange
+            var dotNetCorePlatform = CreateDotNetCorePlatform(
+                isDotNetCoreVersionAlreadyInstalled: true);
+            var repo = new MemorySourceRepo();
+            repo.AddFile(ProjectFileAzureBlazorWasmClientWithTargetFramework6, "test.csproj");
+            var context = CreateContext(repo);
+            var detectedResult = new DotNetCorePlatformDetectorResult
+            {
+                Platform = DotNetCoreConstants.PlatformName,
+                PlatformVersion = "10.0",
+                ProjectFile = "test.csproj",
+            };
+
+            // Act
+            var buildScriptSnippet = dotNetCorePlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert - default dotnet publish handles output, so no auto-copy needed
+            Assert.NotNull(buildScriptSnippet);
+            Assert.False(buildScriptSnippet.CopySourceDirectoryContentToDestinationDirectory);
+        }
+
+        [Fact]
+        public void GeneratedBuildSnippet_SdkVersionDisplayIsPreserved_WithCustomBuildCommand()
+        {
+            // Arrange
+            var dotNetCorePlatform = CreateDotNetCorePlatform(
+                DotNetCoreScriptGeneratorOptions: new DotNetCoreScriptGeneratorOptions
+                {
+                    CustomBuildCommand = "make build",
+                },
+                isDotNetCoreVersionAlreadyInstalled: true);
+            var repo = new MemorySourceRepo();
+            repo.AddFile(ProjectFileAzureBlazorWasmClientWithTargetFramework6, "test.csproj");
+            var context = CreateContext(repo);
+            var detectedResult = new DotNetCorePlatformDetectorResult
+            {
+                Platform = DotNetCoreConstants.PlatformName,
+                PlatformVersion = "10.0",
+                ProjectFile = "test.csproj",
+            };
+
+            // Act
+            var buildScriptSnippet = dotNetCorePlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert - ensure dotnet env setup and display is preserved even when custom build command is used
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains("dotnet --version", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.Contains("make build", buildScriptSnippet.BashBuildScriptSnippet);
+        }
+
+        [Fact]
+        public void GeneratedBuildSnippet_UsesDotNetRestoreAndPublish_WhenNoCustomBuildCommandSet()
+        {
+            // Arrange
+            var dotNetCorePlatform = CreateDotNetCorePlatform(
+                isDotNetCoreVersionAlreadyInstalled: true);
+            var repo = new MemorySourceRepo();
+            repo.AddFile(ProjectFileAzureBlazorWasmClientWithTargetFramework6, "test.csproj");
+            var context = CreateContext(repo);
+            var detectedResult = new DotNetCorePlatformDetectorResult
+            {
+                Platform = DotNetCoreConstants.PlatformName,
+                PlatformVersion = "10.0",
+                ProjectFile = "test.csproj",
+            };
+
+            // Act
+            var buildScriptSnippet = dotNetCorePlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains("dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.Contains("dotnet publish", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("Running custom build command", buildScriptSnippet.BashBuildScriptSnippet);
+        }
+
+        [Fact]
+        public void GeneratedBuildSnippet_AOTWorkloadIsPreserved_WithCustomBuildCommand()
+        {
+            // Arrange
+            var dotNetCorePlatform = CreateDotNetCorePlatform(
+                DotNetCoreScriptGeneratorOptions: new DotNetCoreScriptGeneratorOptions
+                {
+                    CustomBuildCommand = "dotnet publish -c Release -o /output",
+                },
+                isDotNetCoreVersionAlreadyInstalled: true);
+            var repo = new MemorySourceRepo();
+            repo.AddFile(ProjectFileAzureBlazorWasmClientWithTargetFramework6, "test.csproj");
+            var context = CreateContext(repo);
+            var detectedResult = new DotNetCorePlatformDetectorResult
+            {
+                Platform = DotNetCoreConstants.PlatformName,
+                PlatformVersion = "10.0",
+                InstallAOTWorkloads = true,
+                ProjectFile = "test.csproj",
+            };
+
+            // Act
+            var buildScriptSnippet = dotNetCorePlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains(DotNetCoreConstants.InstallBlazorWebAssemblyAOTWorkloadCommand, buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.Contains("dotnet publish -c Release -o /output", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
+        }
+
         private BuildScriptGeneratorContext CreateContext(ISourceRepo sourceRepo = null)
         {
             sourceRepo = sourceRepo ?? new MemorySourceRepo();

--- a/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
+++ b/tests/BuildScriptGenerator.Tests/DotnetCore/DotNetCoreBuildScriptGenerationTest.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
             // Assert
             Assert.NotNull(buildScriptSnippet);
             Assert.Contains("custom build command", buildScriptSnippet.BashBuildScriptSnippet);
-            Assert.DoesNotContain("dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
-            Assert.DoesNotContain("dotnet publish", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("cmd=\"dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("cmd=\"dotnet publish", buildScriptSnippet.BashBuildScriptSnippet);
             // .NET always requires custom command to output to $DESTINATION_DIR directly
             Assert.False(buildScriptSnippet.CopySourceDirectoryContentToDestinationDirectory);
         }
@@ -167,8 +167,8 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.DotNetCore
 
             // Assert
             Assert.NotNull(buildScriptSnippet);
-            Assert.Contains("dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
-            Assert.Contains("dotnet publish", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.Contains("cmd=\"dotnet restore", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.Contains("cmd=\"dotnet publish", buildScriptSnippet.BashBuildScriptSnippet);
             Assert.DoesNotContain("Running custom build command", buildScriptSnippet.BashBuildScriptSnippet);
         }
 

--- a/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
@@ -982,6 +982,114 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
             Assert.Equal(expectedSdkVersion, result.PlatformVersion);
         }
 
+        [Fact]
+        public void GeneratedBuildSnippet_CustomBuildCommandWillExecute_InsteadOfComposerInstall()
+        {
+            // Arrange
+            var phpScriptGeneratorOptions = new PhpScriptGeneratorOptions
+            {
+                CustomBuildCommand = "make build",
+            };
+            var phpPlatform = CreatePhpPlatform(
+                phpScriptGeneratorOptions: phpScriptGeneratorOptions);
+            var repo = new MemorySourceRepo();
+            repo.AddFile("{}", PhpConstants.ComposerFileName);
+            var context = CreateContext(repo);
+            var detectedResult = new PhpPlatformDetectorResult
+            {
+                Platform = PhpConstants.PlatformName,
+                PlatformVersion = "8.4.0",
+            };
+
+            // Act
+            var buildScriptSnippet = phpPlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains("make build", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("composer install", buildScriptSnippet.BashBuildScriptSnippet);
+        }
+
+        [Fact]
+        public void GeneratedBuildSnippet_CustomBuildCommandWillExecute_EvenWithoutComposerJson()
+        {
+            // Arrange
+            var phpScriptGeneratorOptions = new PhpScriptGeneratorOptions
+            {
+                CustomBuildCommand = "php artisan build",
+            };
+            var phpPlatform = CreatePhpPlatform(
+                phpScriptGeneratorOptions: phpScriptGeneratorOptions);
+            var repo = new MemorySourceRepo();
+            repo.AddFile("<?php echo 'hi'; ?>", "index.php");
+            var context = CreateContext(repo);
+            var detectedResult = new PhpPlatformDetectorResult
+            {
+                Platform = PhpConstants.PlatformName,
+                PlatformVersion = "8.4.0",
+            };
+
+            // Act
+            var buildScriptSnippet = phpPlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains("php artisan build", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("No 'composer.json' file found", buildScriptSnippet.BashBuildScriptSnippet);
+        }
+
+        [Fact]
+        public void GeneratedBuildSnippet_UsesComposerInstall_WhenNoCustomBuildCommandSet()
+        {
+            // Arrange
+            var phpPlatform = CreatePhpPlatform();
+            var repo = new MemorySourceRepo();
+            repo.AddFile("{}", PhpConstants.ComposerFileName);
+            var context = CreateContext(repo);
+            var detectedResult = new PhpPlatformDetectorResult
+            {
+                Platform = PhpConstants.PlatformName,
+                PlatformVersion = "8.4.0",
+            };
+
+            // Act
+            var buildScriptSnippet = phpPlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains("composer install", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("Running custom build command", buildScriptSnippet.BashBuildScriptSnippet);
+        }
+
+        [Fact]
+        public void GeneratedBuildSnippet_PhpExecutableDisplayIsPreserved_WithCustomBuildCommand()
+        {
+            // Arrange
+            var phpScriptGeneratorOptions = new PhpScriptGeneratorOptions
+            {
+                CustomBuildCommand = "make build",
+            };
+            var phpPlatform = CreatePhpPlatform(
+                phpScriptGeneratorOptions: phpScriptGeneratorOptions);
+            var repo = new MemorySourceRepo();
+            repo.AddFile("{}", PhpConstants.ComposerFileName);
+            var context = CreateContext(repo);
+            var detectedResult = new PhpPlatformDetectorResult
+            {
+                Platform = PhpConstants.PlatformName,
+                PlatformVersion = "8.4.0",
+            };
+
+            // Act
+            var buildScriptSnippet = phpPlatform.GenerateBashBuildScriptSnippet(context, detectedResult);
+
+            // Assert
+            Assert.NotNull(buildScriptSnippet);
+            Assert.Contains("which php", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.Contains("PHP executable", buildScriptSnippet.BashBuildScriptSnippet);
+            Assert.Contains("make build", buildScriptSnippet.BashBuildScriptSnippet);
+        }
+
         private PhpPlatform CreatePhpPlatform(
             string[] supportedPhpVersions = null,
             string[] supportedPhpComposerVersions = null,

--- a/tests/BuildScriptGenerator.Tests/Python/PythonBashBuildSnippetTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Python/PythonBashBuildSnippetTest.cs
@@ -115,6 +115,158 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Python
         }
 
         [Fact]
+        public void GeneratedSnippet_ContainsCustomBuildCommand_InVirtualEnvironmentBranch()
+        {
+            // Arrange
+            var snippetProps = new PythonBashBuildSnippetProperties(
+                virtualEnvironmentName: "antenv",
+                virtualEnvironmentModule: "venv",
+                virtualEnvironmentParameters: string.Empty,
+                packagesDirectory: "packages_dir",
+                enableCollectStatic: false,
+                compressVirtualEnvCommand: null,
+                compressedVirtualEnvFileName: null,
+                pythonBuildCommandsFileName: FilePaths.BuildCommandsFileName,
+                pythonVersion: "3.14",
+                runPythonPackageCommand: false,
+                customBuildCommand: "custom build command");
+
+            // Act
+            var text = TemplateHelper.Render(TemplateHelper.TemplateResource.PythonSnippet, snippetProps);
+
+            // Assert
+            Assert.Contains("Running custom build command 'custom build command'...", text);
+            Assert.Contains("custom build command", text);
+            Assert.DoesNotContain("InstallUvCommand=\"uv sync --active --link-mode copy\"", text);
+        }
+
+        [Fact]
+        public void GeneratedSnippet_ContainsCustomBuildCommand_InPackagesDirectoryBranch()
+        {
+            // Arrange
+            var snippetProps = new PythonBashBuildSnippetProperties(
+                virtualEnvironmentName: null,
+                virtualEnvironmentModule: null,
+                virtualEnvironmentParameters: null,
+                packagesDirectory: "packages_dir",
+                enableCollectStatic: false,
+                compressVirtualEnvCommand: null,
+                compressedVirtualEnvFileName: null,
+                pythonBuildCommandsFileName: FilePaths.BuildCommandsFileName,
+                pythonVersion: "3.14",
+                runPythonPackageCommand: false,
+                customBuildCommand: "custom build command");
+
+            // Act
+            var text = TemplateHelper.Render(TemplateHelper.TemplateResource.PythonSnippet, snippetProps);
+
+            // Assert
+            Assert.Contains("Running custom build command 'custom build command'...", text);
+            Assert.Contains("custom build command", text);
+            Assert.DoesNotContain("UpgradeCommand=\"pip install --upgrade pip\"", text);
+        }
+
+        [Fact]
+        public void GeneratedSnippet_VirtualenvCreationIsPreserved_WithCustomBuildCommand()
+        {
+            // Arrange
+            var snippetProps = new PythonBashBuildSnippetProperties(
+                virtualEnvironmentName: "antenv",
+                virtualEnvironmentModule: "venv",
+                virtualEnvironmentParameters: string.Empty,
+                packagesDirectory: null,
+                enableCollectStatic: false,
+                compressVirtualEnvCommand: null,
+                compressedVirtualEnvFileName: null,
+                pythonBuildCommandsFileName: FilePaths.BuildCommandsFileName,
+                pythonVersion: "3.14",
+                runPythonPackageCommand: false,
+                customBuildCommand: "pip install --no-deps -r requirements.txt");
+
+            // Act
+            var text = TemplateHelper.Render(TemplateHelper.TemplateResource.PythonSnippet, snippetProps);
+
+            // Assert
+            Assert.Contains("Creating virtual environment", text);
+            Assert.Contains("Activating virtual environment", text);
+            Assert.Contains("pip install --no-deps -r requirements.txt", text);
+        }
+
+        [Fact]
+        public void GeneratedSnippet_CollectstaticIsPreserved_WithCustomBuildCommand_InVenvBranch()
+        {
+            // Arrange
+            var snippetProps = new PythonBashBuildSnippetProperties(
+                virtualEnvironmentName: "antenv",
+                virtualEnvironmentModule: "venv",
+                virtualEnvironmentParameters: string.Empty,
+                packagesDirectory: null,
+                enableCollectStatic: true,
+                compressVirtualEnvCommand: null,
+                compressedVirtualEnvFileName: null,
+                pythonBuildCommandsFileName: FilePaths.BuildCommandsFileName,
+                pythonVersion: "3.14",
+                runPythonPackageCommand: false,
+                customBuildCommand: "custom build command");
+
+            // Act
+            var text = TemplateHelper.Render(TemplateHelper.TemplateResource.PythonSnippet, snippetProps);
+
+            // Assert
+            Assert.Contains("custom build command", text);
+            Assert.Contains("collectstatic", text);
+        }
+
+        [Fact]
+        public void GeneratedSnippet_UsesDefaultPipInstall_WhenNoCustomBuildCommandSet_InVenvBranch()
+        {
+            // Arrange
+            var snippetProps = new PythonBashBuildSnippetProperties(
+                virtualEnvironmentName: "antenv",
+                virtualEnvironmentModule: "venv",
+                virtualEnvironmentParameters: string.Empty,
+                packagesDirectory: null,
+                enableCollectStatic: false,
+                compressVirtualEnvCommand: null,
+                compressedVirtualEnvFileName: null,
+                pythonBuildCommandsFileName: FilePaths.BuildCommandsFileName,
+                pythonVersion: "3.14",
+                runPythonPackageCommand: false);
+
+            // Act
+            var text = TemplateHelper.Render(TemplateHelper.TemplateResource.PythonSnippet, snippetProps);
+
+            // Assert
+            Assert.Contains("pip install", text);
+            Assert.DoesNotContain("Running custom build command", text);
+        }
+
+        [Fact]
+        public void GeneratedSnippet_UsesDefaultPipInstall_WhenNoCustomBuildCommandSet_InPackagesDirBranch()
+        {
+            // Arrange
+            var snippetProps = new PythonBashBuildSnippetProperties(
+                virtualEnvironmentName: null,
+                virtualEnvironmentModule: null,
+                virtualEnvironmentParameters: null,
+                packagesDirectory: "__oryx_packages__",
+                enableCollectStatic: false,
+                compressVirtualEnvCommand: null,
+                compressedVirtualEnvFileName: null,
+                pythonBuildCommandsFileName: FilePaths.BuildCommandsFileName,
+                pythonVersion: "3.14",
+                runPythonPackageCommand: false);
+
+            // Act
+            var text = TemplateHelper.Render(TemplateHelper.TemplateResource.PythonSnippet, snippetProps);
+
+            // Assert
+            Assert.Contains("pip install", text);
+            Assert.DoesNotContain("Running custom build command", text);
+        }
+
+
+        [Fact]
         public void GeneratedSnippet_DoesNotContainPackageWheelType_If_PackageWheelType_IsNotProvided()
         {
             // Arrange

--- a/tests/BuildScriptGenerator.Tests/Python/PythonPlatformTests.cs
+++ b/tests/BuildScriptGenerator.Tests/Python/PythonPlatformTests.cs
@@ -468,6 +468,34 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Python
             Assert.True(scriptGenerator.IsCleanRepo(repo));
         }
 
+        [Fact]
+        public void GeneratedBuildSnippet_CustomBuildCommandWillExecute_InsteadOfDefaultInstallCommands()
+        {
+            // Arrange
+            var pythonScriptGeneratorOptions = new PythonScriptGeneratorOptions
+            {
+                CustomBuildCommand = "custom build command",
+            };
+            var scriptGenerator = CreatePlatform(pythonScriptGeneratorOptions: pythonScriptGeneratorOptions);
+            var repo = new MemorySourceRepo();
+            repo.AddFile("", PythonConstants.RequirementsFileName);
+            repo.AddFile("print(1)", "bla.py");
+            var context = new BuildScriptGeneratorContext { SourceRepo = repo };
+            var detectorResult = new PythonPlatformDetectorResult
+            {
+                Platform = PythonConstants.PlatformName,
+                PlatformVersion = "3.7.5",
+            };
+
+            // Act
+            var snippet = scriptGenerator.GenerateBashBuildScriptSnippet(context, detectorResult);
+
+            // Assert
+            Assert.NotNull(snippet);
+            Assert.Contains("custom build command", snippet.BashBuildScriptSnippet);
+            Assert.DoesNotContain("UpgradeCommand=\"pip install --upgrade pip\"", snippet.BashBuildScriptSnippet);
+        }
+
         [Theory]
         [InlineData(null, "bla.tar.gz")]
         [InlineData("tar-gz", "bla.tar.gz")]


### PR DESCRIPTION
This pull request introduces support for specifying a custom build command(via CUSTOM_BUILD_COMMAND env var) in the generated build scripts for .NET Core, Python, and PHP platforms. This support already exists for nodejs platform. When a custom build command is provided, it overrides the default build steps (like `dotnet publish`, `composer install`, or `pip install`) in the generated scripts. The implementation includes new configuration options, updates to script templates, and ensures the build process and file copying logic adapt accordingly.
These changes make the build process more flexible and customizable for advanced scenarios.

Also introduced a new configuration key `SKIP_PLATFORM_DETECTION` and ensured the CLI correctly merges this setting from multiple sources. Follow up from #2918 to add parity to allow skip detection via env variable/cli flag.

## Testing
Deployed test apps for all platforms - nodejs, python, php, dotnet and set a CUSTOM_BUILD_COMMAND for each scenario and checked if the custom build command was used instead of oryx generated build commands. To verify this, the custom build command also writes a custom txt file which is served from `/` for each app

* Nodejs
<img width="723" height="867" alt="image" src="https://github.com/user-attachments/assets/13ff3c74-ca6a-4981-8f04-61f69681efcb" />
<img width="697" height="149" alt="image" src="https://github.com/user-attachments/assets/e739a30e-876e-49ac-bd4a-6f1f254c7fa8" />

* Python
<img width="1168" height="334" alt="image" src="https://github.com/user-attachments/assets/b1ac4dd9-022b-408e-9cd0-a72e76f588e2" />

* Dotnet
<img width="3325" height="954" alt="image" src="https://github.com/user-attachments/assets/aa945e37-2935-497d-a41d-dc271e479e91" />



