### PR TITLE
[Security] Update Go to 1.26.3 to fix CVEs

### DIFF
--- a/build/testStartupScriptGenerators.sh
+++ b/build/testStartupScriptGenerators.sh
@@ -25,7 +25,7 @@ declare -r MODULE_TO_TEST="..."
 declare -r CONTAINER_NAME="oryxtests_$RANDOM"
 
 echo "Running tests in golang docker image..."
-docker run -v $GEN_DIR:$GEN_DIR_CONTAINER_RO:ro --name $CONTAINER_NAME mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye bash -c \
+docker run -v $GEN_DIR:$GEN_DIR_CONTAINER_RO:ro --name $CONTAINER_NAME mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye bash -c \
 	"cp -rf $GEN_DIR_CONTAINER_RO/* $GEN_DIR_CONTAINER && \
 	cd $GEN_DIR_CONTAINER && \
 	chmod u+x restorePackages.sh && \

--- a/images/runtime/dotnetcore/10.0/noble.Dockerfile
+++ b/images/runtime/dotnetcore/10.0/noble.Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=secret,id=vss_nuget_accesstoken,target=/run/secrets/vss_nuget_a
     dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 10.0.0-rc.1.25460.1
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm AS startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm AS startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/dotnetcore/8.0/bookworm.Dockerfile
+++ b/images/runtime/dotnetcore/8.0/bookworm.Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=secret,id=vss_nuget_accesstoken,target=/run/secrets/vss_nuget_a
     dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 8.*
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm AS startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm AS startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/dotnetcore/8.0/bullseye.Dockerfile
+++ b/images/runtime/dotnetcore/8.0/bullseye.Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=secret,id=vss_nuget_accesstoken,target=/run/secrets/vss_nuget_a
     dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 8.*
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye AS startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye AS startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/dotnetcore/9.0/bookworm.Dockerfile
+++ b/images/runtime/dotnetcore/9.0/bookworm.Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=secret,id=vss_nuget_accesstoken,target=/run/secrets/vss_nuget_a
     dotnet tool install --tool-path /dotnetcore-tools dotnet-monitor --version 9.*
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm AS startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm AS startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/node/18/bullseye.Dockerfile
+++ b/images/runtime/node/18/bullseye.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/node/20/bookworm.Dockerfile
+++ b/images/runtime/node/20/bookworm.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/node/20/bullseye.Dockerfile
+++ b/images/runtime/node/20/bullseye.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/node/22/bookworm.Dockerfile
+++ b/images/runtime/node/22/bookworm.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/node/22/bullseye.Dockerfile
+++ b/images/runtime/node/22/bullseye.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/node/24/noble.Dockerfile
+++ b/images/runtime/node/24/noble.Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 ARG FEED_ACCESSTOKEN
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/php-fpm/8.1/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.1/bullseye.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/php-fpm/8.2/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.2/bullseye.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/php-fpm/8.3/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bookworm.Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/php-fpm/8.3/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bullseye.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/php-fpm/8.4/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bookworm.Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/php-fpm/8.4/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bullseye.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bullseye as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bullseye as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/php-fpm/8.5/noble.Dockerfile
+++ b/images/runtime/php-fpm/8.5/noble.Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/python/noble.Dockerfile
+++ b/images/runtime/python/noble.Dockerfile
@@ -2,7 +2,7 @@ ARG OS_FLAVOR
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-bookworm as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-bookworm as startupCmdGen
 
 # GOPATH is set to "/go" in the base image
 WORKDIR /go/src

--- a/images/runtime/python/template.Dockerfile
+++ b/images/runtime/python/template.Dockerfile
@@ -2,7 +2,7 @@ ARG DEBIAN_FLAVOR
 ARG BASE_IMAGE
 
 # Startup script generator
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.2-${DEBIAN_FLAVOR} as startupCmdGen
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-${DEBIAN_FLAVOR} as startupCmdGen
 
 WORKDIR /go/src
 COPY src/startupscriptgenerator/src .

