### PR TITLE
[PHP-FPM] Restore /etc/nginx/sites-enabled/ for backward compatibility

### DIFF
--- a/images/runtime/php-fpm/8.1/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.1/bullseye.Dockerfile
@@ -288,8 +288,10 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
 RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \
@@ -297,12 +299,14 @@ RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#tcp_nopush\s+on;!tcp_nopush     on;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#gzip\s+on;!gzip  on;!' /etc/nginx/nginx.conf \
 	&& sed -ri -e '/include\s+.*mime\.types;/a\    types_hash_max_size  2048;' /etc/nginx/nginx.conf \
+    && sed -ri -e '/include\s+.*conf\.d\/\*\.conf;/a\    include /etc/nginx/sites-enabled/*;' /etc/nginx/nginx.conf \
     && grep -q '^user  www-data;' /etc/nginx/nginx.conf || { echo 'ERROR: nginx user replacement failed'; exit 1; } \
     && grep -q 'worker_connections.*10068' /etc/nginx/nginx.conf || { echo 'ERROR: worker_connections replacement failed'; exit 1; } \
 	&& grep -q 'multi_accept  on;' /etc/nginx/nginx.conf || { echo 'ERROR: multi_accept append failed'; exit 1; } \
     && grep -q '^[^#]*tcp_nopush\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: tcp_nopush replacement failed'; exit 1; } \
     && grep -q '^[^#]*gzip\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: gzip replacement failed'; exit 1; } \
-	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; }
+	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; } \
+    && grep -q 'include /etc/nginx/sites-enabled/\*;' /etc/nginx/nginx.conf || { echo 'ERROR: sites-enabled include append failed'; exit 1; }
 # Fix temp directory ownership after changing nginx user to www-data
 RUN chown -R www-data:www-data /var/cache/nginx
 RUN nginx -t

--- a/images/runtime/php-fpm/8.2/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.2/bullseye.Dockerfile
@@ -288,8 +288,10 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
 RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \
@@ -297,12 +299,14 @@ RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#tcp_nopush\s+on;!tcp_nopush     on;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#gzip\s+on;!gzip  on;!' /etc/nginx/nginx.conf \
 	&& sed -ri -e '/include\s+.*mime\.types;/a\    types_hash_max_size  2048;' /etc/nginx/nginx.conf \
+    && sed -ri -e '/include\s+.*conf\.d\/\*\.conf;/a\    include /etc/nginx/sites-enabled/*;' /etc/nginx/nginx.conf \
     && grep -q '^user  www-data;' /etc/nginx/nginx.conf || { echo 'ERROR: nginx user replacement failed'; exit 1; } \
     && grep -q 'worker_connections.*10068' /etc/nginx/nginx.conf || { echo 'ERROR: worker_connections replacement failed'; exit 1; } \
 	&& grep -q 'multi_accept  on;' /etc/nginx/nginx.conf || { echo 'ERROR: multi_accept append failed'; exit 1; } \
     && grep -q '^[^#]*tcp_nopush\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: tcp_nopush replacement failed'; exit 1; } \
     && grep -q '^[^#]*gzip\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: gzip replacement failed'; exit 1; } \
-	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; }
+	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; } \
+    && grep -q 'include /etc/nginx/sites-enabled/\*;' /etc/nginx/nginx.conf || { echo 'ERROR: sites-enabled include append failed'; exit 1; }
 # Fix temp directory ownership after changing nginx user to www-data
 RUN chown -R www-data:www-data /var/cache/nginx
 RUN nginx -t

--- a/images/runtime/php-fpm/8.3/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bookworm.Dockerfile
@@ -281,17 +281,11 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bookworm nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-<<<<<<< HEAD
 RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf \
     && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
-=======
-RUN yes '' | apt-get install nginx -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
->>>>>>> c78f737f9cf62be5d5b5ef5fb1547d5a473208f8
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \

