### PR TITLE
Node images for Embr

### DIFF
--- a/build/buildEmbrNodeRuntimeImages.sh
+++ b/build/buildEmbrNodeRuntimeImages.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+readonly REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly CONSTANTS_FILE="$REPO_DIR/images/embrconstants.yml"
+readonly DOCKERFILE="$REPO_DIR/images/runtime/node/embr/template.Dockerfile"
+readonly ARTIFACTS_DIR="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$REPO_DIR/artifacts}"
+readonly IMAGE_LIST="$ARTIFACTS_DIR/images/embr-node-runtime-images.resolute.txt"
+readonly NODE_VERSIONS="${EMBR_NODE_VERSIONS:-22 24}"
+readonly IMAGE_REPOSITORY="${EMBR_NODE_IMAGE_REPOSITORY:-embr-node-runtime}"
+
+yaml_value() {
+    local key="$1"
+    sed -n "s/^  ${key}:[[:space:]]*//p" "$CONSTANTS_FILE"
+}
+
+mkdir -p "$(dirname "$IMAGE_LIST")"
+: > "$IMAGE_LIST"
+
+yarn_version="$(yaml_value "yarnVersion")"
+yarn_url="$(yaml_value "yarnSourceUrl")"
+yarn_sha256="$(yaml_value "yarnSource_SHA256")"
+
+if [[ -z "$yarn_version" || -z "$yarn_url" || -z "$yarn_sha256" ]]; then
+    echo "Missing Yarn source metadata in $CONSTANTS_FILE." >&2
+    exit 1
+fi
+
+for major_version in $NODE_VERSIONS; do
+    full_version="$(yaml_value "node${major_version}Version")"
+    sha256="$(yaml_value "node${major_version}_SHA256")"
+
+    if [[ -z "$full_version" || -z "$sha256" ]]; then
+        echo "Missing version or SHA256 for Node $major_version in $CONSTANTS_FILE." >&2
+        exit 1
+    fi
+
+    minor_version="${full_version%.*}"
+    image="$IMAGE_REPOSITORY:$major_version-resolute"
+    docker build \
+        --file "$DOCKERFILE" \
+        --tag "$image" \
+        --build-arg "NODE_FULL_VERSION=$full_version" \
+        --build-arg "NODE_VERSION=$minor_version" \
+        --build-arg "NODE_MAJOR_VERSION=$major_version" \
+        --build-arg "NODE_SHA256=$sha256" \
+        --build-arg "YARN_VERSION=$yarn_version" \
+        --build-arg "YARN_URL=$yarn_url" \
+        --build-arg "YARN_SHA256=$yarn_sha256" \
+        --build-arg "BUILD_NUMBER=${BUILD_BUILDNUMBER:-local}" \
+        --build-arg "GIT_COMMIT=${BUILD_SOURCEVERSION:-unspecified}" \
+        --build-arg "RELEASE_TAG_NAME=${RELEASE_TAG_NAME:-local}" \
+        "$REPO_DIR"
+    echo "$image" >> "$IMAGE_LIST"
+done
+
+echo "Built local Embr Node runtime images:"
+cat "$IMAGE_LIST"

--- a/build/buildEmbrPythonRuntimeImages.sh
+++ b/build/buildEmbrPythonRuntimeImages.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+readonly REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly CONSTANTS_FILE="$REPO_DIR/images/embrconstants.yml"
+readonly DOCKERFILE="$REPO_DIR/images/runtime/python/embr/template.Dockerfile"
+readonly ACR_NAME="${ACR_NAME:-oryxdevmcr.azurecr.io}"
+readonly ACR_REPOSITORY="${ACR_REPOSITORY:-public/oryx/python}"
+readonly RELEASE_TAG_NAME="${RELEASE_TAG_NAME:-local}"
+readonly BUILD_DEFINITIONNAME="${BUILD_DEFINITIONNAME:-local}"
+readonly ARTIFACTS_DIR="${BUILD_ARTIFACTSTAGINGDIRECTORY:-$REPO_DIR/artifacts}"
+readonly IMAGE_LIST="$ARTIFACTS_DIR/images/embr-python-runtime-images-acr.resolute.txt"
+readonly PYTHON_VERSIONS="${EMBR_PYTHON_VERSIONS:-3.13 3.14 3.15}"
+
+yaml_value() {
+    local key="$1"
+    sed -n "s/^  ${key}:[[:space:]]*//p" "$CONSTANTS_FILE"
+}
+
+mkdir -p "$(dirname "$IMAGE_LIST")"
+: > "$IMAGE_LIST"
+
+for minor_version in $PYTHON_VERSIONS; do
+    compact_version="${minor_version//./}"
+    full_version="$(yaml_value "python${compact_version}Version")"
+    sha256="$(yaml_value "python${compact_version}_SHA256")"
+
+    if [[ -z "$full_version" || -z "$sha256" ]]; then
+        echo "Missing version or SHA256 for Python $minor_version in $CONSTANTS_FILE." >&2
+        exit 1
+    fi
+
+    image="$ACR_NAME/$ACR_REPOSITORY:embr-$minor_version-ubuntu-resolute-$BUILD_DEFINITIONNAME.$RELEASE_TAG_NAME"
+    docker build \
+        --file "$DOCKERFILE" \
+        --tag "$image" \
+        --build-arg "PYTHON_FULL_VERSION=$full_version" \
+        --build-arg "PYTHON_VERSION=$minor_version" \
+        --build-arg "PYTHON_SHA256=$sha256" \
+        --build-arg "BUILD_NUMBER=${BUILD_BUILDNUMBER:-local}" \
+        --build-arg "GIT_COMMIT=${BUILD_SOURCEVERSION:-unspecified}" \
+        --build-arg "RELEASE_TAG_NAME=$RELEASE_TAG_NAME" \
+        "$REPO_DIR"
+    echo "$image" >> "$IMAGE_LIST"
+done
+
+echo "Built Embr Python runtime images:"
+cat "$IMAGE_LIST"

