### PR TITLE
Bake blobfuse2 into Python runtime images for Azure Blob FUSE mounts

### DIFF
--- a/images/runtime/python/install-dependencies.sh
+++ b/images/runtime/python/install-dependencies.sh
@@ -91,5 +91,18 @@ Threading=1
 UsageCount=1
 EOL
 
+# Blobfuse2 for Azure Blob Storage FUSE mounting.
+# Installs blobfuse2 (+ fuse3 / fusermount3) from the Microsoft package repo already configured
+# above (packages.microsoft.com). This lets downstream consumers BlobFuse2-mount an Azure Blob
+# container from inside the running image without a first-mount `apt install` over the network
+# (which otherwise adds a one-time cold-start latency on the first mount). Guarded to the
+# Debian/Ubuntu flavors whose Microsoft prod feed is set up above and that publish blobfuse2.
+if [ "$osFlavor" == "noble" ] || [ "$osFlavor" == "bookworm" ] || [ "$osFlavor" == "bullseye" ]; then \
+    apt-get update \
+        && apt-get install -y --no-install-recommends blobfuse2 fuse3 \
+        && blobfuse2 --version \
+        && command -v fusermount3
+fi
+
 # Clean up for apt. Keeping at the very end to make sure it runs after every apt-get install.
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Adds `blobfuse2` (and `fuse3`/`fusermount3`) to the Python runtime images, installed from the Microsoft package repo that this script already configures for the msodbcsql / mssql-tools packages.

## Motivation

We build container images (Azure ML Managed Harness "Hand" sandboxes) **`FROM mcr.microsoft.com/oryx/python:*-debian-bookworm`** and need to BlobFuse2-mount an Azure Blob container from inside the running container to give each session a durable working directory.

Today we do this with an on-demand `apt-get install blobfuse2` on first mount, which adds a one-time cold-start latency (network + apt) to the first storage-backed operation. Baking `blobfuse2` into the base image removes that latency entirely.

We initially added the package one layer up, in our own image that derives from this one, but the owners of that layer asked us to keep it a thin mirror and pointed us upstream to Oryx — hence this PR. Since `install-dependencies.sh` **already** wires up `packages.microsoft.com` and installs sizable Microsoft tooling (`msodbcsql17`/`msodbcsql18`, `mssql-tools18`, unixODBC), adding `blobfuse2` reuses existing infrastructure and is a small, consistent addition.

## Change

- New guarded block near the end of `images/runtime/python/install-dependencies.sh`:
  ```bash
  if [ "$osFlavor" == "noble" ] || [ "$osFlavor" == "bookworm" ] || [ "$osFlavor" == "bullseye" ]; then
      apt-get update \
          && apt-get install -y --no-install-recommends blobfuse2 fuse3 \
          && blobfuse2 --version \
          && command -v fusermount3
  fi
  ```
- `--no-install-recommends` keeps the footprint minimal (`blobfuse2` pulls only `libfuse3-3`; `fuse3` provides the setuid `fusermount3` needed to mount inside a container).
- Guarded to the flavors whose Microsoft prod feed is configured above and that publish blobfuse2 (bookworm / noble / bullseye), so other flavors are unaffected.
- The build-time `blobfuse2 --version` / `command -v fusermount3` checks fail the image build if the package is ever unavailable, so a broken feed can't ship silently.

## Footprint / blast radius

We recognize this image backs many consumers, so we've scoped the change to be additive and cleaned up (`rm -rf /var/lib/apt/lists/*` still runs at the very end). Installed size is small (a few MB). If you'd prefer this behind a build ARG (e.g. `INSTALL_BLOBFUSE2=false` by default) or published as a separate image variant instead of the default runtime image, we're happy to rework it that way — just let us know which shape you want.

## Testing

- `blobfuse2 --version` and `fusermount3` presence are asserted at build time.
- Verified `blobfuse2` is published for Debian 12 (bookworm) and Ubuntu 24.04 (noble) in the Microsoft package repo.