--- a/images/runtime/php-fpm/8.3/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bookworm.Dockerfile
@@ -282,8 +282,10 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bookworm nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
 RUN yes '' | apt-get install nginx=1.30.0-1~bookworm -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \
@@ -291,12 +293,14 @@ RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#tcp_nopush\s+on;!tcp_nopush     on;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#gzip\s+on;!gzip  on;!' /etc/nginx/nginx.conf \
 	&& sed -ri -e '/include\s+.*mime\.types;/a\    types_hash_max_size  2048;' /etc/nginx/nginx.conf \
+    && sed -ri -e '/include\s+.*conf\.d\/\*\.conf;/a\    include /etc/nginx/sites-enabled/*;' /etc/nginx/nginx.conf \
     && grep -q '^user  www-data;' /etc/nginx/nginx.conf || { echo 'ERROR: nginx user replacement failed'; exit 1; } \
     && grep -q 'worker_connections.*10068' /etc/nginx/nginx.conf || { echo 'ERROR: worker_connections replacement failed'; exit 1; } \
 	&& grep -q 'multi_accept  on;' /etc/nginx/nginx.conf || { echo 'ERROR: multi_accept append failed'; exit 1; } \
     && grep -q '^[^#]*tcp_nopush\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: tcp_nopush replacement failed'; exit 1; } \
     && grep -q '^[^#]*gzip\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: gzip replacement failed'; exit 1; } \
-	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; }
+	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; } \
+    && grep -q 'include /etc/nginx/sites-enabled/\*;' /etc/nginx/nginx.conf || { echo 'ERROR: sites-enabled include append failed'; exit 1; }
 # Fix temp directory ownership after changing nginx user to www-data
 RUN chown -R www-data:www-data /var/cache/nginx
 RUN nginx -t

--- a/images/runtime/php-fpm/8.3/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bullseye.Dockerfile
@@ -286,17 +286,11 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-<<<<<<< HEAD
-RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
+RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf \
     && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
-=======
-RUN yes '' | apt-get install nginx -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
->>>>>>> c78f737f9cf62be5d5b5ef5fb1547d5a473208f8
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \

--- a/images/runtime/php-fpm/8.3/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bullseye.Dockerfile
@@ -287,8 +287,10 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
 RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \
@@ -296,12 +298,14 @@ RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#tcp_nopush\s+on;!tcp_nopush     on;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#gzip\s+on;!gzip  on;!' /etc/nginx/nginx.conf \
 	&& sed -ri -e '/include\s+.*mime\.types;/a\    types_hash_max_size  2048;' /etc/nginx/nginx.conf \
+    && sed -ri -e '/include\s+.*conf\.d\/\*\.conf;/a\    include /etc/nginx/sites-enabled/*;' /etc/nginx/nginx.conf \
     && grep -q '^user  www-data;' /etc/nginx/nginx.conf || { echo 'ERROR: nginx user replacement failed'; exit 1; } \
     && grep -q 'worker_connections.*10068' /etc/nginx/nginx.conf || { echo 'ERROR: worker_connections replacement failed'; exit 1; } \
 	&& grep -q 'multi_accept  on;' /etc/nginx/nginx.conf || { echo 'ERROR: multi_accept append failed'; exit 1; } \
     && grep -q '^[^#]*tcp_nopush\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: tcp_nopush replacement failed'; exit 1; } \
     && grep -q '^[^#]*gzip\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: gzip replacement failed'; exit 1; } \
-	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; }
+	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; } \
+    && grep -q 'include /etc/nginx/sites-enabled/\*;' /etc/nginx/nginx.conf || { echo 'ERROR: sites-enabled include append failed'; exit 1; }
 # Fix temp directory ownership after changing nginx user to www-data
 RUN chown -R www-data:www-data /var/cache/nginx
 RUN nginx -t

--- a/images/runtime/php-fpm/8.4/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bookworm.Dockerfile
@@ -282,8 +282,10 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bookworm nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
 RUN yes '' | apt-get install nginx=1.30.0-1~bookworm -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \
