### PR TITLE
Slim Python images for Embr

### DIFF
--- a/build/buildEmbrPythonRuntimeImages.sh
+++ b/build/buildEmbrPythonRuntimeImages.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+readonly REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly CONSTANTS_FILE="$REPO_DIR/images/embrconstants.yml"
+readonly DOCKERFILE="$REPO_DIR/images/runtime/python/embr/template.Dockerfile"
+readonly ACR_NAME="${ACR_NAME:-oryxdevmcr.azurecr.io}"
+readonly ACR_REPOSITORY="${ACR_REPOSITORY:-public/oryx/python}"
+readonly RELEASE_TAG_NAME="${RELEASE_TAG_NAME:-local}"
+readonly BUILD_DEFINITIONNAME="${BUILD_DEFINITIONNAME:-local}"
+readonly ARTIFACTS_DIR="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$REPO_DIR/artifacts}"
+readonly IMAGE_LIST="$ARTIFACTS_DIR/images/embr-python-runtime-images-acr.resolute.txt"
+readonly PYTHON_VERSIONS="${EMBR_PYTHON_VERSIONS:-3.13 3.14 3.15}"
+
+yaml_value() {
+    local key="$1"
+    sed -n "s/^  ${key}:[[:space:]]*//p" "$CONSTANTS_FILE"
+}
+
+mkdir -p "$(dirname "$IMAGE_LIST")"
+: > "$IMAGE_LIST"
+
+for minor_version in $PYTHON_VERSIONS; do
+    compact_version="${minor_version//./}"
+    full_version="$(yaml_value "python${compact_version}Version")"
+    sha256="$(yaml_value "python${compact_version}_SHA256")"
+
+    if [[ -z "$full_version" || -z "$sha256" ]]; then
+        echo "Missing version or SHA256 for Python $minor_version in $CONSTANTS_FILE." >&2
+        exit 1
+    fi
+
+    image="$ACR_NAME/$ACR_REPOSITORY:embr-$minor_version-ubuntu-resolute-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
+    docker build \
+        --file "$DOCKERFILE" \
+        --tag "$image" \
+        --build-arg "PYTHON_FULL_VERSION=$full_version" \
+        --build-arg "PYTHON_VERSION=$minor_version" \
+        --build-arg "PYTHON_SHA256=$sha256" \
+        --build-arg "BUILD_NUMBER=${BUILD_BUILDNUMBER:-local}" \
+        --build-arg "GIT_COMMIT=${BUILD_SOURCEVERSION:-unspecified}" \
+        --build-arg "RELEASE_TAG_NAME=$RELEASE_TAG_NAME" \
+        "$REPO_DIR"
+    echo "$image" >> "$IMAGE_LIST"
+done
+
+echo "Built Embr Python runtime images:"
+cat "$IMAGE_LIST"

