### PR TITLE
Fix ODBC package versions for PHP 8.2 Bookworm image

### DIFF
--- a/images/runtime/php-fpm/8.2/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.2/bookworm.Dockerfile
@@ -31,7 +31,7 @@ RUN set -eux \
     && curl https://packages.microsoft.com/config/debian/12/prod.list > /etc/apt/sources.list.d/mssql-release.list \
 	&& curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
 	&& apt-get update \
-	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.6.1-1 msodbcsql18=18.1.2.1-1 odbcinst1debian2=2.3.7 odbcinst=2.3.7 unixodbc=2.3.7 unixodbc-dev=2.3.7
+	&& ACCEPT_EULA=Y apt-get install -y msodbcsql17=17.10.6.1-1 msodbcsql18=18.3.3.1-1 odbcinst1debian2=2.3.11-2+deb12u1 odbcinst=2.3.11-2+deb12u1 unixodbc=2.3.11-2+deb12u1 unixodbc-dev=2.3.11-2+deb12u1
 
 ENV PHP_INI_DIR /usr/local/etc/php
 RUN set -eux; \


### PR DESCRIPTION
Fixes PHP 8.2 Bookworm runtime image generation by updating the pinned ODBC packages to versions available for Debian 12.

The previous versions were intended for Bullseye and could not be resolved from the Bookworm repositories, causing the Docker build to fail during `apt-get install`.

Updated packages:

- `msodbcsql18`: `18.1.2.1-1` → `18.3.3.1-1`
- `odbcinst1debian2`: `2.3.7` → `2.3.11-2+deb12u1`
- `odbcinst`: `2.3.7` → `2.3.11-2+deb12u1`
- `unixodbc`: `2.3.7` → `2.3.11-2+deb12u1`
- `unixodbc-dev`: `2.3.7` → `2.3.11-2+deb12u1`

These versions match the existing PHP 8.3 and PHP 8.4 Bookworm runtime images.

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
