### PR TITLE
Fix missing libargon2 dependency in PHP 8.2 Bookworm image

### DIFF
--- a/images/runtime/php-fpm/8.2/bookworm.Dockerfile
+++ b/images/runtime/php-fpm/8.2/bookworm.Dockerfile
@@ -200,8 +200,6 @@ RUN set -eux; \
 		| sort -u \
 		| xargs -r apt-mark manual \
 	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
 # update pecl channel definitions https://github.com/docker-library/php/issues/443
 	pecl update-channels; \
 	rm -rf /tmp/pear ~/.pearrc; \


### PR DESCRIPTION
Fixes PHP 8.2 Bookworm runtime image generation by preventing required runtime dependencies from being removed after PHP compilation.

The `apt-get purge --auto-remove` step removed `libargon2-1`, even though the compiled PHP executable depends on `libargon2.so.1`. This caused subsequent PHP commands to fail with:

```text
/usr/local/bin/php: error while loading shared libraries:
libargon2.so.1: cannot open shared object file

This change removes the unsafe purge step, matching the existing PHP 8.3 and PHP 8.4 Bookworm Dockerfiles.
```

- [ ] The purpose of this PR is explained in this message or in an issue. If an issue please include a reference as \#\<issue\_number\>.
- [ ] Tests are included and/or updated for code changes.
- [ ] Proper license headers are included in each file.