@@ -291,12 +293,14 @@ RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#tcp_nopush\s+on;!tcp_nopush     on;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#gzip\s+on;!gzip  on;!' /etc/nginx/nginx.conf \
 	&& sed -ri -e '/include\s+.*mime\.types;/a\    types_hash_max_size  2048;' /etc/nginx/nginx.conf \
+    && sed -ri -e '/include\s+.*conf\.d\/\*\.conf;/a\    include /etc/nginx/sites-enabled/*;' /etc/nginx/nginx.conf \
     && grep -q '^user  www-data;' /etc/nginx/nginx.conf || { echo 'ERROR: nginx user replacement failed'; exit 1; } \
     && grep -q 'worker_connections.*10068' /etc/nginx/nginx.conf || { echo 'ERROR: worker_connections replacement failed'; exit 1; } \
 	&& grep -q 'multi_accept  on;' /etc/nginx/nginx.conf || { echo 'ERROR: multi_accept append failed'; exit 1; } \
     && grep -q '^[^#]*tcp_nopush\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: tcp_nopush replacement failed'; exit 1; } \
     && grep -q '^[^#]*gzip\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: gzip replacement failed'; exit 1; } \
-	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; }
+	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; } \
+    && grep -q 'include /etc/nginx/sites-enabled/\*;' /etc/nginx/nginx.conf || { echo 'ERROR: sites-enabled include append failed'; exit 1; }
 # Fix temp directory ownership after changing nginx user to www-data
 RUN chown -R www-data:www-data /var/cache/nginx
 RUN nginx -t

--- a/images/runtime/php-fpm/8.4/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bullseye.Dockerfile
@@ -286,17 +286,11 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-<<<<<<< HEAD
 RUN yes '' | apt-get install nginx -y
 RUN rm -f /etc/nginx/conf.d/default.conf \
     && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
-=======
-RUN yes '' | apt-get install nginx -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
->>>>>>> c78f737f9cf62be5d5b5ef5fb1547d5a473208f8
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \

--- a/images/runtime/php-fpm/8.4/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bullseye.Dockerfile
@@ -287,8 +287,10 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/debian bullseye nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
 RUN yes '' | apt-get install nginx=1.30.0-1~bullseye -y
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \
@@ -296,12 +298,14 @@ RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#tcp_nopush\s+on;!tcp_nopush     on;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#gzip\s+on;!gzip  on;!' /etc/nginx/nginx.conf \
 	&& sed -ri -e '/include\s+.*mime\.types;/a\    types_hash_max_size  2048;' /etc/nginx/nginx.conf \
+    && sed -ri -e '/include\s+.*conf\.d\/\*\.conf;/a\    include /etc/nginx/sites-enabled/*;' /etc/nginx/nginx.conf \
     && grep -q '^user  www-data;' /etc/nginx/nginx.conf || { echo 'ERROR: nginx user replacement failed'; exit 1; } \
     && grep -q 'worker_connections.*10068' /etc/nginx/nginx.conf || { echo 'ERROR: worker_connections replacement failed'; exit 1; } \
 	&& grep -q 'multi_accept  on;' /etc/nginx/nginx.conf || { echo 'ERROR: multi_accept append failed'; exit 1; } \
     && grep -q '^[^#]*tcp_nopush\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: tcp_nopush replacement failed'; exit 1; } \
     && grep -q '^[^#]*gzip\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: gzip replacement failed'; exit 1; } \
-	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; }
+	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; } \
+    && grep -q 'include /etc/nginx/sites-enabled/\*;' /etc/nginx/nginx.conf || { echo 'ERROR: sites-enabled include append failed'; exit 1; }
 # Fix temp directory ownership after changing nginx user to www-data
 RUN chown -R www-data:www-data /var/cache/nginx
 RUN nginx -t

