### PR TITLE
Fix version resolution when externalacr provider fails

### DIFF
--- a/src/BuildScriptGenerator/ExternalAcrSdkProvider.cs
+++ b/src/BuildScriptGenerator/ExternalAcrSdkProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         public const string ExternalAcrSdksStorageDir = "/var/OryxAcrSdks";
 
         private const string SocketPath = "/var/sdk-image-sockets/oryx-pull-sdk-image.socket";
-        private const int MaxTimeoutForSocketOperationInSeconds = 100;
+        private const int MaxTimeoutForSocketOperationInSeconds = 300;
 
         private readonly ILogger<ExternalAcrSdkProvider> logger;
         private readonly IStandardOutputWriter outputWriter;

--- a/src/BuildScriptGenerator/ExternalAcrSdkProvider.cs
+++ b/src/BuildScriptGenerator/ExternalAcrSdkProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         public const string ExternalAcrSdksStorageDir = "/var/OryxAcrSdks";
 
         private const string SocketPath = "/var/sdk-image-sockets/oryx-pull-sdk-image.socket";
-        private const int MaxTimeoutForSocketOperationInSeconds = 300;
+        private const int MaxTimeoutForSocketOperationInSeconds = 240;
 
         private readonly ILogger<ExternalAcrSdkProvider> logger;
         private readonly IStandardOutputWriter outputWriter;

