### PR TITLE
Fix PHP source archive download URLs

### DIFF
--- a/images/runtime/php-fpm/8.1/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.1/bullseye.Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9
 ARG PHP_VERSION
 ARG PHP_SHA256
 ENV PHP_VERSION ${PHP_VERSION}
-ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror" PHP_MD5=""
+ENV PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz.asc" PHP_MD5=""
 ENV PHP_SHA256 ${PHP_SHA256}
 
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.2/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.2/bullseye.Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1198C0117593497A5EC5C199286AF1F9897469DC 39B641343D8C104B2B146DC3F9
 ARG PHP_VERSION
 ARG PHP_SHA256
 ENV PHP_VERSION ${PHP_VERSION}
-ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror" PHP_MD5=""
+ENV PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz.asc" PHP_MD5=""
 ENV PHP_SHA256 ${PHP_SHA256}
 
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.3/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bookworm.Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS 1198C0117593497A5EC5C199286AF1F9897469DC AFD8691FDAEDF03BDF6E460563
 ARG PHP_VERSION
 ARG PHP_SHA256
 ENV PHP_VERSION ${PHP_VERSION}
-ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror" PHP_MD5=""
+ENV PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz.asc" PHP_MD5=""
 ENV PHP_SHA256 ${PHP_SHA256}
 
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.3/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.3/bullseye.Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1198C0117593497A5EC5C199286AF1F9897469DC AFD8691FDAEDF03BDF6E460563
 ARG PHP_VERSION
 ARG PHP_SHA256
 ENV PHP_VERSION ${PHP_VERSION}
-ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror" PHP_MD5=""
+ENV PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz.asc" PHP_MD5=""
 ENV PHP_SHA256 ${PHP_SHA256}
 
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.4/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bookworm.Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS AFD8691FDAEDF03BDF6E460563F15A9B715376CA 9D7F99A0CB8F05C8A6958D6256
 ARG PHP_VERSION
 ARG PHP_SHA256
 ENV PHP_VERSION ${PHP_VERSION}
-ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror" PHP_MD5=""
+ENV PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz.asc" PHP_MD5=""
 ENV PHP_SHA256 ${PHP_SHA256}
 
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.4/bullseye.Dockerfile
+++ b/images/runtime/php-fpm/8.4/bullseye.Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS AFD8691FDAEDF03BDF6E460563F15A9B715376CA 9D7F99A0CB8F05C8A6958D6256
 ARG PHP_VERSION
 ARG PHP_SHA256
 ENV PHP_VERSION ${PHP_VERSION}
-ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror" PHP_MD5=""
+ENV PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz.asc" PHP_MD5=""
 ENV PHP_SHA256 ${PHP_SHA256}
 
 RUN set -eux; \

--- a/images/runtime/php-fpm/8.5/noble.Dockerfile
+++ b/images/runtime/php-fpm/8.5/noble.Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS="1198C0117593497A5EC5C199286AF1F9897469DC 49D9AF6BC72A80D6691719C8A
 ARG PHP_VERSION
 ARG PHP_SHA256
 ENV PHP_VERSION=${PHP_VERSION}
-ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror" PHP_MD5=""
+ENV PHP_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz.asc" PHP_MD5=""
 ENV PHP_SHA256=${PHP_SHA256}
 
 RUN set -eux; \

--- a/platforms/php/prereqs/build.sh
+++ b/platforms/php/prereqs/build.sh
@@ -21,8 +21,8 @@ PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
 PHP_CPPFLAGS="$PHP_CFLAGS"
 PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
-PHP_URL="https://secure.php.net/get/php-$PHP_VERSION.tar.xz/from/this/mirror"
-PHP_ASC_URL="" # "https://secure.php.net/get/php-$PHP_VERSION.tar.xz.asc/from/this/mirror"
+PHP_URL="https://www.php.net/distributions/php-$PHP_VERSION.tar.xz"
+PHP_ASC_URL="" # "https://www.php.net/distributions/php-$PHP_VERSION.tar.xz.asc"
 GPG_KEYS=($GPG_KEYS) # Cast the string to an array
 PHP_MD5=""
 

--- a/platforms/php/prereqs/build.sh
+++ b/platforms/php/prereqs/build.sh
@@ -21,8 +21,8 @@ PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
 PHP_CPPFLAGS="$PHP_CFLAGS"
 PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
-PHP_URL="https://www.php.net/distributions/php-$PHP_VERSION.tar.xz"
-PHP_ASC_URL="" # "https://www.php.net/distributions/php-$PHP_VERSION.tar.xz.asc"
+PHP_URL="https://secure.php.net/distributions/php-$PHP_VERSION.tar.xz"
+PHP_ASC_URL="" # "https://secure.php.net/distributions/php-$PHP_VERSION.tar.xz.asc"
 GPG_KEYS=($GPG_KEYS) # Cast the string to an array
 PHP_MD5=""
 


### PR DESCRIPTION
Update PHP source archive URLs from the legacy `/get/.../from/this/mirror` route to PHP's direct `/distributions/` route.

## Changes

- Update PHP FPM runtime Dockerfiles for the maintained PHP 8.1–8.5 variants.
- Update the shared PHP prerequisite build script.
- Update the corresponding detached-signature URLs.
- Preserve the existing `secure.php.net` hostname in the shared prerequisite script.

## Reason

The existing `/get/php-<version>.tar.xz/from/this/mirror` route currently returns HTTP 404. The equivalent `/distributions/php-<version>.tar.xz` archives and `.asc` signatures are available.

## Validation

- Confirmed the archive and signature URLs return HTTP 200 for the active PHP versions referenced by the repository.
- Confirmed `platforms/php/prereqs/build.sh` passes `bash -n`.
- Confirmed no legacy `php.net/get` source archive URLs remain.