--- a/images/runtime/php-fpm/8.5/noble.Dockerfile
+++ b/images/runtime/php-fpm/8.5/noble.Dockerfile
@@ -282,17 +282,11 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     || { echo "ERROR: nginx signing key fingerprint mismatch"; exit 1; } \
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu noble nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
-<<<<<<< HEAD
-RUN apt-get install -y nginx=1.30.0-1~noble
+RUN apt-get install -y nginx
 RUN rm -f /etc/nginx/conf.d/default.conf \
     && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
 COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
-=======
-RUN apt-get install -y nginx
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
->>>>>>> c78f737f9cf62be5d5b5ef5fb1547d5a473208f8
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \

--- a/images/runtime/php-fpm/8.5/noble.Dockerfile
+++ b/images/runtime/php-fpm/8.5/noble.Dockerfile
@@ -283,8 +283,10 @@ RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/
     && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/ubuntu noble nginx" > /etc/apt/sources.list.d/nginx.list
 RUN apt-get update
 RUN apt-get install -y nginx=1.30.0-1~noble
-RUN rm -f /etc/nginx/conf.d/default.conf
-COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf \
+    && mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-available/default
+COPY images/runtime/php-fpm/nginx_conf/default.conf /etc/nginx/sites-enabled/default
 # Patch nginx.conf for behavioral parity with previous Debian/Sury nginx package
 RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!worker_connections\s+1024!worker_connections  10068!g' /etc/nginx/nginx.conf \
@@ -292,12 +294,14 @@ RUN sed -ri -e 's!^user\s+\S+;!user  www-data;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#tcp_nopush\s+on;!tcp_nopush     on;!' /etc/nginx/nginx.conf \
     && sed -ri -e 's!#gzip\s+on;!gzip  on;!' /etc/nginx/nginx.conf \
 	&& sed -ri -e '/include\s+.*mime\.types;/a\    types_hash_max_size  2048;' /etc/nginx/nginx.conf \
+    && sed -ri -e '/include\s+.*conf\.d\/\*\.conf;/a\    include /etc/nginx/sites-enabled/*;' /etc/nginx/nginx.conf \
     && grep -q '^user  www-data;' /etc/nginx/nginx.conf || { echo 'ERROR: nginx user replacement failed'; exit 1; } \
     && grep -q 'worker_connections.*10068' /etc/nginx/nginx.conf || { echo 'ERROR: worker_connections replacement failed'; exit 1; } \
 	&& grep -q 'multi_accept  on;' /etc/nginx/nginx.conf || { echo 'ERROR: multi_accept append failed'; exit 1; } \
     && grep -q '^[^#]*tcp_nopush\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: tcp_nopush replacement failed'; exit 1; } \
     && grep -q '^[^#]*gzip\s*on' /etc/nginx/nginx.conf || { echo 'ERROR: gzip replacement failed'; exit 1; } \
-	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; }
+	&& grep -q 'types_hash_max_size  2048;' /etc/nginx/nginx.conf || { echo 'ERROR: types_hash_max_size append failed'; exit 1; } \
+    && grep -q 'include /etc/nginx/sites-enabled/\*;' /etc/nginx/nginx.conf || { echo 'ERROR: sites-enabled include append failed'; exit 1; }
 # Fix temp directory ownership after changing nginx user to www-data
 RUN chown -R www-data:www-data /var/cache/nginx
 RUN nginx -t


### PR DESCRIPTION
- Restored sites-enabled/ and sites-available/ directories and added include /etc/nginx/sites-enabled/*; to nginx.conf — customers copying their custom config to sites-enabled/ will work as before. This folder is not referenced anywhere else in the image except nginx.conf. 
<img width="1917" height="83" alt="image" src="https://github.com/user-attachments/assets/05e40144-473b-4b56-a3dc-85c6b50e74f8" />
(This is old image)

 - Removed the nginx.org default conf.d/default.conf (port 80 static server block) to match the old behavior where conf.d/ was empty.
 - Updated 8.1 Dockerfiles as well for consistency (We won't be updating 8.1 images), Will delete whole 8.1 folder in next PR since it's EOL.
 
- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