--- a/src/startupscriptgenerator/src/common/go.mod
+++ b/src/startupscriptgenerator/src/common/go.mod
@@ -1,6 +1,6 @@
 module common
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/src/startupscriptgenerator/src/dotnetcore/go.mod
+++ b/src/startupscriptgenerator/src/dotnetcore/go.mod
@@ -1,6 +1,6 @@
 module dotnetcore
 
-go 1.26.2
+go 1.26.3
 
 require github.com/Masterminds/semver v1.5.0
 

--- a/src/startupscriptgenerator/src/hugo/go.mod
+++ b/src/startupscriptgenerator/src/hugo/go.mod
@@ -1,6 +1,6 @@
 module hugo
 
-go 1.26.2
+go 1.26.3
 
 replace gopkg.in/yaml.v2 v2.2.1 => gopkg.in/yaml.v2 v2.4.0
 

--- a/src/startupscriptgenerator/src/node/go.mod
+++ b/src/startupscriptgenerator/src/node/go.mod
@@ -1,6 +1,6 @@
 module node
 
-go 1.26.2
+go 1.26.3
 
 require github.com/stretchr/testify v1.10.0
 

--- a/src/startupscriptgenerator/src/php/go.mod
+++ b/src/startupscriptgenerator/src/php/go.mod
@@ -1,6 +1,6 @@
 module php
 
-go 1.26.2
+go 1.26.3
 
 replace gopkg.in/yaml.v2 v2.2.1 => gopkg.in/yaml.v2 v2.4.0
 

--- a/src/startupscriptgenerator/src/python/go.mod
+++ b/src/startupscriptgenerator/src/python/go.mod
@@ -1,6 +1,6 @@
 module python
 
-go 1.26.2
+go 1.26.3
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
## Summary
Updates Go stdlib from 1.26.2 to 1.26.3 across all runtime Dockerfiles and go.mod files to address high-severity CVEs in the Go standard library.

## CVEs Fixed
- [CVE-2026-42499](https://scout.docker.com/vulnerabilities/id/CVE-2026-42499)https://scout.docker.com/vulnerabilities/id/[CVE-2026-42499](https://scout.docker.com/vulnerabilities/id/CVE-2026-42499)
- [CVE-2026-39836](https://scout.docker.com/vulnerabilities/id/CVE-2026-39836)https://scout.docker.com/vulnerabilities/id/[CVE-2026-39836](https://scout.docker.com/vulnerabilities/id/CVE-2026-39836)
- [CVE-2026-39820](https://scout.docker.com/vulnerabilities/id/CVE-2026-39820)https://scout.docker.com/vulnerabilities/id/[CVE-2026-39820](https://scout.docker.com/vulnerabilities/id/CVE-2026-39820)
- [CVE-2026-33814
](https://scout.docker.com/vulnerabilities/id/CVE-2026-33814)https://scout.docker.com/vulnerabilities/id/[CVE-2026-33814](https://scout.docker.com/vulnerabilities/id/CVE-2026-33814)
- [CVE-2026-33811](https://scout.docker.com/vulnerabilities/id/CVE-2026-33811)https://scout.docker.com/vulnerabilities/id/[CVE-2026-33811](https://scout.docker.com/vulnerabilities/id/CVE-2026-33811)

## Related
- ICM 801686913
- Follow-up to PR #2910 which updated Go from 1.26.1 to 1.26.2

## Files Changed
- 20 Dockerfiles (Python, Node, PHP, .NET runtime images)
- 6 go.mod files (startupscriptgenerator modules)
- 1 test script (testStartupScriptGenerators.sh)
- 1 GitHub workflow (unit-tests.yaml)

## Testing
- [ ] Buddy validation (pipeline 364425)
- [ ] OryxTests (pipeline 368278)