--- a/src/BuildScriptGenerator/ExternalAcrVersionProviderBase.cs
+++ b/src/BuildScriptGenerator/ExternalAcrVersionProviderBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
     public class ExternalAcrVersionProviderBase
     {
         private const string SocketPath = "/var/sdk-image-sockets/oryx-pull-sdk-image.socket";
-        private const int MaxTimeoutForSocketOperationInSeconds = 300;
+        private const int MaxTimeoutForSocketOperationInSeconds = 240;
 
         private readonly BuildScriptGeneratorOptions commonOptions;
         private readonly ILogger logger;

--- a/src/BuildScriptGenerator/ExternalAcrVersionProviderBase.cs
+++ b/src/BuildScriptGenerator/ExternalAcrVersionProviderBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator
     public class ExternalAcrVersionProviderBase
     {
         private const string SocketPath = "/var/sdk-image-sockets/oryx-pull-sdk-image.socket";
-        private const int MaxTimeoutForSocketOperationInSeconds = 100;
+        private const int MaxTimeoutForSocketOperationInSeconds = 300;
 
         private readonly BuildScriptGeneratorOptions commonOptions;
         private readonly ILogger logger;

--- a/src/BuildScriptGenerator/Node/NodePlatform.cs
+++ b/src/BuildScriptGenerator/Node/NodePlatform.cs
@@ -847,10 +847,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
         {
             // If External ACR SDK provider is enabled, then we try to get the version from it first
             // before applying the hierarchical rules, because it has the highest priority in terms of version selection.
+            // Only use the version if it actually came from the External ACR provider, not from a fallback provider.
             if (this.commonOptions.EnableExternalAcrSdkProvider)
             {
                 var acrVersionInfo = this.nodeVersionProvider.GetVersionInfo();
-                if (acrVersionInfo?.DefaultVersion != null)
+                if (acrVersionInfo?.PlatformVersionSourceType == PlatformVersionSourceType.AvailableViaExternalAcrProvider
+                    && acrVersionInfo?.DefaultVersion != null)
                 {
                     return acrVersionInfo.DefaultVersion;
                 }

--- a/src/BuildScriptGenerator/Node/VersionProviders/NodeExternalAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/Node/VersionProviders/NodeExternalAcrVersionProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Node
                 return null;
             }
 
-            return PlatformVersionInfo.CreateAvailableOnAcr(
+            return PlatformVersionInfo.CreateAvailableViaExternalAcrProvider(
                 supportedVersions: new[] { version },
                 defaultVersion: version);
         }

--- a/src/BuildScriptGenerator/Php/PhpPlatform.cs
+++ b/src/BuildScriptGenerator/Php/PhpPlatform.cs
@@ -582,10 +582,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
             string ResolvePhpVersion(string detectedVersion)
             {
                 // If external ACR provider is enabled, try to resolve version from it first.
+                // Only use the version if it actually came from the External ACR provider, not from a fallback provider.
                 if (this.commonOptions.EnableExternalAcrSdkProvider)
                 {
                     var acrVersionInfo = this.phpVersionProvider.GetVersionInfo();
-                    if (acrVersionInfo?.DefaultVersion != null)
+                    if (acrVersionInfo?.PlatformVersionSourceType == PlatformVersionSourceType.AvailableViaExternalAcrProvider
+                        && acrVersionInfo?.DefaultVersion != null)
                     {
                         this.logger.LogDebug("External ACR SDK provider is enabled and returned version {version} for PHP.", acrVersionInfo.DefaultVersion);
                         return acrVersionInfo.DefaultVersion;

--- a/src/BuildScriptGenerator/Php/VersionProviders/PhpExternalAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/Php/VersionProviders/PhpExternalAcrVersionProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Php
                 return null;
             }
 
-            return PlatformVersionInfo.CreateAvailableOnAcr(
+            return PlatformVersionInfo.CreateAvailableViaExternalAcrProvider(
                 supportedVersions: new[] { version },
                 defaultVersion: version);
         }

--- a/src/BuildScriptGenerator/PlatformVersionInfo.cs
+++ b/src/BuildScriptGenerator/PlatformVersionInfo.cs
@@ -61,5 +61,17 @@ namespace Microsoft.Oryx.BuildScriptGenerator
                 PlatformVersionSourceType = PlatformVersionSourceType.AvailableOnAcr,
             };
         }
+
+        public static PlatformVersionInfo CreateAvailableViaExternalAcrProvider(
+            IEnumerable<string> supportedVersions,
+            string defaultVersion)
+        {
+            return new PlatformVersionInfo
+            {
+                SupportedVersions = supportedVersions,
+                DefaultVersion = defaultVersion,
+                PlatformVersionSourceType = PlatformVersionSourceType.AvailableViaExternalAcrProvider,
+            };
+        }
     }
 }

--- a/src/BuildScriptGenerator/PlatformVersionSourceType.cs
+++ b/src/BuildScriptGenerator/PlatformVersionSourceType.cs
@@ -11,5 +11,6 @@ namespace Microsoft.Oryx.BuildScriptGenerator
         AvailableOnWeb,
         AvailableViaExternalProvider,
         AvailableOnAcr,
+        AvailableViaExternalAcrProvider,
     }
 }

--- a/src/BuildScriptGenerator/Python/PythonPlatform.cs
+++ b/src/BuildScriptGenerator/Python/PythonPlatform.cs
@@ -834,10 +834,12 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
         {
             // If External ACR SDK provider is enabled, then we try to get the version from it first
             // before applying the hierarchical rules, because it has the highest priority in terms of version selection.
+            // Only use the version if it actually came from the External ACR provider, not from a fallback provider.
             if (this.commonOptions.EnableExternalAcrSdkProvider)
             {
                 var acrVersionInfo = this.versionProvider.GetVersionInfo();
-                if (acrVersionInfo?.DefaultVersion != null)
+                if (acrVersionInfo?.PlatformVersionSourceType == PlatformVersionSourceType.AvailableViaExternalAcrProvider
+                    && acrVersionInfo?.DefaultVersion != null)
                 {
                     return acrVersionInfo.DefaultVersion;
                 }

--- a/src/BuildScriptGenerator/Python/VersionProviders/PythonExternalAcrVersionProvider.cs
+++ b/src/BuildScriptGenerator/Python/VersionProviders/PythonExternalAcrVersionProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Python
                 return null;
             }
 
-            return PlatformVersionInfo.CreateAvailableOnAcr(
+            return PlatformVersionInfo.CreateAvailableViaExternalAcrProvider(
                 supportedVersions: new[] { version },
                 defaultVersion: version);
         }

--- a/tests/BuildScriptGenerator.Tests/Node/NodePlatformTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Node/NodePlatformTest.cs
@@ -1181,11 +1181,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Node
         }
 
         [Fact]
