### PR TITLE
Unpin nginx version in PHP FPM runtime images

### DIFF
--- a/images/runtime/php-fpm/8.2/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.2/bullseye.Dockerfile
@@ -287,7 +287,7 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
+RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
@@ -310,8 +310,8 @@ RUN nginx -t
 ENV NGINX_PORT 8080
 
 # Install common PHP extensions
-# TEMPORARY: Holding odbc related packages and nginx from upgrading.
-RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev nginx \
+# TEMPORARY: Holding odbc related packages from upgrading.
+RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev \
     && apt-get update \
     && apt-get upgrade -y \
     && ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so \
@@ -321,7 +321,6 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
-    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl

--- a/images/runtime/php-fpm/8.3/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bookworm.Dockerfile
@@ -281,7 +281,7 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bookworm nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-RUN yes '' | apt-get install nginx=1.30.0-1~bookworm -y
+RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
@@ -304,8 +304,8 @@ RUN nginx -t
 ENV NGINX_PORT 8080
 
 # Install common PHP extensions
-# TEMPORARY: Holding odbc related packages and nginx from upgrading.
-RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev nginx \
+# TEMPORARY: Holding odbc related packages from upgrading.
+RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev \
     && apt-get update \
     && apt-get upgrade -y \
     && ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so \
@@ -315,7 +315,6 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
-    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl

--- a/images/runtime/php-fpm/8.3/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bullseye.Dockerfile
@@ -286,7 +286,7 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
+RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
@@ -309,8 +309,8 @@ RUN nginx -t
 ENV NGINX_PORT 8080
 
 # Install common PHP extensions
-# TEMPORARY: Holding odbc related packages and nginx from upgrading.
-RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev nginx \
+# TEMPORARY: Holding odbc related packages from upgrading.
+RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev \
     && apt-get update \
     && apt-get upgrade -y \
     && ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so \
@@ -320,7 +320,6 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
-    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl

--- a/images/runtime/php-fpm/8.4/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bookworm.Dockerfile
@@ -281,7 +281,7 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bookworm nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-RUN yes '' | apt-get install nginx=1.30.0-1~bookworm -y
+RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
@@ -304,8 +304,8 @@ RUN nginx -t
 ENV NGINX_PORT 8080
 
 # Install common PHP extensions
-# TEMPORARY: Holding odbc related packages and nginx from upgrading.
-RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev nginx \
+# TEMPORARY: Holding odbc related packages from upgrading.
+RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev \
     && apt-get update \
     && apt-get upgrade -y \
     && ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so \
@@ -315,7 +315,6 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
-    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     # From php 8.4 version imap is removed from php core and moved to pecl

--- a/images/runtime/php-fpm/8.4/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bullseye.Dockerfile
@@ -286,7 +286,7 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
+RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
@@ -309,8 +309,8 @@ RUN nginx -t
 ENV NGINX_PORT 8080
 
 # Install common PHP extensions
-# TEMPORARY: Holding odbc related packages and nginx from upgrading.
-RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev nginx \
+# TEMPORARY: Holding odbc related packages from upgrading.
+RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc unixodbc-dev \
     && apt-get update \
     && apt-get upgrade -y \
     && ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so \
@@ -320,7 +320,6 @@ RUN apt-mark hold msodbcsql17 msodbcsql18 odbcinst1debian2 odbcinst unixodbc uni
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
-    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     # From php 8.4 version imap is removed from php core and moved to pecl

--- a/images/runtime/php-fpm/8.5/noble.Dockerfile
+++ b/images/runtime/php-fpm/8.5/noble.Dockerfile
@@ -282,7 +282,7 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu noble nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-RUN apt-get install -y nginx=1.30.0-1~noble
+RUN apt-get install -y nginx
 RUN rm -f /etc/nginx/conf.d/default.conf
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
@@ -305,8 +305,8 @@ RUN nginx -t
 ENV NGINX_PORT=8080
 
 # Install common PHP extensions
-# TEMPORARY: Holding odbc related packages and nginx from upgrading.
-RUN apt-mark hold msodbcsql18 unixodbc unixodbc-dev nginx \
+# TEMPORARY: Holding odbc related packages from upgrading.
+RUN apt-mark hold msodbcsql18 unixodbc unixodbc-dev \
     && apt-get update \
     && apt-get upgrade -y \
     && ln -s /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/libldap.so \
@@ -316,7 +316,6 @@ RUN apt-mark hold msodbcsql18 unixodbc unixodbc-dev nginx \
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade -y \
-    && apt-mark unhold nginx \
     && apt-get install -y --no-install-recommends apache2-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     # From php 8.4 version imap is removed from php core and moved to pecl


### PR DESCRIPTION
Remove pinned nginx version (1.30.0) from PHP 8.2–8.5 FPM Dockerfiles and remove nginx from the apt-mark hold list. This allows nginx to receive updates from the stable nginx.org repository automatically during image builds.

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
