### PR TITLE
Update cgmanifest to match pinned Python runtime package versions

### DIFF
--- a/images/runtime/python/cgmanifest.json
+++ b/images/runtime/python/cgmanifest.json
@@ -5,7 +5,7 @@
       "Component": {
         "pip": {
           "Name": "viztracer",
-          "Version": "0.15.5"
+          "Version": "0.15.6"
         },
         "Type": "pip"
       },
@@ -15,7 +15,7 @@
       "Component": {
         "pip": {
           "Name": "vizplugins",
-          "Version": "0.1.2"
+          "Version": "0.1.3"
         },
         "Type": "pip"
       },
@@ -25,7 +25,7 @@
       "Component": {
         "pip": {
           "Name": "orjson",
-          "Version": "3.9.15"
+          "Version": "3.11.8"
         },
         "Type": "pip"
       },


### PR DESCRIPTION
Updates cgmanifest.json to reflect the versions currently pinned in the Python runtime Dockerfiles:

These were out of sync with template.Dockerfile and noble.Dockerfile, causing Component Governance to track incorrect versions.

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