-        public void Detect_ReturnsVersionProviderDefault_WhenExternalAcrEnabled_OverridingDetectedVersion()
+        public void Detect_ReturnsDetectedVersion_WhenExternalAcrEnabled_ButVersionNotFromExternalAcr()
         {
             // Arrange
-            var detectedVersion = "14.0.0";
-            var versionProviderDefault = "18.0.0";
+            var detectedVersion = "22.0.0";
+            var versionProviderDefault = "24.0.0";
             var commonOptions = new BuildScriptGeneratorOptions
             {
                 EnableExternalAcrSdkProvider = true,
@@ -1200,11 +1200,89 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Node
             // Act
             var result = platform.Detect(context);
 
-            // Assert - ExternalACR short-circuit uses version provider's DefaultVersion,
-            // overriding the detected version
+            // Assert - When the version info did not come from the External ACR provider,
+            // the detected version should be used instead of the provider's default
             Assert.NotNull(result);
             Assert.Equal(NodeConstants.PlatformName, result.Platform);
-            Assert.Equal(versionProviderDefault, result.PlatformVersion);
+            Assert.Equal(detectedVersion, result.PlatformVersion);
+        }
+
+        [Fact]
+        public void Detect_ReturnsUserSpecifiedVersion_WhenExternalAcrEnabled_ButVersionNotFromExternalAcr()
+        {
+            // Arrange
+            var userVersion = "22.0.0";
+            var detectedVersion = "20.0.0";
+            var versionProviderDefault = "24.0.0";
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                EnableExternalAcrSdkProvider = true,
+            };
+            var nodeScriptGeneratorOptions = new NodeScriptGeneratorOptions
+            {
+                NodeVersion = userVersion,
+            };
+            var platform = CreateNodePlatform(
+                supportedNodeVersions: new[] { userVersion, detectedVersion, versionProviderDefault },
+                defaultVersion: versionProviderDefault,
+                detectedVersion: detectedVersion,
+                commonOptions: commonOptions,
+                nodeScriptGeneratorOptions: nodeScriptGeneratorOptions);
+            var context = CreateContext();
+
+            // Act
+            var result = platform.Detect(context);
+
+            // Assert - When ExternalACR fails and blob fallback is used,
+            // --platform-version should win over the blob default
+            Assert.NotNull(result);
+            Assert.Equal(NodeConstants.PlatformName, result.Platform);
+            Assert.Equal(userVersion, result.PlatformVersion);
+        }
+
+        [Fact]
+        public void Detect_ReturnsExternalAcrVersion_WhenVersionSourceIsExternalAcr()
+        {
+            // Arrange
+            var detectedVersion = "22.0.0";
+            var externalAcrVersion = "24.0.0";
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                EnableExternalAcrSdkProvider = true,
+            };
+            var nodeScriptGeneratorOptions = new NodeScriptGeneratorOptions();
+            var versionProvider = new TestNodeVersionProvider(
+                new[] { detectedVersion, externalAcrVersion },
+                externalAcrVersion,
+                PlatformVersionSourceType.AvailableViaExternalAcrProvider);
+            var externalSdkProvider = new TestExternalSdkProvider();
+            var environment = new TestEnvironment();
+            var detector = new TestNodePlatformDetector(detectedVersion: detectedVersion);
+            var platformInstaller = new NodePlatformInstaller(
+                Options.Create(commonOptions),
+                NullLoggerFactory.Instance);
+            var platform = new TestNodePlatform(
+                Options.Create(commonOptions),
+                Options.Create(nodeScriptGeneratorOptions),
+                versionProvider,
+                NullLogger<NodePlatform>.Instance,
+                detector,
+                environment,
+                platformInstaller,
+                externalSdkProvider,
+                new TestExternalAcrSdkProvider(),
+                new TestAcrSdkProvider(),
+                TelemetryClientHelper.GetTelemetryClient(),
+                new DefaultStandardOutputWriter());
+            var context = CreateContext();
+
+            // Act
+            var result = platform.Detect(context);
+
+            // Assert - When version truly came from External ACR, it should override detected version
+            Assert.NotNull(result);
+            Assert.Equal(NodeConstants.PlatformName, result.Platform);
+            Assert.Equal(externalAcrVersion, result.PlatformVersion);
         }
 
         private TestNodePlatform CreateNodePlatform(
@@ -1406,6 +1484,7 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Node
         {
             private readonly string[] _supportedNodeVersions;
             private readonly string _defaultVersion;
+            private readonly PlatformVersionSourceType _sourceType;
 
             public TestNodeVersionProvider()
             {
@@ -1415,11 +1494,24 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Node
             {
                 _supportedNodeVersions = supportedNodeVersions;
                 _defaultVersion = defaultVersion;
+                _sourceType = PlatformVersionSourceType.OnDisk;
+            }
+
+            public TestNodeVersionProvider(
+                string[] supportedNodeVersions,
+                string defaultVersion,
+                PlatformVersionSourceType sourceType)
+            {
+                _supportedNodeVersions = supportedNodeVersions;
+                _defaultVersion = defaultVersion;
+                _sourceType = sourceType;
             }
 
             public PlatformVersionInfo GetVersionInfo()
             {
-                return PlatformVersionInfo.CreateOnDiskVersionInfo(_supportedNodeVersions, _defaultVersion);
+                return _sourceType == PlatformVersionSourceType.AvailableViaExternalAcrProvider
+                    ? PlatformVersionInfo.CreateAvailableViaExternalAcrProvider(_supportedNodeVersions, _defaultVersion)
+                    : PlatformVersionInfo.CreateOnDiskVersionInfo(_supportedNodeVersions, _defaultVersion);
             }
         }
 

--- a/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
+++ b/tests/BuildScriptGenerator.Tests/Php/PhpPlatformTest.cs
@@ -887,11 +887,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
         }
 
         [Fact]
-        public void Detect_ReturnsVersionProviderDefault_WhenExternalAcrEnabled_OverridingDetectedVersion()
+        public void Detect_ReturnsDetectedVersion_WhenExternalAcrEnabled_ButVersionNotFromExternalAcr()
         {
             // Arrange
-            var detectedVersion = "7.3.5";
-            var versionProviderDefault = "8.1.0";
+            var detectedVersion = "8.3.0";
+            var versionProviderDefault = "8.4.0";
             var repo = new MemorySourceRepo();
             repo.AddFile("<?php echo true; ?>", "foo.php");
             var context = CreateContext(repo);
@@ -908,11 +908,97 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
             // Act
             var result = platform.Detect(context);
 
-            // Assert - ExternalACR short-circuit uses version provider's DefaultVersion,
-            // overriding the detected version
+            // Assert - When the version info did not come from the External ACR provider,
+            // the detected version should be used instead of the provider's default
             Assert.NotNull(result);
             Assert.Equal(PhpConstants.PlatformName, result.Platform);
-            Assert.Equal(versionProviderDefault, result.PlatformVersion);
+            Assert.Equal(detectedVersion, result.PlatformVersion);
+        }
+
+        [Fact]
+        public void Detect_ReturnsUserSpecifiedVersion_WhenExternalAcrEnabled_ButVersionNotFromExternalAcr()
+        {
+            // Arrange
+            var userVersion = "8.3.0";
+            var detectedVersion = "8.2.0";
+            var versionProviderDefault = "8.4.0";
+            var repo = new MemorySourceRepo();
+            repo.AddFile("<?php echo true; ?>", "foo.php");
+            var context = CreateContext(repo);
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                EnableExternalAcrSdkProvider = true,
+            };
+            var phpScriptGeneratorOptions = new PhpScriptGeneratorOptions
+            {
+                PhpVersion = userVersion,
+            };
+            var platform = CreatePhpPlatform(
+                supportedPhpVersions: new[] { userVersion, detectedVersion, versionProviderDefault },
+                defaultVersion: versionProviderDefault,
+                detectedVersion: detectedVersion,
+                commonOptions: commonOptions,
+                phpScriptGeneratorOptions: phpScriptGeneratorOptions);
+
+            // Act
+            var result = platform.Detect(context);
+
+            // Assert - When ExternalACR fails and blob fallback is used,
+            // --platform-version should win over the blob default
+            Assert.NotNull(result);
+            Assert.Equal(PhpConstants.PlatformName, result.Platform);
+            Assert.Equal(userVersion, result.PlatformVersion);
+        }
+
+        [Fact]
+        public void Detect_ReturnsExternalAcrVersion_WhenVersionSourceIsExternalAcr()
+        {
+            // Arrange
+            var detectedVersion = "8.3.0";
+            var externalAcrVersion = "8.4.0";
+            var repo = new MemorySourceRepo();
+            repo.AddFile("<?php echo true; ?>", "foo.php");
+            var context = CreateContext(repo);
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                EnableExternalAcrSdkProvider = true,
+            };
+            var versionProvider = new TestPhpVersionProvider(
+                new[] { detectedVersion, externalAcrVersion },
+                externalAcrVersion,
+                PlatformVersionSourceType.AvailableViaExternalAcrProvider);
+            var composerVersionProvider = new TestPhpComposerVersionProvider(
+                new[] { PhpVersions.ComposerDefaultVersion },
+                PhpVersions.ComposerDefaultVersion);
+            var detector = new TestPhpPlatformDetector(detectedVersion: detectedVersion);
+            var phpInstaller = new TestPhpPlatformInstaller(
+                Options.Create(commonOptions),
+                isVersionAlreadyInstalled: true);
+            var phpComposerInstaller = new TestPhpComposerInstaller(
+                Options.Create(commonOptions),
+                isVersionAlreadyInstalled: true);
+            var platform = new TestPhpPlatform(
+                Options.Create(new PhpScriptGeneratorOptions()),
+                Options.Create(commonOptions),
+                versionProvider,
+                composerVersionProvider,
+                NullLogger<TestPhpPlatform>.Instance,
+                detector,
+                phpInstaller,
+                phpComposerInstaller,
+                new TestExternalSdkProvider(),
+                new TestExternalAcrSdkProvider(),
+                new TestAcrSdkProvider(),
+                TelemetryClientHelper.GetTelemetryClient(),
+                new DefaultStandardOutputWriter());
+
+            // Act
+            var result = platform.Detect(context);
+
+            // Assert - When version truly came from External ACR, it should override detected version
+            Assert.NotNull(result);
+            Assert.Equal(PhpConstants.PlatformName, result.Platform);
+            Assert.Equal(externalAcrVersion, result.PlatformVersion);
         }
 
         [Fact]

