### PR TITLE
Unhold nginx after apt-get upgrade in PHP-FPM Dockerfiles

### DIFF
--- a/images/runtime/php-fpm/8.2/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.2/bullseye.Dockerfile
@@ -319,16 +319,12 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
     && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
 
 RUN set -eux; \
-    if [[ $PHP_VERSION == 7.4.* || $PHP_VERSION == 8.0.* || $PHP_VERSION == 8.1.*  || $PHP_VERSION == 8.2.* || $PHP_VERSION == 8.3.* ]]; then \
-		apt-get update \
-        && apt-get upgrade -y \
-        && apt-get install -y --no-install-recommends apache2-dev \
-        && docker-php-ext-configure gd --with-freetype --with-jpeg \
-        && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl ; \
-    else \
-		docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-        && docker-php-ext-configure imap --with-kerberos --with-imap-ssl ; \
-    fi
+    apt-get update \
+    && apt-get upgrade -y \
+    && apt-mark unhold nginx \
+    && apt-get install -y --no-install-recommends apache2-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
 
 RUN docker-php-ext-configure pdo_odbc --with-pdo-odbc=unixODBC,/usr \
     && docker-php-ext-install gd \

--- a/images/runtime/php-fpm/8.3/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bookworm.Dockerfile
@@ -313,16 +313,12 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
     && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
 
 RUN set -eux; \
-    if [[ $PHP_VERSION == 7.4.* || $PHP_VERSION == 8.0.* || $PHP_VERSION == 8.1.*  || $PHP_VERSION == 8.2.* || $PHP_VERSION == 8.3.* ]]; then \
-		apt-get update \
-        && apt-get upgrade -y \
-        && apt-get install -y --no-install-recommends apache2-dev \
-        && docker-php-ext-configure gd --with-freetype --with-jpeg \
-        && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl ; \
-    else \
-		docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-        && docker-php-ext-configure imap --with-kerberos --with-imap-ssl ; \
-    fi
+    apt-get update \
+    && apt-get upgrade -y \
+    && apt-mark unhold nginx \
+    && apt-get install -y --no-install-recommends apache2-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
 
 RUN docker-php-ext-configure pdo_odbc --with-pdo-odbc=unixODBC,/usr \
     && docker-php-ext-install gd \

--- a/images/runtime/php-fpm/8.3/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bullseye.Dockerfile
@@ -318,16 +318,12 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
     && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
 
 RUN set -eux; \
-    if [[ $PHP_VERSION == 7.4.* || $PHP_VERSION == 8.0.* || $PHP_VERSION == 8.1.*  || $PHP_VERSION == 8.2.* || $PHP_VERSION == 8.3.* ]]; then \
-		apt-get update \
-        && apt-get upgrade -y \
-        && apt-get install -y --no-install-recommends apache2-dev \
-        && docker-php-ext-configure gd --with-freetype --with-jpeg \
-        && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl ; \
-    else \
-		docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-        && docker-php-ext-configure imap --with-kerberos --with-imap-ssl ; \
-    fi
+    apt-get update \
+    && apt-get upgrade -y \
+    && apt-mark unhold nginx \
+    && apt-get install -y --no-install-recommends apache2-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
 
 RUN docker-php-ext-configure pdo_odbc --with-pdo-odbc=unixODBC,/usr \
     && docker-php-ext-install gd \

--- a/images/runtime/php-fpm/8.4/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bookworm.Dockerfile
@@ -315,6 +315,7 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
+    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     # From php 8.4 version imap is removed from php core and moved to pecl

--- a/images/runtime/php-fpm/8.4/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bullseye.Dockerfile
@@ -320,6 +320,7 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
+    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     # From php 8.4 version imap is removed from php core and moved to pecl

--- a/images/runtime/php-fpm/8.5/noble.Dockerfile
+++ b/images/runtime/php-fpm/8.5/noble.Dockerfile
@@ -316,6 +316,7 @@ RUN apt-mark hold msodbcsql18 unixodbc unixodbc-dev nginx \
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
+    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     # From php 8.4 version imap is removed from php core and moved to pecl


### PR DESCRIPTION
Nginx is currently held (apt-mark hold) to prevent it from being upgraded during image build, but the hold is never released. This causes customer apt-get install nginx commands to fail at container runtime.
 
 Changes:
  - Add apt-mark unhold nginx after the final apt-get upgrade step so customers can install/reinstall nginx at runtime
  - Remove dead if/else version-check branches in PHP
   8.1–8.3 Dockerfiles (the else path for older --with-png-dir style config is never reached for these versions)

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