--- a/build/buildEmbrPythonRuntimeImages.sh
+++ b/build/buildEmbrPythonRuntimeImages.sh
@@ -25,6 +25,19 @@ yaml_value() {
 mkdir -p "$(dirname "$IMAGE_LIST")"
 : > "$IMAGE_LIST"
 
+gunicorn_version="$(yaml_value "gunicornVersion")"
+gunicorn_url="$(yaml_value "gunicornSourceUrl")"
+gunicorn_sha256="$(yaml_value "gunicornSource_SHA256")"
+packaging_version="$(yaml_value "packagingVersion")"
+packaging_url="$(yaml_value "packagingSourceUrl")"
+packaging_sha256="$(yaml_value "packagingSource_SHA256")"
+
+if [[ -z "$gunicorn_version" || -z "$gunicorn_url" || -z "$gunicorn_sha256" \
+    || -z "$packaging_version" || -z "$packaging_url" || -z "$packaging_sha256" ]]; then
+    echo "Missing Gunicorn or packaging source metadata in $CONSTANTS_FILE." >&2
+    exit 1
+fi
+
 for minor_version in $PYTHON_VERSIONS; do
     compact_version="${minor_version//./}"
     full_version="$(yaml_value "python${compact_version}Version")"
@@ -42,6 +55,12 @@ for minor_version in $PYTHON_VERSIONS; do
         --build-arg "PYTHON_FULL_VERSION=$full_version" \
         --build-arg "PYTHON_VERSION=$minor_version" \
         --build-arg "PYTHON_SHA256=$sha256" \
+        --build-arg "GUNICORN_VERSION=$gunicorn_version" \
+        --build-arg "GUNICORN_URL=$gunicorn_url" \
+        --build-arg "GUNICORN_SHA256=$gunicorn_sha256" \
+        --build-arg "PACKAGING_VERSION=$packaging_version" \
+        --build-arg "PACKAGING_URL=$packaging_url" \
+        --build-arg "PACKAGING_SHA256=$packaging_sha256" \
         --build-arg "BUILD_NUMBER=${BUILD_BUILDNUMBER:-local}" \
         --build-arg "GIT_COMMIT=${BUILD_SOURCEVERSION:-unspecified}" \
         --build-arg "RELEASE_TAG_NAME=$RELEASE_TAG_NAME" \

--- a/build/testEmbrPythonRuntimeImages.sh
+++ b/build/testEmbrPythonRuntimeImages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -s "$1" ]]; then
+    echo "Usage: $0 <image-list>" >&2
+    exit 1
+fi
+
+while IFS= read -r image; do
+    image="${image%$'\r'}"
+    [[ -n "$image" ]] || continue
+    expected_version="$(sed -n 's/.*:embr-\([0-9]\+\.[0-9]\+\)-ubuntu-resolute-.*/\1/p' <<< "$image")"
+    if [[ -z "$expected_version" ]]; then
+        echo "Unexpected Embr Python image tag: $image" >&2
+        exit 1
+    fi
+
+    docker run --rm --env "EXPECTED_VERSION=$expected_version" "$image" sh -ceu '
+        actual_version="$(python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")")"
+        test "$actual_version" = "$EXPECTED_VERSION"
+        python -c "import bz2, ctypes, curses, dbm.gnu, lzma, readline, sqlite3, ssl, tkinter, uuid"
+        python -c "import urllib.request; urllib.request.urlopen(\"https://www.python.org/\", timeout=30).close()"
+        test -n "$(find /usr/local/share/ca-certificates -name "azl_*.crt" -print -quit)"
+        test ! -x /usr/bin/gcc
+        test ! -x /usr/bin/g++
+        python -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None"
+        python -c "import importlib.util; assert importlib.util.find_spec(\"gunicorn\") is None"
+        python -c "import importlib.util; assert importlib.util.find_spec(\"uvicorn\") is None"
+    '
+done < "$1"
+
+echo "All Embr Python runtime image tests passed."

--- a/build/testEmbrPythonRuntimeImages.sh
+++ b/build/testEmbrPythonRuntimeImages.sh
@@ -23,14 +23,32 @@ while IFS= read -r image; do
     docker run --rm --env "EXPECTED_VERSION=$expected_version" "$image" sh -ceu '
         actual_version="$(python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")")"
         test "$actual_version" = "$EXPECTED_VERSION"
-        python -c "import bz2, ctypes, curses, dbm.gnu, lzma, readline, sqlite3, ssl, tkinter, uuid"
+        python -c "import bz2, ctypes, curses, dbm.gnu, lzma, readline, sqlite3, ssl, uuid"
         python -c "import urllib.request; urllib.request.urlopen(\"https://www.python.org/\", timeout=30).close()"
+        python -c "import ctypes; ctypes.CDLL(\"libpq.so.5\"); ctypes.CDLL(\"libmysqlclient.so.24\")"
         test -n "$(find /usr/local/share/ca-certificates -name "azl_*.crt" -print -quit)"
         test ! -x /usr/bin/gcc
         test ! -x /usr/bin/g++
         python -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None"
-        python -c "import importlib.util; assert importlib.util.find_spec(\"gunicorn\") is None"
+        python -c "import importlib.util; assert importlib.util.find_spec(\"_tkinter\") is None"
+        gunicorn --version | grep -q "^gunicorn (version "
         python -c "import importlib.util; assert importlib.util.find_spec(\"uvicorn\") is None"
+        test -x /opt/oryx/benv
+        test -x /opt/startupcmdgen/startupcmdgen
+        test "$(readlink /usr/local/bin/oryx)" = "/opt/startupcmdgen/startupcmdgen"
+        mkdir -p /tmp/oryx-startup-test
+        oryx create-script \
+            -appPath /tmp/oryx-startup-test \
+            -output /tmp/oryx-startup.sh \
+            -bindPort 8000 \
+            -userStartupCommand "gunicorn wsgiref.simple_server:demo_app --bind 0.0.0.0:8000"
+        test -s /tmp/oryx-startup.sh
+        grep -q "gunicorn wsgiref.simple_server:demo_app" /tmp/oryx-startup.sh
+        EXPECTED_VERSION="$EXPECTED_VERSION" bash -c '"'"'
+            source /opt/oryx/benv "python=$EXPECTED_VERSION"
+            test "$python" = "/opt/python/$EXPECTED_VERSION/bin/python"
+            test "$(python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")")" = "$EXPECTED_VERSION"
+        '"'"'
     '
 done < "$1"
 