--- a/tests/BuildScriptGenerator.Tests/Php/TestPhpVersionProvider.cs
+++ b/tests/BuildScriptGenerator.Tests/Php/TestPhpVersionProvider.cs
@@ -12,11 +12,23 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
     {
         private readonly string[] _supportedPhpVersions;
         private readonly string _defaultVersion;
+        private readonly PlatformVersionSourceType _sourceType;
 
         public TestPhpVersionProvider(string[] supportedPhpVersions, string defaultVersion)
         {
             _supportedPhpVersions = supportedPhpVersions;
             _defaultVersion = defaultVersion;
+            _sourceType = PlatformVersionSourceType.OnDisk;
+        }
+
+        public TestPhpVersionProvider(
+            string[] supportedPhpVersions,
+            string defaultVersion,
+            PlatformVersionSourceType sourceType)
+        {
+            _supportedPhpVersions = supportedPhpVersions;
+            _defaultVersion = defaultVersion;
+            _sourceType = sourceType;
         }
 
         public PlatformVersionInfo GetVersionInfo()
@@ -25,6 +37,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Php
             if (version == null)
             {
                 version = PhpVersions.Php73Version;
+            }
+
+            if (_sourceType == PlatformVersionSourceType.AvailableViaExternalAcrProvider)
+            {
+                return PlatformVersionInfo.CreateAvailableViaExternalAcrProvider(_supportedPhpVersions, version);
             }
 
             return PlatformVersionInfo.CreateOnDiskVersionInfo(_supportedPhpVersions, version);

--- a/tests/BuildScriptGenerator.Tests/Python/PythonPlatformTests.cs
+++ b/tests/BuildScriptGenerator.Tests/Python/PythonPlatformTests.cs
@@ -648,11 +648,11 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Python
         }
 
         [Fact]
