### PR TITLE
Add duration logs for Oryx build steps (Node, .NET, PHP)

### DIFF
--- a/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/DotNetCore/DotNetCoreBashBuildSnippet.sh.tpl
@@ -6,7 +6,10 @@ echo "Using .NET Core SDK Version: $dotnetCoreVersion"
     echo
     echo "Running '{{ InstallBlazorWebAssemblyAOTWorkloadCommand }}'..."
     echo
+    START_TIME=$SECONDS
     {{ InstallBlazorWebAssemblyAOTWorkloadCommand }}
+    ELAPSED_TIME=$(($SECONDS - $START_TIME))
+    echo "Installing Blazor WebAssembly AOT workload done in $ELAPSED_TIME sec(s)."
 {{ end }}
 
 {{ if CustomBuildCommand | IsNotBlank }}
@@ -14,27 +17,40 @@ echo
 echo "Running custom build command '{{ CustomBuildCommand }}'..."
 echo "Note: the custom build command must output to \$DESTINATION_DIR (e.g., dotnet publish -c Release -o \$DESTINATION_DIR)."
 echo
+START_TIME=$SECONDS
 {{ CustomBuildCommand }}
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+echo "Custom build command done in $ELAPSED_TIME sec(s)."
 {{ else }}
 doc="https://docs.microsoft.com/en-us/azure/app-service/configure-language-dotnetcore?pivots=platform-linux"
 suggestion="Please build your app locally before publishing." 
 msg="${suggestion} | ${doc}"
 
 {{ # .NET Core 1.1 based projects require restore to be run before publish }}
+echo "Restoring..."
+START_TIME=$SECONDS
 cmd="dotnet restore \"{{ ProjectFile }}\""
 LogErrorWithTryCatch "$cmd" "$msg"
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+echo "dotnet restore done in $ELAPSED_TIME sec(s)."
 
 if [ "$SOURCE_DIR" == "$DESTINATION_DIR" ]
 then
     echo "Publishing..."
+    START_TIME=$SECONDS
     cmd="dotnet publish \"{{ ProjectFile }}\" -c {{ Configuration }}"
     LogErrorWithTryCatch "$cmd" "$msg"
+    ELAPSED_TIME=$(($SECONDS - $START_TIME))
+    echo "dotnet publish done in $ELAPSED_TIME sec(s)."
 else
     echo
     echo "Publishing to directory $DESTINATION_DIR..."
     echo    
+    START_TIME=$SECONDS
     cmd="dotnet publish \"{{ ProjectFile }}\" -c {{ Configuration }} -o $DESTINATION_DIR"
     LogErrorWithTryCatch "$cmd" "$msg"
+    ELAPSED_TIME=$(($SECONDS - $START_TIME))
+    echo "dotnet publish done in $ELAPSED_TIME sec(s)."
 
     # we copy *.csproj to destination directory so the detector can identify
     # the destination directory as a DotNet application

--- a/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Node/NodeBashBuildSnippet.sh.tpl
@@ -122,7 +122,10 @@ then
 	echo "Running '{{ ProductionOnlyPackageInstallCommand }}'..."
 	echo
 	printf %s ", {{ ProductionOnlyPackageInstallCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ ProductionOnlyPackageInstallCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Installing production dependencies done in $ELAPSED_TIME sec(s)."
 	
 
 	if [ -d "node_modules" ]; then
@@ -131,7 +134,7 @@ then
 		START_TIME=$SECONDS
 		rsync -rcE --links "node_modules/" "$SOURCE_DIR/node_modules"
 		ELAPSED_TIME=$(($SECONDS - $START_TIME))
-		echo "Done in $ELAPSED_TIME sec(s)."
+		echo "Copying production dependencies done in $ELAPSED_TIME sec(s)."
 	fi
 fi
 
@@ -150,16 +153,25 @@ cd "$SOURCE_DIR"
 	echo "Running '{{ CustomBuildCommand }}'..."
 	echo
 	printf %s ", {{ CustomBuildCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ CustomBuildCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Custom build command done in $ELAPSED_TIME sec(s)."
 {{ else if CustomRunBuildCommand | IsNotBlank }}
 	echo
 	echo "Running '{{ PackageInstallCommand }}'..."
 	echo
 	printf %s ", {{ PackageInstallCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ PackageInstallCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Package install done in $ELAPSED_TIME sec(s)."
 	echo
 	printf %s ", {{ CustomRunBuildCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ CustomRunBuildCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Custom run build command done in $ELAPSED_TIME sec(s)."
 	echo
 {{ else if LernaRunBuildCommand | IsNotBlank }}
 	echo
@@ -169,44 +181,65 @@ cd "$SOURCE_DIR"
 	echo
 	echo "Running '{{ LernaInitCommand }} & {{ LernaBootstrapCommand }}':"
 	printf %s ", {{ LernaInitCommand }}', '{{ LernaBootstrapCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ LernaInitCommand }}
 	{{ LernaBootstrapCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Lerna init and bootstrap done in $ELAPSED_TIME sec(s)."
 	echo
 	echo
 	echo "Running '{{ LernaRunBuildCommand }}'..."
 	echo
 	printf %s ", {{ LernaRunBuildCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ LernaRunBuildCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Lerna run build command done in $ELAPSED_TIME sec(s)."
 {{ else if LageRunBuildCommand | IsNotBlank }}
 	echo
 	echo "Running ' {{ InstallLageCommand }} ':"
 	printf %s ", {{ InstallLageCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ InstallLageCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Installing Lage done in $ELAPSED_TIME sec(s)."
 	echo
 	echo
 	echo "Running '{{ LageRunBuildCommand }}'..."
 	printf %s ", {{ LageRunBuildCommand }}" >> "$COMMAND_MANIFEST_FILE"
 	echo
+	START_TIME=$SECONDS
 	{{ LageRunBuildCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Lage run build command done in $ELAPSED_TIME sec(s)."
 {{ else }}
 	echo
 	echo "Running '{{ PackageInstallCommand }}'..."
 	echo
 	printf %s ", {{ PackageInstallCommand }}" >> "$COMMAND_MANIFEST_FILE"
+	START_TIME=$SECONDS
 	{{ PackageInstallCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "Package install done in $ELAPSED_TIME sec(s)."
 	{{ if NpmRunBuildCommand | IsNotBlank }}
 	echo
 	echo "Running '{{ NpmRunBuildCommand }}'..."
 	printf %s ", {{ NpmRunBuildCommand }}" >> "$COMMAND_MANIFEST_FILE"
 	echo
+	START_TIME=$SECONDS
 	{{ NpmRunBuildCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "npm run build done in $ELAPSED_TIME sec(s)."
 	{{ end }}
 	{{ if NpmRunBuildAzureCommand | IsNotBlank }}
 	echo
 	echo "Running '{{ NpmRunBuildAzureCommand }}'..."
 	printf %s ", {{ NpmRunBuildAzureCommand }}" >> "$COMMAND_MANIFEST_FILE"
 	echo
+	START_TIME=$SECONDS
 	{{ NpmRunBuildAzureCommand }}
+	ELAPSED_TIME=$(($SECONDS - $START_TIME))
+	echo "npm run build (Azure) done in $ELAPSED_TIME sec(s)."
 	{{ end }}
 {{ end }}
 
@@ -222,14 +255,20 @@ cd "$SOURCE_DIR"
 echo
 echo "Running custom packaging scripts that might exist..."
 echo
+START_TIME=$SECONDS
 npm run package || true
 npm run prepublishOnly || true
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+echo "Custom packaging scripts done in $ELAPSED_TIME sec(s)."
 printf %s ", npm run package || true, npm run prepublishOnly || true" >> "$COMMAND_MANIFEST_FILE"
 echo
 echo "Running 'npm pack'..."
 echo
 printf %s ", npm pack" >> "$COMMAND_MANIFEST_FILE"
+START_TIME=$SECONDS
 npm pack
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+echo "npm pack done in $ELAPSED_TIME sec(s)."
 {{ end }}
 
 
@@ -289,7 +328,7 @@ then
 		cd node_modules
 		{{ CompressNodeModulesCommand }} ../$zippedModulesFileName .
 		ELAPSED_TIME=$(($SECONDS - $START_TIME))
-		echo "Done in $ELAPSED_TIME sec(s)."
+		echo "Archiving node_modules done in $ELAPSED_TIME sec(s)."
 	fi
 fi
 {{ end }}

--- a/src/BuildScriptGenerator/Php/PhpBashBuildSnippet.sh.tpl
+++ b/src/BuildScriptGenerator/Php/PhpBashBuildSnippet.sh.tpl
@@ -5,7 +5,10 @@ echo "PHP executable: $phpBin"
 echo
 echo "Running custom build command '{{ CustomBuildCommand }}'..."
 echo
+START_TIME=$SECONDS
 {{ CustomBuildCommand }}
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+echo "Custom build command done in $ELAPSED_TIME sec(s)."
 {{ else if ComposerFileExists }}
 echo "Composer archive: $composer"
 echo "Running 'composer install --ignore-platform-reqs --no-interaction'..."
@@ -13,7 +16,10 @@ echo
 # `--ignore-platform-reqs` ensures Composer won't fail a build when
 # an extension is missing from the build image (it could exist in the
 # runtime image regardless)
+START_TIME=$SECONDS
 php $composer install --ignore-platform-reqs --no-interaction
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+echo "composer install done in $ELAPSED_TIME sec(s)."
 {{ else }}
 echo "No 'composer.json' file found; not running 'composer install'."
 {{ end }}


### PR DESCRIPTION
## What
Adds elapsed-time logging around time-consuming steps in the Node, .NET, and PHP build snippets, extending the pattern introduced for Python and the common build script in #2743.

## Why
Build logs previously emitted a generic "Done in X sec(s)." for most steps, making it hard to tell *which* phase — dependency install, build, or packaging — was the bottleneck in slow CI/App Service builds. Each step now reports its own labelled duration.

## Changes
**Node** (`NodeBashBuildSnippet.sh.tpl`)
- Production dependency install & copy, custom/Lerna/Lage/npm build commands, package install, `npm run build` / `build:azure`, custom packaging scripts, `npm pack`, and node_modules archiving now log labelled durations.

**.NET** (`DotNetCoreBashBuildSnippet.sh.tpl`)
- Blazor WebAssembly AOT workload install, custom build command, `dotnet restore`, and `dotnet publish` now log durations.

**PHP** (`PhpBashBuildSnippet.sh.tpl`)
- Custom build command and `composer install` now log durations.

_Python and the common wrapper (`BaseBashBuildScript.sh.tpl`, `PlatformInstallerBase.cs`) were already covered by https://github.com/microsoft/Oryx/pull/2743

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