--- a/build/buildEmbrPythonRuntimeImages.sh
+++ b/build/buildEmbrPythonRuntimeImages.sh
@@ -25,6 +25,19 @@ yaml_value() {
 mkdir -p "$(dirname "$IMAGE_LIST")"
 : > "$IMAGE_LIST"
 
+gunicorn_version="$(yaml_value "gunicornVersion")"
+gunicorn_url="$(yaml_value "gunicornSourceUrl")"
+gunicorn_sha256="$(yaml_value "gunicornSource_SHA256")"
+packaging_version="$(yaml_value "packagingVersion")"
+packaging_url="$(yaml_value "packagingSourceUrl")"
+packaging_sha256="$(yaml_value "packagingSource_SHA256")"
+
+if [[ -z "$gunicorn_version" || -z "$gunicorn_url" || -z "$gunicorn_sha256" \
+    || -z "$packaging_version" || -z "$packaging_url" || -z "$packaging_sha256" ]]; then
+    echo "Missing Gunicorn or packaging source metadata in $CONSTANTS_FILE." >&2
+    exit 1
+fi
+
 for minor_version in $PYTHON_VERSIONS; do
     compact_version="${minor_version//./}"
     full_version="$(yaml_value "python${compact_version}Version")"
@@ -42,6 +55,12 @@ for minor_version in $PYTHON_VERSIONS; do
         --build-arg "PYTHON_FULL_VERSION=$full_version" \
         --build-arg "PYTHON_VERSION=$minor_version" \
         --build-arg "PYTHON_SHA256=$sha256" \
+        --build-arg "GUNICORN_VERSION=$gunicorn_version" \
+        --build-arg "GUNICORN_URL=$gunicorn_url" \
+        --build-arg "GUNICORN_SHA256=$gunicorn_sha256" \
+        --build-arg "PACKAGING_VERSION=$packaging_version" \
+        --build-arg "PACKAGING_URL=$packaging_url" \
+        --build-arg "PACKAGING_SHA256=$packaging_sha256" \
         --build-arg "BUILD_NUMBER=${BUILD_BUILDNUMBER:-local}" \
         --build-arg "GIT_COMMIT=${BUILD_SOURCEVERSION:-unspecified}" \
         --build-arg "RELEASE_TAG_NAME=$RELEASE_TAG_NAME" \

--- a/build/testEmbrNodeRuntimeImages.sh
+++ b/build/testEmbrNodeRuntimeImages.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+readonly REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly NATIVE_MODULE_TEST_DOCKERFILE="$REPO_DIR/images/runtime/node/embr/nativeModuleTest.Dockerfile"
+
+if [[ $# -ne 1 || ! -s "$1" ]]; then
+    echo "Usage: $0 <image-list>" >&2
+    exit 1
+fi
+
+while IFS= read -r image; do
+    image="${image%$'\r'}"
+    [[ -n "$image" ]] || continue
+    expected_major="$(sed -n 's/.*:\([0-9]\+\)-resolute$/\1/p' <<< "$image")"
+    if [[ -z "$expected_major" ]]; then
+        echo "Unexpected Embr Node image tag: $image" >&2
+        exit 1
+    fi
+
+    docker run --rm --env "EXPECTED_MAJOR=$expected_major" "$image" bash -ceu '
+        test "$(node -p "process.versions.node")" = "$NODE_VERSION"
+        test "$(node -p "process.versions.node.split(\".\")[0]")" = "$EXPECTED_MAJOR"
+        npm --version >/dev/null
+        npx --version >/dev/null
+        test "$(yarn --version)" = "$YARN_VERSION"
+        node -e "require(\"https\").get(\"https://nodejs.org/\", response => { if (response.statusCode >= 400) process.exit(1); response.resume(); }).on(\"error\", () => process.exit(1))"
+        test -n "$(find /usr/local/share/ca-certificates -name "azl_*.crt" -print -quit)"
+        for excluded_command in gcc g++ cc make python python3 git pm2 corepack; do
+            ! command -v "$excluded_command" >/dev/null
+        done
+        command -v tar >/dev/null
+        command -v gzip >/dev/null
+        command -v unzip >/dev/null
+        command -v zstd >/dev/null
+        test -x /opt/oryx/benv
+        test -x /opt/startupcmdgen/startupcmdgen
+        test "$(readlink /usr/local/bin/oryx)" = "/opt/startupcmdgen/startupcmdgen"
+        ! find /opt/nodejs -type f \( -name "*.h" -o -name "*.a" \) -print -quit | grep -q .
+        ! ldd "$(command -v node)" | grep -q "not found"
+
+        mkdir -p /tmp/npm-app
+        cat > /tmp/npm-app/package.json <<EOF
+{"scripts":{"start":"node server.js"}}
+EOF
+        cat > /tmp/npm-app/server.js <<EOF
+require("http").createServer((request, response) => response.end("ok")).listen(process.env.PORT);
+EOF
+        oryx create-script -appPath /tmp/npm-app -output /tmp/npm-startup.sh -bindPort 8123
+        grep -q "npm start" /tmp/npm-startup.sh
+        sh /tmp/npm-startup.sh >/tmp/npm-startup.log 2>&1 &
+        server_pid=$!
+        trap "kill $server_pid 2>/dev/null || true" EXIT
+        for attempt in $(seq 1 30); do
+            if test "$(curl --silent --fail http://127.0.0.1:8123)" = "ok"; then
+                break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+                cat /tmp/npm-startup.log >&2
+                exit 1
+            fi
+            sleep 1
+        done
+        test "$(curl --silent --fail http://127.0.0.1:8123)" = "ok"
+        kill "$server_pid"
+        wait "$server_pid" || true
+        trap - EXIT
+
+        mkdir -p /tmp/yarn-app
+        cp /tmp/npm-app/package.json /tmp/npm-app/server.js /tmp/yarn-app/
+        touch /tmp/yarn-app/yarn.lock
+        oryx create-script -appPath /tmp/yarn-app -output /tmp/yarn-startup.sh -bindPort 8124
+        grep -q "yarn run start" /tmp/yarn-startup.sh
+        sh /tmp/yarn-startup.sh >/tmp/yarn-startup.log 2>&1 &
+        server_pid=$!
+        trap "kill $server_pid 2>/dev/null || true" EXIT
+        for attempt in $(seq 1 30); do
+            if test "$(curl --silent --fail http://127.0.0.1:8124)" = "ok"; then
+                break
+            fi
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+                cat /tmp/yarn-startup.log >&2
+                exit 1
+            fi
+            sleep 1
+        done
+        test "$(curl --silent --fail http://127.0.0.1:8124)" = "ok"
+        kill "$server_pid"
+        wait "$server_pid" || true
+        trap - EXIT
+
+        mkdir -p /tmp/direct-app
+        cp /tmp/npm-app/server.js /tmp/direct-app/index.js
+        oryx create-script -appPath /tmp/direct-app -output /tmp/direct-startup.sh
+        grep -q "node index.js" /tmp/direct-startup.sh
+
+        mkdir -p /tmp/archive-source
+        printf ok > /tmp/archive-source/sentinel
+        for archive_type in tar.gz tar.zst zip; do
+            mkdir -p "/tmp/archive-$archive_type"
+            cat > "/tmp/archive-$archive_type/oryx-manifest.toml" <<EOF
+CompressedNodeModulesFile = "node_modules.$archive_type"
+EOF
+            oryx create-script \
+                -appPath "/tmp/archive-$archive_type" \
+                -output "/tmp/archive-$archive_type/startup.sh" \
+                -userStartupCommand "test \"\$(cat node_modules/sentinel)\" = ok"
+        done
+        tar -czf /tmp/archive-tar.gz/node_modules.tar.gz -C /tmp/archive-source .
+        tar -I zstd -cf /tmp/archive-tar.zst/node_modules.tar.zst -C /tmp/archive-source .
+        printf %s \
+            UEsDBBQAAAAIAGOCKF1H3dx5BAAAAAIAAAAIAAAAc2VudGluZWzLzwYAUEsBAhQAFAAAAAgAY4IoXUfd3HkEAAAAAgAAAAgAAAAAAAAAAAAAAAAAAAAAAHNlbnRpbmVsUEsFBgAAAAABAAEANgAAACoAAAAAAA== \
+            | base64 -d > /tmp/archive-zip/node_modules.zip
+        grep -q "tar -xzf node_modules.tar.gz" /tmp/archive-tar.gz/startup.sh
+        grep -q "tar -I zstd -xf node_modules.tar.zst" /tmp/archive-tar.zst/startup.sh
+        grep -q "unzip -q node_modules.zip" /tmp/archive-zip/startup.sh
+        sh /tmp/archive-tar.gz/startup.sh
+        sh /tmp/archive-tar.zst/startup.sh
+        sh /tmp/archive-zip/startup.sh
+
+        EXPECTED_MAJOR="$EXPECTED_MAJOR" bash -c '"'"'
+            source /opt/oryx/benv "node=$EXPECTED_MAJOR"
+            test "$node" = "/opt/nodejs/$EXPECTED_MAJOR/bin/node"
+            test "$("$node" -p "process.versions.node")" = "$NODE_VERSION"
+        '"'"'
+    '
+
+    docker build \
+        --file "$NATIVE_MODULE_TEST_DOCKERFILE" \
+        --build-arg "NODE_MAJOR=$expected_major" \
+        --build-arg "RUNTIME_IMAGE=$image" \
+        --output type=cacheonly \
+        "$REPO_DIR"
+done < "$1"
+
+echo "All Embr Node runtime image tests passed."

--- a/build/testEmbrPythonRuntimeImages.sh
+++ b/build/testEmbrPythonRuntimeImages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+if [[ $# -ne 1 || ! -s "$1" ]]; then
+    echo "Usage: $0 <image-list>" >&2
+    exit 1
+fi
+
+while IFS= read -r image; do
+    image="${image%$'\r'}"
+    [[ -n "$image" ]] || continue
+    expected_version="$(sed -n 's/.*:embr-\([0-9]\+\.[0-9]\+\)-ubuntu-resolute-.*/\1/p' <<< "$image")"
+    if [[ -z "$expected_version" ]]; then
+        echo "Unexpected Embr Python image tag: $image" >&2
+        exit 1
+    fi
+
+    docker run --rm --env "EXPECTED_VERSION=$expected_version" "$image" sh -ceu '
+        actual_version="$(python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")")"
+        test "$actual_version" = "$EXPECTED_VERSION"
+        python -c "import bz2, ctypes, curses, dbm.gnu, lzma, readline, sqlite3, ssl, tkinter, uuid"
+        python -c "import urllib.request; urllib.request.urlopen(\"https://www.python.org/\", timeout=30).close()"
+        test -n "$(find /usr/local/share/ca-certificates -name "azl_*.crt" -print -quit)"
+        test ! -x /usr/bin/gcc
+        test ! -x /usr/bin/g++
+        python -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None"
+        python -c "import importlib.util; assert importlib.util.find_spec(\"gunicorn\") is None"
+        python -c "import importlib.util; assert importlib.util.find_spec(\"uvicorn\") is None"
+    '
+done < "$1"
+
+echo "All Embr Python runtime image tests passed."

--- a/build/testEmbrPythonRuntimeImages.sh
+++ b/build/testEmbrPythonRuntimeImages.sh
@@ -23,14 +23,32 @@ while IFS= read -r image; do
     docker run --rm --env "EXPECTED_VERSION=$expected_version" "$image" sh -ceu '
         actual_version="$(python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")")"
         test "$actual_version" = "$EXPECTED_VERSION"
-        python -c "import bz2, ctypes, curses, dbm.gnu, lzma, readline, sqlite3, ssl, tkinter, uuid"
+        python -c "import bz2, ctypes, curses, dbm.gnu, lzma, readline, sqlite3, ssl, uuid"
         python -c "import urllib.request; urllib.request.urlopen(\"https://www.python.org/\", timeout=30).close()"
+        python -c "import ctypes; ctypes.CDLL(\"libpq.so.5\"); ctypes.CDLL(\"libmysqlclient.so.24\")"
         test -n "$(find /usr/local/share/ca-certificates -name "azl_*.crt" -print -quit)"
         test ! -x /usr/bin/gcc
         test ! -x /usr/bin/g++
         python -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None"
-        python -c "import importlib.util; assert importlib.util.find_spec(\"gunicorn\") is None"
+        python -c "import importlib.util; assert importlib.util.find_spec(\"_tkinter\") is None"
+        gunicorn --version | grep -q "^gunicorn (version "
         python -c "import importlib.util; assert importlib.util.find_spec(\"uvicorn\") is None"
+        test -x /opt/oryx/benv
+        test -x /opt/startupcmdgen/startupcmdgen
+        test "$(readlink /usr/local/bin/oryx)" = "/opt/startupcmdgen/startupcmdgen"
+        mkdir -p /tmp/oryx-startup-test
+        oryx create-script \
+            -appPath /tmp/oryx-startup-test \
+            -output /tmp/oryx-startup.sh \
+            -bindPort 8000 \
+            -userStartupCommand "gunicorn wsgiref.simple_server:demo_app --bind 0.0.0.0:8000"
+        test -s /tmp/oryx-startup.sh
+        grep -q "gunicorn wsgiref.simple_server:demo_app" /tmp/oryx-startup.sh
+        EXPECTED_VERSION="$EXPECTED_VERSION" bash -c '"'"'
+            source /opt/oryx/benv "python=$EXPECTED_VERSION"
+            test "$python" = "/opt/python/$EXPECTED_VERSION/bin/python"
+            test "$(python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")")" = "$EXPECTED_VERSION"
+        '"'"'
     '
 done < "$1"
 

--- a/images/embrconstants.yml
+++ b/images/embrconstants.yml
@@ -1,0 +1,11 @@
+variables:
+  python313osFlavors: resolute
+  python314osFlavors: resolute
+  python315osFlavors: resolute
+  pythonosFlavors: resolute
+  python313Version: 3.13.15
+  python313_SHA256: 1e66a7945a48390ee4c2a4268a0e4185884059a13c4aab6d148aa208deea4a76
+  python314Version: 3.14.7
+  python314_SHA256: 3b48dac8fb59f62eaa67ac83c1eb12bda1b7a08406dd286e252c11a66be27f81
+  python315Version: 3.15.0b3
+  python315_SHA256: 6a935ae234a67e6549894373b0cfeb8361182d03b21442328ae9598ab7422127

--- a/images/embrconstants.yml
+++ b/images/embrconstants.yml
@@ -1,4 +1,11 @@
 variables:
+  node22Version: 22.23.2
+  node22_SHA256: d60acfe00a2932254bb0ad20e01b0d74397a0875595de719654b214f4b03f307
+  node24Version: 24.19.0
+  node24_SHA256: 14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647
+  yarnVersion: 1.22.22
+  yarnSourceUrl: https://github.com/yarnpkg/yarn/releases/download/v1.22.22/yarn-v1.22.22.tar.gz
+  yarnSource_SHA256: 88268464199d1611fcf73ce9c0a6c4d44c7d5363682720d8506f6508addf36a0
   python313osFlavors: resolute
   python314osFlavors: resolute
   python315osFlavors: resolute

--- a/images/embrconstants.yml
+++ b/images/embrconstants.yml
@@ -9,3 +9,9 @@ variables:
   python314_SHA256: 3b48dac8fb59f62eaa67ac83c1eb12bda1b7a08406dd286e252c11a66be27f81
   python315Version: 3.15.0b3
   python315_SHA256: 6a935ae234a67e6549894373b0cfeb8361182d03b21442328ae9598ab7422127
+  gunicornVersion: 24.1.1
+  gunicornSourceUrl: https://codeload.github.com/benoitc/gunicorn/tar.gz/refs/tags/24.1.1
+  gunicornSource_SHA256: 8522dbd3d8ae27f0568939e88e35effe43ed6077eb2c2cbd1ab084d37cf3d9f0
+  packagingVersion: 26.0
+  packagingSourceUrl: https://codeload.github.com/pypa/packaging/tar.gz/refs/tags/26.0
+  packagingSource_SHA256: 7b1995333d1d9a2d857ba85c493df323055e64248a45c2af32ebe9ae8dce663b

--- a/images/runtime/node/embr/nativeModuleTest.Dockerfile
+++ b/images/runtime/node/embr/nativeModuleTest.Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1.7
+
+ARG NODE_MAJOR
+ARG RUNTIME_IMAGE
+
+FROM node:${NODE_MAJOR}-bookworm AS nativebuild
+
+WORKDIR /app
+RUN npm init --yes \
+    && npm install --omit=dev --save-exact sharp@0.34.5
+
+FROM ${RUNTIME_IMAGE}
+
+COPY --from=nativebuild /app /tmp/native-module-test
+RUN node -e \
+    'const sharp = require("/tmp/native-module-test/node_modules/sharp"); sharp({ create: { width: 1, height: 1, channels: 4, background: "red" } }).png().toBuffer().then(output => { if (output.length === 0) process.exit(1); })'

--- a/images/runtime/node/embr/template.Dockerfile
+++ b/images/runtime/node/embr/template.Dockerfile
@@ -1,0 +1,128 @@
+# syntax=docker/dockerfile:1.7
+
+ARG UBUNTU_BASE_IMAGE=mcr.microsoft.com/mirror/docker/library/ubuntu:resolute
+ARG AZURE_LINUX_BASE_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26-bookworm AS startupcmdgen
+
+WORKDIR /go/src
+COPY src/startupscriptgenerator/src .
+ARG GIT_COMMIT=unspecified
+ARG BUILD_NUMBER=unspecified
+ARG RELEASE_TAG_NAME=unspecified
+ENV GIT_COMMIT=${GIT_COMMIT} \
+    BUILD_NUMBER=${BUILD_NUMBER} \
+    RELEASE_TAG_NAME=${RELEASE_TAG_NAME}
+RUN chmod +x build.sh \
+    && ./build.sh node /opt/startupcmdgen/startupcmdgen
+
+FROM ${AZURE_LINUX_BASE_IMAGE} AS azurelinuxcertificates
+
+RUN tdnf makecache \
+    && tdnf install -y ca-certificates \
+    && update-ca-trust extract \
+    && tdnf clean all
+
+FROM ${UBUNTU_BASE_IMAGE} AS embrbase
+
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        netbase \
+        openssl \
+        unzip \
+        zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=azurelinuxcertificates \
+    /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY images/runtime/scripts/install-azurelinux-certs.sh /tmp/install-azurelinux-certs.sh
+RUN chmod +x /tmp/install-azurelinux-certs.sh \
+    && /tmp/install-azurelinux-certs.sh \
+        /tmp/azurelinux-ca-certs \
+        /tmp/azurelinux-ca-certs/tls-ca-bundle.pem \
+    && rm -f /tmp/install-azurelinux-certs.sh
+
+FROM embrbase AS runtimearchives
+
+ARG NODE_FULL_VERSION
+ARG NODE_SHA256
+ARG YARN_VERSION
+ARG YARN_URL
+ARG YARN_SHA256
+
+RUN test -n "${NODE_FULL_VERSION}${NODE_SHA256}" \
+    && test -n "${YARN_VERSION}${YARN_URL}${YARN_SHA256}" \
+    && apt-get -o Acquire::Retries=5 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xz-utils \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --fail --location --retry 5 --retry-all-errors \
+        "https://nodejs.org/dist/v${NODE_FULL_VERSION}/node-v${NODE_FULL_VERSION}-linux-x64.tar.xz" \
+        --output /tmp/node.tar.xz \
+    && echo "${NODE_SHA256}  /tmp/node.tar.xz" | sha256sum -c - \
+    && mkdir -p "/opt/nodejs/${NODE_FULL_VERSION}" \
+    && tar -xJf /tmp/node.tar.xz \
+        --strip-components=1 \
+        -C "/opt/nodejs/${NODE_FULL_VERSION}" \
+    && rm -rf "/opt/nodejs/${NODE_FULL_VERSION}/include" \
+        "/opt/nodejs/${NODE_FULL_VERSION}/lib/node_modules/corepack" \
+        "/opt/nodejs/${NODE_FULL_VERSION}/bin/corepack" \
+    && curl --fail --location --retry 5 --retry-all-errors \
+        "${YARN_URL}" \
+        --output /tmp/yarn.tar.gz \
+    && echo "${YARN_SHA256}  /tmp/yarn.tar.gz" | sha256sum -c - \
+    && mkdir -p "/opt/yarn/${YARN_VERSION}" \
+    && tar -xzf /tmp/yarn.tar.gz \
+        --strip-components=1 \
+        -C "/opt/yarn/${YARN_VERSION}" \
+    && rm -f /tmp/node.tar.xz /tmp/yarn.tar.gz
+
+FROM embrbase AS main
+
+ARG NODE_FULL_VERSION
+ARG NODE_VERSION
+ARG NODE_MAJOR_VERSION
+ARG YARN_VERSION
+ARG BUILD_NUMBER=unspecified
+ARG GIT_COMMIT=unspecified
+ARG RELEASE_TAG_NAME=unspecified
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    NODE_VERSION=${NODE_FULL_VERSION} \
+    YARN_VERSION=${YARN_VERSION} \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+LABEL com.microsoft.oryx.build-number="${BUILD_NUMBER}" \
+    com.microsoft.oryx.git-commit="${GIT_COMMIT}" \
+    com.microsoft.oryx.release-tag-name="${RELEASE_TAG_NAME}"
+
+RUN test -n "${NODE_FULL_VERSION}" \
+    && test -n "${NODE_VERSION}" \
+    && test -n "${NODE_MAJOR_VERSION}" \
+    && test -n "${YARN_VERSION}"
+
+COPY --from=runtimearchives \
+    /opt/nodejs/${NODE_FULL_VERSION} \
+    /opt/nodejs/${NODE_FULL_VERSION}
+COPY --from=runtimearchives \
+    /opt/yarn/${YARN_VERSION} \
+    /opt/yarn/${YARN_VERSION}
+COPY --from=startupcmdgen \
+    /opt/startupcmdgen/startupcmdgen \
+    /opt/startupcmdgen/startupcmdgen
+COPY images/build/benv.sh /opt/oryx/benv
+
+RUN cd /opt/nodejs \
+    && ln -s "${NODE_FULL_VERSION}" "${NODE_VERSION}" \
+    && ln -s "${NODE_VERSION}" "${NODE_MAJOR_VERSION}" \
+    && chmod +x /opt/oryx/benv \
+    && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx \
+    && ln -s "/opt/nodejs/${NODE_VERSION}/bin/node" /usr/local/bin/node \
+    && ln -s "/opt/nodejs/${NODE_VERSION}/bin/npm" /usr/local/bin/npm \
+    && ln -s "/opt/nodejs/${NODE_VERSION}/bin/npx" /usr/local/bin/npx \
+    && ln -s "/opt/yarn/${YARN_VERSION}/bin/yarn" /usr/local/bin/yarn \
+    && ln -s "/opt/yarn/${YARN_VERSION}/bin/yarn" /usr/local/bin/yarnpkg
+
+ENV PATH="/opt/nodejs/${NODE_VERSION}/bin:${PATH}"

--- a/images/runtime/python/embr/README.md
+++ b/images/runtime/python/embr/README.md
@@ -1,0 +1,34 @@
+# Embr Python runtime images
+
+These images provide the runtime substrate for deployment-specific Embr
+application images. They use Ubuntu Resolute and contain CPython, runtime
+libraries, basic network tools, and the Ubuntu and Azure Linux certificate
+trust stores.
+
+Application frameworks, application servers, database clients, compilers,
+profilers, and the Oryx startup-script generator are intentionally excluded.
+Applications must package those dependencies in their build output.
+
+The Oryx pipelines build Python 3.13, 3.14, and 3.15 from the versions and
+SHA256 checksums in `images/embrconstants.yml`. Candidate images are published
+to `oryxdevmcr.azurecr.io/public/oryx/python`; release images use the existing
+MCR repository:
+
+```text
+mcr.microsoft.com/oryx/python:embr-<major.minor>-ubuntu-resolute-<release>
+```
+
+On `main`, the release pipeline also publishes the moving
+`embr-<major.minor>-ubuntu-resolute` tag. Consumers that require reproducible
+deployments must resolve and persist the image digest.
+
+To build and test all configured versions locally:
+
+```bash
+BUILD_DEFINITIONNAME=local \
+RELEASE_TAG_NAME=dev \
+bash build/buildEmbrPythonRuntimeImages.sh
+
+bash build/testEmbrPythonRuntimeImages.sh \
+  artifacts/images/embr-python-runtime-images-acr.resolute.txt
+```

--- a/images/runtime/python/embr/template.Dockerfile
+++ b/images/runtime/python/embr/template.Dockerfile
@@ -1,0 +1,154 @@
+# syntax=docker/dockerfile:1.7
+
+ARG UBUNTU_BASE_IMAGE=mcr.microsoft.com/mirror/docker/library/ubuntu:resolute
+ARG AZURE_LINUX_BASE_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+
+FROM ${AZURE_LINUX_BASE_IMAGE} AS azurelinuxcertificates
+
+RUN tdnf makecache \
+    && tdnf install -y ca-certificates \
+    && update-ca-trust extract \
+    && tdnf clean all
+
+FROM ${UBUNTU_BASE_IMAGE} AS embrbase
+
+RUN apt-get -o Acquire::Retries=5 update \
+    && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        netbase \
+        openssl \
+        libatomic1 \
+        libbz2-1.0 \
+        libexpat1 \
+        libffi8 \
+        libgdbm6t64 \
+        libgdbm-compat4t64 \
+        liblzma5 \
+        libncursesw6 \
+        libreadline8t64 \
+        libsqlite3-0 \
+        libssl3t64 \
+        libuuid1 \
+        tk8.6 \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=azurelinuxcertificates \
+    /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    /tmp/azurelinux-ca-certs/tls-ca-bundle.pem
+COPY images/runtime/scripts/install-azurelinux-certs.sh /tmp/install-azurelinux-certs.sh
+RUN chmod +x /tmp/install-azurelinux-certs.sh \
+    && /tmp/install-azurelinux-certs.sh \
+        /tmp/azurelinux-ca-certs \
+        /tmp/azurelinux-ca-certs/tls-ca-bundle.pem \
+    && rm -f /tmp/install-azurelinux-certs.sh
+
+FROM embrbase AS pythonbuildbase
+
+RUN apt-get -o Acquire::Retries=5 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        gnupg \
+        libbluetooth-dev \
+        libbz2-dev \
+        libffi-dev \
+        libgdbm-dev \
+        liblzma-dev \
+        libncurses5-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        pkg-config \
+        tk-dev \
+        uuid-dev \
+        wget \
+        xz-utils \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM pythonbuildbase AS pythonbuilder
+
+ARG PYTHON_FULL_VERSION
+ARG PYTHON_GPG_KEY
+ARG PYTHON_SHA256
+
+COPY images/receiveGpgKeys.sh /tmp/receiveGpgKeys.sh
+RUN test -n "${PYTHON_FULL_VERSION}" \
+    && test -n "${PYTHON_GPG_KEY}${PYTHON_SHA256}" \
+    && chmod +x /tmp/receiveGpgKeys.sh \
+    && mkdir -p /usr/src/python \
+    && wget \
+        "https://www.python.org/ftp/python/${PYTHON_FULL_VERSION%%[a-z]*}/Python-${PYTHON_FULL_VERSION}.tar.xz" \
+        -O /tmp/python.tar.xz \
+    && if [ -n "${PYTHON_SHA256}" ]; then \
+        echo "${PYTHON_SHA256}  /tmp/python.tar.xz" | sha256sum -c -; \
+    else \
+        wget \
+            "https://www.python.org/ftp/python/${PYTHON_FULL_VERSION%%[a-z]*}/Python-${PYTHON_FULL_VERSION}.tar.xz.asc" \
+            -O /tmp/python.tar.xz.asc; \
+        /tmp/receiveGpgKeys.sh "${PYTHON_GPG_KEY}"; \
+        gpg --batch --verify /tmp/python.tar.xz.asc /tmp/python.tar.xz; \
+    fi \
+    && tar -xJf /tmp/python.tar.xz --strip-components=1 -C /usr/src/python \
+    && cd /usr/src/python \
+    && configure_args="" \
+    && case "${PYTHON_FULL_VERSION}" in \
+        3.15.*) configure_args="--without-system-libmpdec" ;; \
+    esac \
+    && ./configure \
+        --prefix="/opt/python/${PYTHON_FULL_VERSION}" \
+        --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+        --enable-loadable-sqlite-extensions \
+        --enable-optimizations \
+        --enable-shared \
+        --with-lto \
+        --with-system-ffi \
+        --without-ensurepip \
+        ${configure_args} \
+    && make -j "$(nproc)" \
+    && make install
+
+FROM embrbase AS main
+
+ARG PYTHON_FULL_VERSION
+ARG PYTHON_VERSION
+ARG PYTHON_MAJOR_VERSION=3
+ARG BUILD_NUMBER=unspecified
+ARG GIT_COMMIT=unspecified
+ARG RELEASE_TAG_NAME=unspecified
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+LABEL com.microsoft.oryx.build-number="${BUILD_NUMBER}" \
+    com.microsoft.oryx.git-commit="${GIT_COMMIT}" \
+    com.microsoft.oryx.release-tag-name="${RELEASE_TAG_NAME}"
+
+RUN test -n "${PYTHON_FULL_VERSION}" \
+    && test -n "${PYTHON_VERSION}"
+
+COPY --from=pythonbuilder \
+    /opt/python/${PYTHON_FULL_VERSION} \
+    /opt/python/${PYTHON_FULL_VERSION}
+
+RUN cd /opt/python \
+    && ln -s "${PYTHON_FULL_VERSION}" "${PYTHON_VERSION}" \
+    && ln -s "${PYTHON_VERSION}" "${PYTHON_MAJOR_VERSION}" \
+    && cd "/opt/python/${PYTHON_FULL_VERSION}/bin" \
+    && ln -s python3 python \
+    && ln -s python3-config python-config \
+    && printf '/opt/python/%s/lib\n' "${PYTHON_MAJOR_VERSION}" \
+        > /etc/ld.so.conf.d/python.conf \
+    && ldconfig \
+    && find "/opt/python/${PYTHON_FULL_VERSION}" -depth \
+        \( -type d \( -name test -o -name tests -o -name idle_test \) \
+        -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+        -exec rm -rf '{}' +
+
+ENV PATH="/opt/python/${PYTHON_MAJOR_VERSION}/bin:${PATH}" \
+    PYTHON_VERSION=${PYTHON_FULL_VERSION}

--- a/images/runtime/python/embr/template.Dockerfile
+++ b/images/runtime/python/embr/template.Dockerfile
@@ -108,7 +108,11 @@ RUN test -n "${PYTHON_FULL_VERSION}" \
         --without-ensurepip \
         ${configure_args} \
     && make -j "$(nproc)" \
-    && make install
+    && make install \
+    && find "/opt/python/${PYTHON_FULL_VERSION}" -depth \
+        \( -type d \( -name test -o -name tests -o -name idle_test \) \
+        -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+        -exec rm -rf '{}' +
 
 FROM embrbase AS main
 
@@ -144,11 +148,7 @@ RUN cd /opt/python \
     && ln -s python3-config python-config \
     && printf '/opt/python/%s/lib\n' "${PYTHON_MAJOR_VERSION}" \
         > /etc/ld.so.conf.d/python.conf \
-    && ldconfig \
-    && find "/opt/python/${PYTHON_FULL_VERSION}" -depth \
-        \( -type d \( -name test -o -name tests -o -name idle_test \) \
-        -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
-        -exec rm -rf '{}' +
+    && ldconfig
 
 ENV PATH="/opt/python/${PYTHON_MAJOR_VERSION}/bin:${PATH}" \
     PYTHON_VERSION=${PYTHON_FULL_VERSION}

--- a/images/runtime/python/embr/template.Dockerfile
+++ b/images/runtime/python/embr/template.Dockerfile
@@ -3,6 +3,19 @@
 ARG UBUNTU_BASE_IMAGE=mcr.microsoft.com/mirror/docker/library/ubuntu:resolute
 ARG AZURE_LINUX_BASE_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
 
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26-bookworm AS startupcmdgen
+
+WORKDIR /go/src
+COPY src/startupscriptgenerator/src .
+ARG GIT_COMMIT=unspecified
+ARG BUILD_NUMBER=unspecified
+ARG RELEASE_TAG_NAME=unspecified
+ENV GIT_COMMIT=${GIT_COMMIT} \
+    BUILD_NUMBER=${BUILD_NUMBER} \
+    RELEASE_TAG_NAME=${RELEASE_TAG_NAME}
+RUN chmod +x build.sh \
+    && ./build.sh python /opt/startupcmdgen/startupcmdgen
+
 FROM ${AZURE_LINUX_BASE_IMAGE} AS azurelinuxcertificates
 
 RUN tdnf makecache \
@@ -27,11 +40,12 @@ RUN apt-get -o Acquire::Retries=5 update \
         libgdbm-compat4t64 \
         liblzma5 \
         libncursesw6 \
+        libmysqlclient24 \
+        libpq5 \
         libreadline8t64 \
         libsqlite3-0 \
         libssl3t64 \
         libuuid1 \
-        tk8.6 \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
@@ -61,7 +75,6 @@ RUN apt-get -o Acquire::Retries=5 update \
         libsqlite3-dev \
         libssl-dev \
         pkg-config \
-        tk-dev \
         uuid-dev \
         wget \
         xz-utils \
@@ -114,6 +127,58 @@ RUN test -n "${PYTHON_FULL_VERSION}" \
         -o -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
         -exec rm -rf '{}' +
 
+FROM pythonbuildbase AS pythonwheels
+
+ARG GUNICORN_VERSION
+ARG GUNICORN_URL
+ARG GUNICORN_SHA256
+ARG PACKAGING_VERSION
+ARG PACKAGING_URL
+ARG PACKAGING_SHA256
+
+RUN test -n "${GUNICORN_VERSION}${GUNICORN_URL}${GUNICORN_SHA256}" \
+    && test -n "${PACKAGING_VERSION}${PACKAGING_URL}${PACKAGING_SHA256}" \
+    && apt-get -o Acquire::Retries=5 update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        flit \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --fail --location --retry 5 --retry-all-errors \
+        "${GUNICORN_URL}" \
+        --output /tmp/gunicorn.tar.gz \
+    && echo "${GUNICORN_SHA256}  /tmp/gunicorn.tar.gz" | sha256sum -c - \
+    && curl --fail --location --retry 5 --retry-all-errors \
+        "${PACKAGING_URL}" \
+        --output /tmp/packaging.tar.gz \
+    && echo "${PACKAGING_SHA256}  /tmp/packaging.tar.gz" | sha256sum -c - \
+    && mkdir -p /tmp/gunicorn-source /tmp/packaging-source /tmp/wheels \
+    && tar -xzf /tmp/gunicorn.tar.gz --strip-components=1 -C /tmp/gunicorn-source \
+    && tar -xzf /tmp/packaging.tar.gz --strip-components=1 -C /tmp/packaging-source \
+    && python3 -m pip wheel --no-deps --no-build-isolation \
+        --wheel-dir /tmp/wheels \
+        /tmp/packaging-source \
+        /tmp/gunicorn-source
+
+FROM pythonbuilder AS pythonruntime
+
+ARG PYTHON_FULL_VERSION
+
+COPY --from=pythonwheels /tmp/wheels/*.whl /tmp/
+RUN LD_LIBRARY_PATH="/opt/python/${PYTHON_FULL_VERSION}/lib" \
+        "/opt/python/${PYTHON_FULL_VERSION}/bin/python3" -c \
+        'import pathlib, sys, zipfile; target = pathlib.Path(sys.argv[1]); [zipfile.ZipFile(wheel).extractall(target) for wheel in sys.argv[2:]]' \
+        "/opt/python/${PYTHON_FULL_VERSION}/lib/python${PYTHON_FULL_VERSION%.*}/site-packages" \
+        /tmp/packaging-*.whl \
+        /tmp/gunicorn-*.whl \
+    && printf '%s\n' \
+        '#!/bin/sh' \
+        'exec "$(dirname "$0")/python3" -c "from gunicorn.app.wsgiapp import run; run(prog=\"gunicorn\")" "$@"' \
+        > "/opt/python/${PYTHON_FULL_VERSION}/bin/gunicorn" \
+    && chmod +x "/opt/python/${PYTHON_FULL_VERSION}/bin/gunicorn" \
+    && rm -f /tmp/gunicorn-*.whl /tmp/packaging-*.whl
+
 FROM embrbase AS main
 
 ARG PYTHON_FULL_VERSION
@@ -136,9 +201,13 @@ LABEL com.microsoft.oryx.build-number="${BUILD_NUMBER}" \
 RUN test -n "${PYTHON_FULL_VERSION}" \
     && test -n "${PYTHON_VERSION}"
 
-COPY --from=pythonbuilder \
+COPY --from=pythonruntime \
     /opt/python/${PYTHON_FULL_VERSION} \
     /opt/python/${PYTHON_FULL_VERSION}
+COPY --from=startupcmdgen \
+    /opt/startupcmdgen/startupcmdgen \
+    /opt/startupcmdgen/startupcmdgen
+COPY images/build/benv.sh /opt/oryx/benv
 
 RUN cd /opt/python \
     && ln -s "${PYTHON_FULL_VERSION}" "${PYTHON_VERSION}" \
@@ -148,7 +217,9 @@ RUN cd /opt/python \
     && ln -s python3-config python-config \
     && printf '/opt/python/%s/lib\n' "${PYTHON_MAJOR_VERSION}" \
         > /etc/ld.so.conf.d/python.conf \
-    && ldconfig
+    && ldconfig \
+    && chmod +x /opt/oryx/benv \
+    && ln -s /opt/startupcmdgen/startupcmdgen /usr/local/bin/oryx
 
 ENV PATH="/opt/python/${PYTHON_MAJOR_VERSION}/bin:${PATH}" \
     PYTHON_VERSION=${PYTHON_FULL_VERSION}

--- a/vsts/pipelines/ci.yml
+++ b/vsts/pipelines/ci.yml
@@ -245,6 +245,22 @@ stages:
         parameters:
             imageType: bookworm
 
+    - job: Job_Embr_Python_Resolute_RuntimeImages
+      displayName: Build and Test Embr Python Resolute Runtime Images
+      condition: succeeded()
+      timeoutInMinutes: 180
+      pool:
+        name: AzurePipelines-EO
+        demands:
+          - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+      variables:
+        skipComponentGovernanceDetection: true
+      steps:
+      - template: templates/_setReleaseTag.yml
+      - template: templates/_embrPythonRuntimeImagesStepTemplate.yml
+        parameters:
+          pushImages: true
+
     - template: templates/_integrationJobTemplate.yml
       parameters:
           storageAccountUrl: ${{ parameters.storageAccountUrl }}

--- a/vsts/pipelines/nightly.yml
+++ b/vsts/pipelines/nightly.yml
@@ -205,6 +205,24 @@ stages:
         parameters:
             imageType: bookworm
 
+    - job: Job_Embr_Python_Resolute_RuntimeImages
+      displayName: Build and Test Embr Python Resolute Runtime Images
+      condition: succeeded()
+      timeoutInMinutes: 180
+      pool:
+        name: AzurePipelines-EO
+        demands:
+          - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+      variables:
+        skipComponentGovernanceDetection: true
+      steps:
+      - script: |
+          echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
+        displayName: Set release tag
+      - template: templates/_embrPythonRuntimeImagesStepTemplate.yml
+        parameters:
+          pushImages: true
+
     - template: templates/_integrationJobTemplate.yml
       parameters:
         storageAccountUrl: ${{ parameters.storageAccountUrl }}

--- a/vsts/pipelines/templates/_embrPythonRuntimeImagesStepTemplate.yml
+++ b/vsts/pipelines/templates/_embrPythonRuntimeImagesStepTemplate.yml
@@ -1,0 +1,63 @@
+parameters:
+- name: pushImages
+  type: boolean
+  default: false
+- name: acrName
+  type: string
+  default: oryxdevmcr.azurecr.io
+- name: ascName
+  type: string
+  default: oryx-new-service-connection
+
+steps:
+- checkout: self
+  clean: true
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: Component Detection - OSS Compliance
+  inputs:
+    ignoreDirectories: '$(Build.SourcesDirectory)/tests'
+
+- ${{ if eq(parameters.pushImages, true) }}:
+  - task: Docker@1
+    displayName: Login to Oryx development ACR
+    inputs:
+      command: login
+      azureSubscriptionEndpoint: ${{ parameters.ascName }}
+      azureContainerRegistry: ${{ parameters.acrName }}
+
+- task: Bash@3
+  displayName: Build Embr Python Resolute runtime images
+  inputs:
+    targetType: filePath
+    filePath: ./build/buildEmbrPythonRuntimeImages.sh
+
+- task: Bash@3
+  displayName: Test Embr Python Resolute runtime images
+  inputs:
+    targetType: filePath
+    filePath: ./build/testEmbrPythonRuntimeImages.sh
+    arguments: '$(Build.ArtifactStagingDirectory)/images/embr-python-runtime-images-acr.resolute.txt'
+
+- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+  displayName: Generate Software Bill of Materials (SBOM)
+  inputs:
+    BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+
+- ${{ if eq(parameters.pushImages, true) }}:
+  - task: Docker@1
+    displayName: Push Embr Python runtime images to development ACR
+    inputs:
+      azureSubscriptionEndpoint: ${{ parameters.ascName }}
+      azureContainerRegistry: ${{ parameters.acrName }}
+      command: Push an image
+      pushMultipleImages: true
+      imageNamesPath: '$(Build.ArtifactStagingDirectory)/images/embr-python-runtime-images-acr.resolute.txt'
+      includeLatestTag: false
+      enforceDockerNamingConvention: false
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Embr Python runtime image metadata
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: drop

--- a/vsts/pipelines/templates/_releaseStepTemplate.yml
+++ b/vsts/pipelines/templates/_releaseStepTemplate.yml
@@ -93,6 +93,13 @@ steps:
     scriptPath: ./vsts/scripts/tagRunTimeImagesForRelease.sh
   condition: and(succeeded(), eq(variables['ReleaseRuntimeImages'], 'true'))
 
+- task: Bash@3
+  displayName: 'Pull and create release tags for Embr Python runtime images'
+  inputs:
+    targetType: filePath
+    filePath: ./vsts/scripts/tagEmbrPythonRuntimeImagesForRelease.sh
+  condition: and(succeeded(), eq(variables['ReleaseRuntimeImages'], 'true'))
+
 - task: Shellpp@0
   displayName: 'Pull and create release tags for CLI images'
   inputs:

--- a/vsts/pipelines/validation.yml
+++ b/vsts/pipelines/validation.yml
@@ -167,5 +167,22 @@ jobs:
   - template: templates/_buildTemplate.yml
     parameters:
         imageType: bookworm
-        
+
+- job: Job_Embr_Python_Resolute_RuntimeImages
+  displayName: Build and Test Embr Python Resolute Runtime Images
+  timeoutInMinutes: 180
+  pool:
+    name: AzurePipelines-EO
+    demands:
+      - ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+  variables:
+  - group: Oryx
+  steps:
+  - script: |
+      echo "##vso[task.setvariable variable=RELEASE_TAG_NAME;]$(Build.BuildNumber)"
+    displayName: Set release tag
+  - template: templates/_embrPythonRuntimeImagesStepTemplate.yml
+    parameters:
+      pushImages: false
+
 trigger: none

--- a/vsts/scripts/tagEmbrPythonRuntimeImagesForRelease.sh
+++ b/vsts/scripts/tagEmbrPythonRuntimeImagesForRelease.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+# --------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+readonly SOURCE_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/embr-python-runtime-images-acr.resolute.txt"
+readonly OUTPUT_FILE="$BUILD_ARTIFACTSTAGINGDIRECTORY/drop/images/oryxprodmcr-runtime-images-mcr.txt"
+readonly PROD_REPOSITORY="oryxprodmcr.azurecr.io/public/oryx/python"
+
+if [[ ! -s "$SOURCE_FILE" ]]; then
+    echo "Embr Python runtime image list not found: $SOURCE_FILE" >&2
+    exit 1
+fi
+
+touch "$OUTPUT_FILE"
+
+while IFS= read -r source_image; do
+    source_image="${source_image%$'\r'}"
+    [[ -n "$source_image" ]] || continue
+    minor_version="$(sed -n 's/.*:embr-\([0-9]\+\.[0-9]\+\)-ubuntu-resolute-.*/\1/p' <<< "$source_image")"
+    if [[ -z "$minor_version" ]]; then
+        echo "Unexpected Embr Python image tag: $source_image" >&2
+        exit 1
+    fi
+
+    immutable_image="$PROD_REPOSITORY:embr-$minor_version-ubuntu-resolute-$RELEASE_TAG_NAME"
+    docker pull "$source_image"
+    docker tag "$source_image" "$immutable_image"
+    echo "$immutable_image" >> "$OUTPUT_FILE"
+
+    if [[ "$BUILD_SOURCEBRANCHNAME" == "main" ]]; then
+        moving_image="$PROD_REPOSITORY:embr-$minor_version-ubuntu-resolute"
+        docker tag "$source_image" "$moving_image"
+        echo "$moving_image" >> "$OUTPUT_FILE"
+    fi
+done < "$SOURCE_FILE"
+
+echo "Prepared Embr Python release tags:"
+cat "$OUTPUT_FILE"


### PR DESCRIPTION
### What changed


Adds Embr-specific Node.js runtime images for Ubuntu Resolute covering Node 22.23.2 and 24.19.0. Each image contains checksum-verified Node binaries, npm, npx, Yarn Classic 1.22.22, Ubuntu and Azure Linux CA trust, the Oryx Node startup generator, `/opt/oryx/benv`, and the archive tools required to restore Oryx-compressed `node_modules`. Compilers, Python, Git, PM2, Corepack, Node headers, and other build-only tooling are excluded. The build script creates only local `embr-node-runtime:*` images and contains no registry login or push behavior.


### Validation

- Built both runtime images locally:

- `embr-node-runtime:22-resolute`

- `embr-node-runtime:24-resolute`

- Passed runtime contract tests covering npm and Yarn HTTP startup, direct Node entrypoints, HTTPS trust, `benv`, dynamic linkage, and Oryx startup generation.

- Verified `.tar.gz`, `.tar.zst`, and `.zip` `node_modules` extraction.

- Verified a separately built native `sharp` dependency executes in each compiler-free runtime.

- Final image sizes:
  
  - Node 22: approximately 113.6 MB compressed / 297.8 MB root filesystem
  
  - Node 24: approximately 114.2 MB compressed / 299.5 MB root filesystem