-        public void Detect_ReturnsVersionProviderDefault_WhenExternalAcrEnabled_OverridingDetectedVersion()
+        public void Detect_ReturnsDetectedVersion_WhenExternalAcrEnabled_ButVersionNotFromExternalAcr()
         {
             // Arrange
-            var detectedVersion = "3.8.0";
-            var versionProviderDefault = "3.10.0";
+            var detectedVersion = "3.13.0";
+            var versionProviderDefault = "3.14.0";
             var commonOptions = new BuildScriptGeneratorOptions
             {
                 EnableExternalAcrSdkProvider = true,
@@ -667,12 +667,84 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Python
             // Act
             var result = platform.Detect(context);
 
-            // Assert - ExternalACR short-circuit uses version provider's DefaultVersion,
-            // overriding the detected version
+            // Assert - When the version info did not come from the External ACR provider,
+            // the detected version should be used instead of the provider's default
             Assert.NotNull(result);
             Assert.Equal(PythonConstants.PlatformName, result.Platform);
-            Assert.Equal(versionProviderDefault, result.PlatformVersion);
+            Assert.Equal(detectedVersion, result.PlatformVersion);
         }
+
+        [Fact]
+        public void Detect_ReturnsUserSpecifiedVersion_WhenExternalAcrEnabled_ButVersionNotFromExternalAcr()
+        {
+            // Arrange
+            var userVersion = "3.13.0";
+            var detectedVersion = "3.12.0";
+            var versionProviderDefault = "3.14.0";
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                EnableExternalAcrSdkProvider = true,
+            };
+            var pythonScriptGeneratorOptions = new PythonScriptGeneratorOptions
+            {
+                PythonVersion = userVersion,
+            };
+            var platform = CreatePlatform(
+                supportedVersions: new[] { userVersion, detectedVersion, versionProviderDefault },
+                defaultVersion: versionProviderDefault,
+                detectedVersion: detectedVersion,
+                commonOptions: commonOptions,
+                pythonScriptGeneratorOptions: pythonScriptGeneratorOptions);
+            var context = CreateContext();
+
+            // Act
+            var result = platform.Detect(context);
+
+            // Assert - When ExternalACR fails and blob fallback is used,
+            // --platform-version should win over the blob default
+            Assert.NotNull(result);
+            Assert.Equal(PythonConstants.PlatformName, result.Platform);
+            Assert.Equal(userVersion, result.PlatformVersion);
+        }
+
+        [Fact]
+        public void Detect_ReturnsExternalAcrVersion_WhenVersionSourceIsExternalAcr()
+        {
+            // Arrange
+            var detectedVersion = "3.13.0";
+            var externalAcrVersion = "3.14.0";
+            var commonOptions = new BuildScriptGeneratorOptions
+            {
+                EnableExternalAcrSdkProvider = true,
+            };
+            var versionProvider = new TestPythonVersionProvider(
+                new[] { detectedVersion, externalAcrVersion },
+                externalAcrVersion,
+                PlatformVersionSourceType.AvailableViaExternalAcrProvider);
+            var detector = new TestPythonPlatformDetector(detectedVersion: detectedVersion);
+            var platform = new PythonPlatform(
+                Options.Create(commonOptions),
+                Options.Create(new PythonScriptGeneratorOptions()),
+                versionProvider,
+                NullLogger<PythonPlatform>.Instance,
+                detector,
+                new PythonPlatformInstaller(Options.Create(commonOptions), NullLoggerFactory.Instance),
+                new TestExternalSdkProvider(),
+                new TestExternalAcrSdkProvider(),
+                new TestAcrSdkProvider(),
+                TelemetryClientHelper.GetTelemetryClient(),
+                new DefaultStandardOutputWriter());
+            var context = CreateContext();
+
+            // Act
+            var result = platform.Detect(context);
+
+            // Assert - When version truly came from External ACR, it should override detected version
+            Assert.NotNull(result);
+            Assert.Equal(PythonConstants.PlatformName, result.Platform);
+            Assert.Equal(externalAcrVersion, result.PlatformVersion);
+        }
+
         private PythonPlatform CreatePlatform(
             IPythonVersionProvider pythonVersionProvider,
             IExternalSdkProvider externalSdkProvider,

--- a/tests/BuildScriptGenerator.Tests/Python/TestPythonVersionProvider.cs
+++ b/tests/BuildScriptGenerator.Tests/Python/TestPythonVersionProvider.cs
@@ -11,16 +11,30 @@ namespace Microsoft.Oryx.BuildScriptGenerator.Tests.Python
     {
         private readonly string[] _supportedPythonVersions;
         private readonly string _defaultVersion;
+        private readonly PlatformVersionSourceType _sourceType;
 
         public TestPythonVersionProvider(string[] supportedPythonVersions, string defaultVersion)
         {
             _supportedPythonVersions = supportedPythonVersions;
             _defaultVersion = defaultVersion;
+            _sourceType = PlatformVersionSourceType.OnDisk;
+        }
+
+        public TestPythonVersionProvider(
+            string[] supportedPythonVersions,
+            string defaultVersion,
+            PlatformVersionSourceType sourceType)
+        {
+            _supportedPythonVersions = supportedPythonVersions;
+            _defaultVersion = defaultVersion;
+            _sourceType = sourceType;
         }
 
         public PlatformVersionInfo GetVersionInfo()
         {
-            return PlatformVersionInfo.CreateOnDiskVersionInfo(_supportedPythonVersions, _defaultVersion);
+            return _sourceType == PlatformVersionSourceType.AvailableViaExternalAcrProvider
+                ? PlatformVersionInfo.CreateAvailableViaExternalAcrProvider(_supportedPythonVersions, _defaultVersion)
+                : PlatformVersionInfo.CreateOnDiskVersionInfo(_supportedPythonVersions, _defaultVersion);
         }
     }
 }


### PR DESCRIPTION
This pull request refines how platform versions are selected when using the External ACR SDK provider for Node, Python, and PHP. The changes ensure that a version is only used if it was explicitly provided by the External ACR provider, not from any fallback source. 
Also increase timeout for externalacrprovider from 100 to 240s to compensate for any slow image pulls causing timeouts

## Testing
Deploy an app where externalacr provider is enabled but an error in getting sdk version is simulated by absence of sdk companion image
* Before the fix -> fallback to defaultversion.txt via external blob sdk provider [python 3.12 apps ends up using 3.8 sdk]
 
<img width="1351" height="654" alt="image" src="https://github.com/user-attachments/assets/7b3e9505-2e31-4f70-b1f5-a8b4e28667d3" />

* After the fix 
the user specified platform version via `--platform-version` takes precedence and we get appropriate version from external blob sdk provider
<img width="1345" height="640" alt="image" src="https://github.com/user-attachments/assets/347de996-a91a-43d7-88b3-473a1702bc33" />