--- a/images/embrconstants.yml
+++ b/images/embrconstants.yml
@@ -1,0 +1,11 @@
+variables:
+  python313osFlavors: resolute
+  python314osFlavors: resolute
+  python315osFlavors: resolute
+  pythonosFlavors: resolute
+  python313Version: 3.13.15
+  python313_SHA256: 1e66a7945a48390ee4c2a4268a0e4185884059a13c4aab6d148aa208deea4a76
+  python314Version: 3.14.7
+  python314_SHA256: 3b48dac8fb59f62eaa67ac83c1eb12bda1b7a08406dd286e252c11a66be27f81
+  python315Version: 3.15.0b3
+  python315_SHA256: 6a935ae234a67e6549894373b0cfeb8361182d03b21442328ae9598ab7422127

--- a/images/embrconstants.yml
+++ b/images/embrconstants.yml
@@ -9,3 +9,9 @@ variables:
   python314_SHA256: 3b48dac8fb59f62eaa67ac83c1eb12bda1b7a08406dd286e252c11a66be27f81
   python315Version: 3.15.0b3
   python315_SHA256: 6a935ae234a67e6549894373b0cfeb8361182d03b21442328ae9598ab7422127
+  gunicornVersion: 24.1.1
+  gunicornSourceUrl: https://codeload.github.com/benoitc/gunicorn/tar.gz/refs/tags/24.1.1
+  gunicornSource_SHA256: 8522dbd3d8ae27f0568939e88e35effe43ed6077eb2c2cbd1ab084d37cf3d9f0
+  packagingVersion: 26.0
+  packagingSourceUrl: https://codeload.github.com/pypa/packaging/tar.gz/refs/tags/26.0
+  packagingSource_SHA256: 7b1995333d1d9a2d857ba85c493df323055e64248a45c2af32ebe9ae8dce663b

--- a/images/runtime/python/embr/README.md
+++ b/images/runtime/python/embr/README.md
@@ -1,0 +1,34 @@
+# Embr Python runtime images
+
+These images provide the runtime substrate for deployment-specific Embr
+application images. They use Ubuntu Resolute and contain CPython, runtime
+libraries, basic network tools, and the Ubuntu and Azure Linux certificate
+trust stores.
+
+Application frameworks, application servers, database clients, compilers,
+profilers, and the Oryx startup-script generator are intentionally excluded.
+Applications must package those dependencies in their build output.
+
+The Oryx pipelines build Python 3.13, 3.14, and 3.15 from the versions and
+SHA256 checksums in `images/embrconstants.yml`. Candidate images are published
+to `oryxdevmcr.azurecr.io/public/oryx/python`; release images use the existing
+MCR repository:
+
+```text
+mcr.microsoft.com/oryx/python:embr-<major.minor>-ubuntu-resolute-<release>
+```
+
+On `main`, the release pipeline also publishes the moving
+`embr-<major.minor>-ubuntu-resolute` tag. Consumers that require reproducible
+deployments must resolve and persist the image digest.
+
+To build and test all configured versions locally:
+
+```bash
+BUILD_DEFINITIONNAME=local \
+RELEASE_TAG_NAME=dev \
+bash build/buildEmbrPythonRuntimeImages.sh
+
+bash build/testEmbrPythonRuntimeImages.sh \
+  artifacts/images/embr-python-runtime-images-acr.resolute.txt
+```

--- a/images/runtime/python/embr/template.Dockerfile
+++ b/images/runtime/python/embr/template.Dockerfile
@@ -1,0 +1,154 @@
+# syntax=docker/dockerfile:1.7
+
+ARG UBUNTU_BASE_IMAGE=mcr.microsoft.com/mirror/docker/library/ubuntu:resolute
+ARG AZURE_LINUX_BASE_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+
+FROM ${AZURE_LINUX_BASE_IMAGE} AS azurelinuxcertificates
+
+RUN tdnf makecache \
+    && tdnf install -y ca-certificates \
+    && update-ca-trust extract \
+    && tdnf clean all
+
+FROM ${UBUNTU_BASE_IMAGE} AS embrbase
+
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        netbase \
+        openssl \
+        libatomic1 \
+        libbz2-1.0 \
+        libexpat1 \
+        libffi8 \
+        libgdbm6t64 \
+        libgdbm-compat4t64 \
+        liblzma5 \
+        libncursesw6 \
+        libreadline8t64 \
+        libsqlite3-0 \
+        libssl3t64 \
+        libuuid1 \
+        tk8.6 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=azurelinuxcertificates \
+    /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY images/runtime/scripts/install-azurelinux-certs.sh /tmp/install-azurelinux-certs.sh
+RUN chmod +x /tmp/install-azurelinux-certs.sh \
+    && /tmp/install-azurelinux-certs.sh \
+        /tmp/azurelinux-ca-certs \
+        /tmp/azurelinux-ca-certs/tls-ca-bundle.pem \
+    && rm -f /tmp/install-azurelinux-certs.sh
+
+FROM embrbase AS pythonbuildbase
+
+RUN apt-get -o Acquire::Retries=5 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        gnupg \
+        libbluetooth-dev \
+        libbz2-dev \
+        libffi-dev \
+        libgdbm-dev \
+        liblzma-dev \
+        libncurses5-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        pkg-config \
+        tk-dev \
+        uuid-dev \
+        wget \
+        xz-utils \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM pythonbuildbase AS pythonbuilder
+
+ARG PYTHON_FULL_VERSION
+ARG PYTHON_GPG_KEY
+ARG PYTHON_SHA256
+
+COPY images/receiveGpgKeys.sh /tmp/receiveGpgKeys.sh
+RUN test -n "${PYTHON_FULL_VERSION}" \
+    && test -n "${PYTHON_GPG_KEY}${PYTHON_SHA256}" \
+    && chmod +x /tmp/receiveGpgKeys.sh \
+    && mkdir -p /usr/src/python \
+    && wget \
+        "https://www.python.org/ftp/python/${PYTHON_FULL_VERSION%%[a-z]*}/Python-${PYTHON_FULL_VERSION}.tar.xz" \
+        -O /tmp/python.tar.xz \
+    && if [ -n "${PYTHON_SHA256}" ]; then \
+        echo "${PYTHON_SHA256}  /tmp/python.tar.xz" | sha256sum -c -; \
+    else \
+        wget \
+            "https://www.python.org/ftp/python/${PYTHON_FULL_VERSION%%[a-z]*}/Python-${PYTHON_FULL_VERSION}.tar.xz.asc" \
+            -O /tmp/python.tar.xz.asc; \
+        /tmp/receiveGpgKeys.sh "${PYTHON_GPG_KEY}"; \
+        gpg --batch --verify /tmp/python.tar.xz.asc /tmp/python.tar.xz; \
+    fi \
+    && tar -xJf /tmp/python.tar.xz --strip-components=1 -C /usr/src/python \
+    && cd /usr/src/python \
+    && configure_args="" \
+    && case "${PYTHON_FULL_VERSION}" in \
+        3.15.*) configure_args="--without-system-libmpdec" ;; \
+    esac \
+    && ./configure \
+        --prefix="/opt/python/${PYTHON_FULL_VERSION}" \
+        --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+        --enable-loadable-sqlite-extensions \
+        --enable-optimizations \
+        --enable-shared \
+        --with-lto \
+        --with-system-ffi \
+        --without-ensurepip \
+        ${configure_args} \
+    && make -j "$(nproc)" \
+    && make install
+
+FROM embrbase AS main
+
+ARG PYTHON_FULL_VERSION
+ARG PYTHON_VERSION
+ARG PYTHON_MAJOR_VERSION=3
+ARG BUILD_NUMBER=unspecified
+ARG GIT_COMMIT=unspecified
+ARG RELEASE_TAG_NAME=unspecified
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+LABEL com.microsoft.oryx.build-number="${BUILD_NUMBER}" \
+    com.microsoft.oryx.git-commit="${GIT_COMMIT}" \
+    com.microsoft.oryx.release-tag-name="${RELEASE_TAG_NAME}"
+
+RUN test -n "${PYTHON_FULL_VERSION}" \
+    && test -n "${PYTHON_VERSION}"
+
+COPY --from=pythonbuilder \
+    /opt/python/${PYTHON_FULL_VERSION} \
+    /opt/python/${PYTHON_FULL_VERSION}
+
+RUN cd /opt/python \
+    && ln -s "${PYTHON_FULL_VERSION}" "${PYTHON_VERSION}" \
+    && ln -s "${PYTHON_VERSION}" "${PYTHON_MAJOR_VERSION}" \
+    && cd "/opt/python/${PYTHON_FULL_VERSION}/bin" \
+    && ln -s python3 python \
+    && ln -s python3-config python-config \
+    && printf '/opt/python/%s/lib\n' "${PYTHON_MAJOR_VERSION}" \
+        > /etc/ld.so.conf.d/python.conf \
+    && ldconfig \
+    && find "/opt/python/${PYTHON_FULL_VERSION}" -depth \
+        \( -type d \( -name test -o -name tests -o -name idle_test \) \
+        -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+        -exec rm -rf '{}' +
+
+ENV PATH="/opt/python/${PYTHON_MAJOR_VERSION}/bin:${PATH}" \
+    PYTHON_VERSION=${PYTHON_FULL_VERSION}

--- a/images/runtime/python/embr/template.Dockerfile
+++ b/images/runtime/python/embr/template.Dockerfile
@@ -108,7 +108,11 @@ RUN test -n "${PYTHON_FULL_VERSION}" \
         --without-ensurepip \
         ${configure_args} \
     && make -j "$(nproc)" \
-    && make install
+    && make install \
+    && find "/opt/python/${PYTHON_FULL_VERSION}" -depth \
+        \( -type d \( -name test -o -name tests -o -name idle_test \) \
+        -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+        -exec rm -rf '{}' +
 
 FROM embrbase AS main
 
@@ -144,11 +148,7 @@ RUN cd /opt/python \
     && ln -s python3-config python-config \
     && printf '/opt/python/%s/lib\n' "${PYTHON_MAJOR_VERSION}" \
         > /etc/ld.so.conf.d/python.conf \
-    && ldconfig \
-    && find "/opt/python/${PYTHON_FULL_VERSION}" -depth \
-        \( -type d \( -name test -o -name tests -o -name idle_test \) \
-        -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
-        -exec rm -rf '{}' +
+    && ldconfig
 
 ENV PATH="/opt/python/${PYTHON_MAJOR_VERSION}/bin:${PATH}" \
     PYTHON_VERSION=${PYTHON_FULL_VERSION}

--- a/images/runtime/python/embr/template.Dockerfile
+++ b/images/runtime/python/embr/template.Dockerfile
@@ -3,6 +3,19 @@
 ARG UBUNTU_BASE_IMAGE=mcr.microsoft.com/mirror/docker/library/ubuntu:resolute
 ARG AZURE_LINUX_BASE_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
 
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26-bookworm AS startupcmdgen
+
+WORKDIR /go/src
+COPY src/startupscriptgenerator/src .
+ARG GIT_COMMIT=unspecified
+ARG BUILD_NUMBER=unspecified
+ARG RELEASE_TAG_NAME=unspecified
+ENV GIT_COMMIT=${GIT_COMMIT} \
+    BUILD_NUMBER=${BUILD_NUMBER} \
+    RELEASE_TAG_NAME=${RELEASE_TAG_NAME}
+RUN chmod +x build.sh \
+    && ./build.sh python /opt/startupcmdgen/startupcmdgen
+
 FROM ${AZURE_LINUX_BASE_IMAGE} AS azurelinuxcertificates
 
 RUN tdnf makecache \
@@ -27,11 +40,12 @@ RUN apt-get -o Acquire::Retries=5 update \
         libgdbm-compat4t64 \
         liblzma5 \
         libncursesw6 \
+        libmysqlclient24 \
+        libpq5 \
         libreadline8t64 \
         libsqlite3-0 \
         libssl3t64 \
         libuuid1 \
-        tk8.6 \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
@@ -61,7 +75,6 @@ RUN apt-get -o Acquire::Retries=5 update \
         libsqlite3-dev \
         libssl-dev \
         pkg-config \
-        tk-dev \
         uuid-dev \
         wget \
         xz-utils \
@@ -114,6 +127,58 @@ RUN test -n "${PYTHON_FULL_VERSION}" \
         -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
         -exec rm -rf '{}' +
 
+FROM pythonbuildbase AS pythonwheels
+
+ARG GUNICORN_VERSION
+ARG GUNICORN_URL
+ARG GUNICORN_SHA256
+ARG PACKAGING_VERSION
+ARG PACKAGING_URL
+ARG PACKAGING_SHA256
+
+RUN test -n "${GUNICORN_VERSION}${GUNICORN_URL}${GUNICORN_SHA256}" \
+    && test -n "${PACKAGING_VERSION}${PACKAGING_URL}${PACKAGING_SHA256}" \
+    && apt-get -o Acquire::Retries=5 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        flit \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --fail --location --retry 5 --retry-all-errors \
+        "${GUNICORN_URL}" \
+        --output /tmp/gunicorn.tar.gz \
+    && echo "${GUNICORN_SHA256}  /tmp/gunicorn.tar.gz" | sha256sum -c - \
+    && curl --fail --location --retry 5 --retry-all-errors \
+        "${PACKAGING_URL}" \
+        --output /tmp/packaging.tar.gz \
+    && echo "${PACKAGING_SHA256}  /tmp/packaging.tar.gz" | sha256sum -c - \
+    && mkdir -p /tmp/gunicorn-source /tmp/packaging-source /tmp/wheels \
+    && tar -xzf /tmp/gunicorn.tar.gz --strip-components=1 -C /tmp/gunicorn-source \
+    && tar -xzf /tmp/packaging.tar.gz --strip-components=1 -C /tmp/packaging-source \
+    && python3 -m pip wheel --no-deps --no-build-isolation \
+        --wheel-dir /tmp/wheels \
+        /tmp/packaging-source \
+        /tmp/gunicorn-source
+
+FROM pythonbuilder AS pythonruntime
+
+ARG PYTHON_FULL_VERSION
+
+COPY --from=pythonwheels /tmp/wheels/*.whl /tmp/
+RUN LD_LIBRARY_PATH="/opt/python/${PYTHON_FULL_VERSION}/lib" \
+        "/opt/python/${PYTHON_FULL_VERSION}/bin/python3" -c \
+        'import pathlib, sys, zipfile; target = pathlib.Path(sys.argv[1]); [zipfile.ZipFile(wheel).extractall(target) for wheel in sys.argv[2:]]' \
+        "/opt/python/${PYTHON_FULL_VERSION}/lib/python${PYTHON_FULL_VERSION%.*}/site-packages" \
+        /tmp/packaging-*.whl \
+        /tmp/gunicorn-*.whl \
+    && printf '%s\n' \
+        '#!/bin/sh' \
+        'exec "$(dirname "$0")/python3" -c "from gunicorn.app.wsgiapp import run; run(prog=\"gunicorn\")" "$@"' \
+        > "/opt/python/${PYTHON_FULL_VERSION}/bin/gunicorn" \
+    && chmod +x "/opt/python/${PYTHON_FULL_VERSION}/bin/gunicorn" \
+    && rm -f /tmp/gunicorn-*.whl /tmp/packaging-*.whl
+
 FROM embrbase AS main
 
 ARG PYTHON_FULL_VERSION
@@ -136,9 +201,13 @@ LABEL com.microsoft.oryx.build-number="${BUILD_NUMBER}" \
 RUN test -n "${PYTHON_FULL_VERSION}" \
     && test -n "${PYTHON_VERSION}"
 
-COPY --from=pythonbuilder \
+COPY --from=pythonruntime \
     /opt/python/${PYTHON_FULL_VERSION} \
     /opt/python/${PYTHON_FULL_VERSION}
+COPY --from=startupcmdgen \
+    /opt/startupcmdgen/startupcmdgen \
+    /opt/startupcmdgen/startupcmdgen
+COPY images/build/benv.sh /opt/oryx/benv
 
 RUN cd /opt/python \
     && ln -s "${PYTHON_FULL_VERSION}" "${PYTHON_VERSION}" \
@@ -148,7 +217,9 @@ RUN cd /opt/python \
     && ln -s python3-config python-config \
     && printf '/opt/python/%s/lib\n' "${PYTHON_MAJOR_VERSION}" \
         > /etc/ld.so.conf.d/python.conf \
-    && ldconfig
+    && ldconfig \
+    && chmod +x /opt/oryx/benv \
+    && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx
 
 ENV PATH="/opt/python/${PYTHON_MAJOR_VERSION}/bin:${PATH}" \
     PYTHON_VERSION=${PYTHON_FULL_VERSION}

--- a/vsts/pipelines/ci.yml
+++ b/vsts/pipelines/ci.yml
@@ -245,6 +245,22 @@ stages:
         parameters:
             imageType: bookworm
 
+    - job: Job_Embr_Python_Resolute_RuntimeImages
+      displayName: Build and Test Embr Python Resolute Runtime Images
+      condition: succeeded()
+      timeoutInMinutes: 180
+      pool:
+        name: AzurePipelines-EO
+        demands:
+          - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+      variables:
+        skipComponentGovernanceDetection: true
+      steps:
+      - template: templates/_setReleaseTag.yml
+      - template: templates/_embrPythonRuntimeImagesStepTemplate.yml
+        parameters:
+          pushImages: true
+
     - template: templates/_integrationJobTemplate.yml
       parameters:
           storageAccountUrl: ${{ parameters.storageAccountUrl }}

--- a/vsts/pipelines/nightly.yml
+++ b/vsts/pipelines/nightly.yml
@@ -205,6 +205,24 @@ stages:
         parameters:
             imageType: bookworm
 
+    - job: Job_Embr_Python_Resolute_RuntimeImages
+      displayName: Build and Test Embr Python Resolute Runtime Images
+      condition: succeeded()
+      timeoutInMinutes: 180
+      pool:
+        name: AzurePipelines-EO
+        demands:
+          - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+      variables:
+        skipComponentGovernanceDetection: true
+      steps:
+      - script: |
+          echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
+        displayName: Set release tag
+      - template: templates/_embrPythonRuntimeImagesStepTemplate.yml
+        parameters:
+          pushImages: true
+
     - template: templates/_integrationJobTemplate.yml
       parameters:
         storageAccountUrl: ${{ parameters.storageAccountUrl }}

--- a/vsts/pipelines/templates/_embrPythonRuntimeImagesStepTemplate.yml
+++ b/vsts/pipelines/templates/_embrPythonRuntimeImagesStepTemplate.yml
@@ -1,0 +1,63 @@
+parameters:
+- name: pushImages
+  type: boolean
+  default: false
+- name: acrName
+  type: string
+  default: oryxdevmcr.azurecr.io
+- name: ascName
+  type: string
+  default: oryx-new-service-connection
+
+steps:
+- checkout: self
+  clean: true
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: Component Detection - OSS Compliance
+  inputs:
+    ignoreDirectories: '$(Build.SourcesDirectory)/tests'
+
+- ${{ if eq(parameters.pushImages, true) }}:
+  - task: Docker@1
+    displayName: Login to Oryx development ACR
+    inputs:
+      command: login
+      azureSubscriptionEndpoint: ${{ parameters.ascName }}
+      azureContainerRegistry: ${{ parameters.acrName }}
+
+- task: Bash@3
+  displayName: Build Embr Python Resolute runtime images
+  inputs:
+    targetType: filePath
+    filePath: ./build/buildEmbrPythonRuntimeImages.sh
+
+- task: Bash@3
+  displayName: Test Embr Python Resolute runtime images
+  inputs:
+    targetType: filePath
+    filePath: ./build/testEmbrPythonRuntimeImages.sh
+    arguments: '$(Build.ArtifactStagingDirectory)/images/embr-python-runtime-images-acr.resolute.txt'
+
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: Generate Software Bill of Materials (SBOM)
+  inputs:
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+
+- ${{ if eq(parameters.pushImages, true) }}:
+  - task: Docker@1
+    displayName: Push Embr Python runtime images to development ACR
+    inputs:
+      azureSubscriptionEndpoint: ${{ parameters.ascName }}
+      azureContainerRegistry: ${{ parameters.acrName }}
+      command: Push an image
+      pushMultipleImages: true
+      imageNamesPath: '$(Build.ArtifactStagingDirectory)/images/embr-python-runtime-images-acr.resolute.txt'
+      includeLatestTag: false
+      enforceDockerNamingConvention: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Embr Python runtime image metadata
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: drop

--- a/vsts/pipelines/templates/_releaseStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseStepTemplate.yml
@@ -93,6 +93,13 @@ steps:
     scriptPath: ./vsts/scripts/tagRunTimeImagesForRelease.sh
   condition: and(succeeded(), eq(variables['ReleaseRuntimeImages'], 'true'))
 
+- task: Bash@3
+  displayName: 'Pull and create release tags for Embr Python runtime images'
+  inputs:
+    targetType: filePath
+    filePath: ./vsts/scripts/tagEmbrPythonRuntimeImagesForRelease.sh
+  condition: and(succeeded(), eq(variables['ReleaseRuntimeImages'], 'true'))
+
 - task: Shellpp@0
   displayName: 'Pull and create release tags for CLI images'
   inputs:

--- a/vsts/pipelines/validation.yml
+++ b/vsts/pipelines/validation.yml
@@ -167,5 +167,22 @@ jobs:
   - template: templates/_buildTemplate.yml
     parameters:
         imageType: bookworm
-        
+
+- job: Job_Embr_Python_Resolute_RuntimeImages
+  displayName: Build and Test Embr Python Resolute Runtime Images
+  timeoutInMinutes: 180
+  pool:
+    name: AzurePipelines-EO
+    demands:
+      - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+  variables:
+  - group: Oryx
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
+    displayName: Set release tag
+  - template: templates/_embrPythonRuntimeImagesStepTemplate.yml
+    parameters:
+      pushImages: false
+
 trigger: none

--- a/vsts/scripts/tagEmbrPythonRuntimeImagesForRelease.sh
+++ b/vsts/scripts/tagEmbrPythonRuntimeImagesForRelease.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+readonly SOURCE_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/embr-python-runtime-images-acr.resolute.txt"
+readonly OUTPUT_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/oryxprodmcr-runtime-images-mcr.txt"
+readonly PROD_REPOSITORY="oryxprodmcr.azurecr.io/public/oryx/python"
+
+if [[ ! -s "$SOURCE_FILE" ]]; then
+    echo "Embr Python runtime image list not found: $SOURCE_FILE" >&2
+    exit 1
+fi
+
+touch "$OUTPUT_FILE"
+
+while IFS= read -r source_image; do
+    source_image="${source_image%$'\r'}"
+    [[ -n "$source_image" ]] || continue
+    minor_version="$(sed -n 's/.*:embr-\([0-9]\+\.[0-9]\+\)-ubuntu-resolute-.*/\1/p' <<< "$source_image")"
+    if [[ -z "$minor_version" ]]; then
+        echo "Unexpected Embr Python image tag: $source_image" >&2
+        exit 1
+    fi
+
+    immutable_image="$PROD_REPOSITORY:embr-$minor_version-ubuntu-resolute-$RELEASE_TAG_NAME"
+    docker pull "$source_image"
+    docker tag "$source_image" "$immutable_image"
+    echo "$immutable_image" >> "$OUTPUT_FILE"
+
+    if [[ "$BUILD_SOURCEBRANCHNAME" == "main" ]]; then
+        moving_image="$PROD_REPOSITORY:embr-$minor_version-ubuntu-resolute"
+        docker tag "$source_image" "$moving_image"
+        echo "$moving_image" >> "$OUTPUT_FILE"
+    fi
+done < "$SOURCE_FILE"
+
+echo "Prepared Embr Python release tags:"
+cat "$OUTPUT_FILE"


### PR DESCRIPTION
<!--
Thank you for contributing to the Oryx project.

Please verify the following before submitting your PR, thank you.
-->

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
### What changed


Adds Embr-specific Python runtime images for Ubuntu Resolute covering Python 3.13, 3.14, and preview 3.15. The images retain the runtime dependencies required by Embr applications - Gunicorn, PostgreSQL/MySQL client libraries, Azure Linux CA certificates, the Oryx startup generator, and `/opt/oryx/benv`—while excluding compilers, pip, Uvicorn, Tkinter, and other build-only tooling. The existing Oryx pipelines build, validate, publish candidate images to the development registry, and promote immutable and moving `embr-*` tags through the production release path.


### Validation



- Built all three runtime images locally.

- Passed runtime contract tests covering Python modules, TLS trust, database libraries, Gunicorn, Oryx startup-script generation, `benv`, and excluded tooling.

- Started an Oryx-generated Gunicorn application and verified an HTTP 200 response.

- Tested E2E on Embr private subscription

- Final compressed image sizes:

  - Python 3.13: 96 MB
  
  - Python 3.14: 98 MB
  
  - Python 3.15: 101 MB

- Pending E2E tests

  - Deploy representative Python 3.13, 3.14, and 3.15 applications through the normal Embr/Oryx build path.
  
  - Verify Oryx-generated startup launches a WSGI app with Gunicorn and the public endpoint returns HTTP 200.
  
  - Validate HTTPS calls using the merged Ubuntu/Azure certificate trust.
  
  - Deploy apps using PostgreSQL and MySQL drivers; verify imports and real database connections succeed.
  
  - Confirm runtime-version selection through `/opt/oryx/benv`.
  
  - Verify logs, restarts, health checks, and redeployment work without build-only tools in the runtime.
  
  - Confirm failures are surfaced clearly for excluded capabilities such as pip, Uvicorn, Tkinter, or native compilation at startup.
  
  - Treat Python 3.15 separately as preview until a GA version is published.

### What's included

- **Gunicorn:** Provides the production WSGI server expected by Oryx-generated Python startup commands. Python’s built-in server is not production-ready.

- **PostgreSQL/MySQL client libraries:** Supply native shared libraries required at runtime by common database drivers such as `psycopg` and `mysqlclient`; compilation remains in the build image.

- **Azure Linux CA certificates:** Preserve trust for Microsoft/Azure endpoints that may rely on certificates not present in Ubuntu’s default trust store.

- **Oryx startup generator:** Converts deployment metadata and startup settings into the executable command that launches the application.

- **`/opt/oryx/benv`:** Resolves the requested runtime version and configures `PATH` and related environment variables for Oryx-generated and legacy startup scripts.

